### PR TITLE
Fix firmware reverting to BIOSwhen pushing to template in content library.

### DIFF
--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -121,6 +121,13 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
 	var err error
 
+	ui.Say("Clear boot order...")
+	err = vm.SetBootOrder([]string{"-"})
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
 	if s.ContentLibConfig.Ovf {
 		ui.Say(fmt.Sprintf("Importing VM OVF template %s to Content Library...", s.ContentLibConfig.Name))
 		err = s.importOvfTemplate(vm)

--- a/builder/vsphere/common/step_template.go
+++ b/builder/vsphere/common/step_template.go
@@ -12,8 +12,6 @@ type StepConvertToTemplate struct {
 	ConvertToTemplate bool
 }
 
-func (s *StepConvertToTemplate) Cleanup(state multistep.StateBag) {}
-
 func (s *StepConvertToTemplate) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
@@ -29,3 +27,5 @@ func (s *StepConvertToTemplate) Run(_ context.Context, state multistep.StateBag)
 
 	return multistep.ActionContinue
 }
+
+func (s *StepConvertToTemplate) Cleanup(state multistep.StateBag) {}

--- a/builder/vsphere/common/step_template.go
+++ b/builder/vsphere/common/step_template.go
@@ -12,6 +12,8 @@ type StepConvertToTemplate struct {
 	ConvertToTemplate bool
 }
 
+func (s *StepConvertToTemplate) Cleanup(state multistep.StateBag) {}
+
 func (s *StepConvertToTemplate) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
@@ -27,5 +29,3 @@ func (s *StepConvertToTemplate) Run(_ context.Context, state multistep.StateBag)
 
 	return multistep.ActionContinue
 }
-
-func (s *StepConvertToTemplate) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
Setting Secure boot with UEFI firmware works when the VM is created, but is lost when the VM is pushed to a content library. This appears to be becuase the boot order section is not removed before the template is pushed to the content library. It is removed as part of the VM cleanup code, but that is tied to the VM create/Remove code rather tightly.

I have copied the boot order clearing code into the template step before the push happens. This works locally and a VM created from the template item now has UEFI and Secure Boot.

Closes #13 
