### PR TITLE
Correcting VMWare Resource ID/Value Loading Order for Importing VM-Template to Content Library

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -783,6 +783,21 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	template.Library = l.library.ID
 	template.SourceVM = vm.vm.Reference().Value
 
+	if template.Placement.ResourcePool != "" {
+		rp, err := vm.driver.FindResourcePool(template.Placement.Cluster, template.Placement.Host, template.Placement.ResourcePool)
+		if err != nil {
+			return err
+		}
+		template.Placement.ResourcePool = rp.pool.Reference().Value
+	}
+	if template.VMHomeStorage != nil {
+		d, err := vm.driver.FindDatastore(template.VMHomeStorage.Datastore, template.Placement.Host)
+		if err != nil {
+			return err
+		}
+		template.VMHomeStorage.Datastore = d.Reference().Value
+	}
+
 	if template.Placement.Cluster != "" {
 		c, err := vm.driver.FindCluster(template.Placement.Cluster)
 		if err != nil {
@@ -803,21 +818,6 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 			return err
 		}
 		template.Placement.Host = h.host.Reference().Value
-	}
-	if template.Placement.ResourcePool != "" {
-		rp, err := vm.driver.FindResourcePool(template.Placement.Cluster, template.Placement.Host, template.Placement.ResourcePool)
-		if err != nil {
-			return err
-		}
-		template.Placement.ResourcePool = rp.pool.Reference().Value
-	}
-
-	if template.VMHomeStorage != nil {
-		d, err := vm.driver.FindDatastore(template.VMHomeStorage.Datastore, template.Placement.Host)
-		if err != nil {
-			return err
-		}
-		template.VMHomeStorage.Datastore = d.Reference().Value
 	}
 
 	vcm := vcenter.NewManager(vm.driver.restClient.client)


### PR DESCRIPTION
Correcting VMWare resource reference value lookup order for ResourcePool and VMHomeStorage since they are dependent on the original input values for Cluster and Host

packer-plugin-vsphere:v0.0.1 - Execution Error Messae:
```
 ==> dnsmasq.vsphere-clone.vm-base: Importing VM template packer-dnsmasq:0.0.0-1b965293-alpine-3.12.6 to Content Library...
 ==> dnsmasq.vsphere-clone.vm-base: Failed to import template packer-dnsmasq:0.0.0-1b965293-alpine-3.12.6: resource pool 'domain-c346/Resources/HashiCorpPackerVMs' not found
 ==> dnsmasq.vsphere-clone.vm-base: Provisioning step had errors: Running the cleanup provisioner, if present...
```