### PR TITLE
Fix removing templates with snapshots

### DIFF
--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -78,7 +78,7 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 	d := state.Get("driver").(driver.Driver)
 	vmPath := path.Join(s.Location.Folder, s.Location.VMName)
 
-	err := d.PreCleanVM(ui, vmPath, s.Force)
+	err := d.PreCleanVM(ui, vmPath, s.Force, s.Location.Cluster, s.Location.Host, s.Location.ResourcePool)
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -22,7 +22,7 @@ type Driver interface {
 	NewVM(ref *types.ManagedObjectReference) VirtualMachine
 	FindVM(name string) (VirtualMachine, error)
 	FindCluster(name string) (*Cluster, error)
-	PreCleanVM(ui packersdk.Ui, vmPath string, force bool) error
+	PreCleanVM(ui packersdk.Ui, vmPath string, force bool, vsphereCluster string, vsphereHost string, vsphereResourcePool string) error
 	CreateVM(config *CreateConfig) (VirtualMachine, error)
 
 	NewDatastore(ref *types.ManagedObjectReference) Datastore

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -60,7 +60,7 @@ func (d *DriverMock) FindCluster(name string) (*Cluster, error) {
 	return nil, nil
 }
 
-func (d *DriverMock) PreCleanVM(ui packersdk.Ui, vmPath string, force bool) error {
+func (d *DriverMock) PreCleanVM(ui packersdk.Ui, vmPath string, force bool, vsphereCluster string, vsphereHost string, vsphereResourcePool string) error {
 	d.PreCleanVMCalled = true
 	if d.PreCleanShouldFail {
 		return fmt.Errorf("pre clean failed")

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -148,6 +148,14 @@ func (vm *VirtualMachineMock) ConvertToTemplate() error {
 	return nil
 }
 
+func (vm *VirtualMachineMock) IsTemplate() (bool, error) {
+	return false, nil
+}
+
+func (vm *VirtualMachineMock) ConvertToVirtualMachine(vsphereCluster string, vsphereHost string, vsphereResourcePool string) error {
+	return nil
+}
+
 func (vm *VirtualMachineMock) ImportOvfToContentLibrary(ovf vcenter.OVF) error {
 	return nil
 }

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -127,7 +127,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	d := state.Get("driver").(driver.Driver)
 	vmPath := path.Join(s.Location.Folder, s.Location.VMName)
 
-	err := d.PreCleanVM(ui, vmPath, s.Force)
+	err := d.PreCleanVM(ui, vmPath, s.Force, s.Location.Cluster, s.Location.Host, s.Location.ResourcePool)
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt


### PR DESCRIPTION
## Description

This PR resolves the issue where `packer` is not able to remove a `vsphere` template if it has snapshots `create_snapshot = true` in both the `vsphere-clone` and `vsphere-iso` builders.  This fix will convert a template back to a virtual machine so that the VMware API will allow it to be deleted.

## Tests

The same tests that were in the [original packer issue #10889](https://github.com/hashicorp/packer/issues/10889) were run to verify that it is working properly.

## `vsphere-clone` without -force

```text
$ ~/bin/packer build  .
vsphere-clone.cleanuptest: output will be in this color.

Build 'vsphere-clone.cleanuptest' errored after 6 seconds 33 milliseconds: Templates/QA/forcecleanuptest already exists, you can use -force flag to destroy it: <nil>

==> Wait completed after 6 seconds 43 milliseconds

==> Some builds didn't complete successfully and had errors:
--> vsphere-clone.cleanuptest: Templates/QA/forcecleanuptest already exists, you can use -force flag to destroy it: <nil>

==> Builds finished but no artifacts were created.
```

## `vsphere-clone` with -force

```text
$ ~/bin/packer build -force .
vsphere-clone.cleanuptest: output will be in this color.

==> vsphere-clone.cleanuptest: the vm/template Templates/QA/forcecleanuptest already exists, but deleting it due to -force flag
==> vsphere-clone.cleanuptest: Templates/QA/forcecleanuptest is a template, attempting to convert it to a vm
==> vsphere-clone.cleanuptest: Cloning VM...
==> vsphere-clone.cleanuptest: Customizing hardware...
==> vsphere-clone.cleanuptest: Mounting ISO images...
==> vsphere-clone.cleanuptest: Adding configuration parameters...
==> vsphere-clone.cleanuptest: Power on VM...
==> vsphere-clone.cleanuptest: Waiting for IP...
==> vsphere-clone.cleanuptest: IP address: 10.199.97.65
==> vsphere-clone.cleanuptest: Using SSH communicator to connect: 10.199.97.65
==> vsphere-clone.cleanuptest: Waiting for SSH to become available...
==> vsphere-clone.cleanuptest: Connected to SSH!
==> vsphere-clone.cleanuptest: Shutting down VM...
==> vsphere-clone.cleanuptest: Deleting Floppy drives...
==> vsphere-clone.cleanuptest: Eject CD-ROM drives...
==> vsphere-clone.cleanuptest: Deleting CD-ROM drives...
==> vsphere-clone.cleanuptest: Creating snapshot...
==> vsphere-clone.cleanuptest: Convert VM into template...
Build 'vsphere-clone.cleanuptest' finished after 1 minute 40 seconds.

==> Wait completed after 1 minute 40 seconds

==> Builds finished. The artifacts of successful builds are:
--> vsphere-clone.cleanuptest: forcecleanuptest
```

## `vsphere-iso` without -force

```text
 ~/bin/packer build  .
vsphere-iso.cleanuptest: output will be in this color.

==> vsphere-iso.cleanuptest: File /packerfix-vsphere-iso/packer_cache/deec2d1ff8d6c29ab23a695254ed8556b69537b7.iso already uploaded; continuing
==> vsphere-iso.cleanuptest: File [Datastore] packer_cache//deec2d1ff8d6c29ab23a695254ed8556b69537b7.iso already exists; skipping upload.
Build 'vsphere-iso.cleanuptest' errored after 1 second 419 milliseconds: Templates/QA/isoforcecleanuptest already exists, you can use -force flag to destroy it: <nil>

==> Wait completed after 1 second 428 milliseconds

==> Some builds didn't complete successfully and had errors:
--> vsphere-iso.cleanuptest: Templates/QA/isoforcecleanuptest already exists, you can use -force flag to destroy it: <nil>

==> Builds finished but no artifacts were created.
```

## `vsphere-iso` with -force

```text
$ ~/bin/packer build -force .
vsphere-iso.cleanuptest: output will be in this color.

==> vsphere-iso.cleanuptest: File /packerfix-vsphere-iso/packer_cache/deec2d1ff8d6c29ab23a695254ed8556b69537b7.iso already uploaded; continuing
==> vsphere-iso.cleanuptest: File [Datastore] packer_cache//deec2d1ff8d6c29ab23a695254ed8556b69537b7.iso already exists; skipping upload.
==> vsphere-iso.cleanuptest: the vm/template Templates/QA/isoforcecleanuptest already exists, but deleting it due to -force flag
==> vsphere-iso.cleanuptest: Templates/QA/isoforcecleanuptest is a template, attempting to convert it to a vm
==> vsphere-iso.cleanuptest: Creating VM...
==> vsphere-iso.cleanuptest: Customizing hardware...
==> vsphere-iso.cleanuptest: Mounting ISO images...
==> vsphere-iso.cleanuptest: Adding configuration parameters...
==> vsphere-iso.cleanuptest: Starting HTTP server on port 8540
==> vsphere-iso.cleanuptest: Set boot order temporary...
==> vsphere-iso.cleanuptest: Power on VM...
==> vsphere-iso.cleanuptest: Waiting 10s for boot...
==> vsphere-iso.cleanuptest: HTTP server is working at http://10.199.105.74:8540/
==> vsphere-iso.cleanuptest: Typing boot command...
==> vsphere-iso.cleanuptest: Waiting for IP...
==> vsphere-iso.cleanuptest: IP address: 10.199.98.175
==> vsphere-iso.cleanuptest: Using SSH communicator to connect: 10.199.98.175
==> vsphere-iso.cleanuptest: Waiting for SSH to become available...
==> vsphere-iso.cleanuptest: Connected to SSH!
==> vsphere-iso.cleanuptest: Shutting down VM...
==> vsphere-iso.cleanuptest: Deleting Floppy drives...
==> vsphere-iso.cleanuptest: Eject CD-ROM drives...
==> vsphere-iso.cleanuptest: Deleting CD-ROM drives...
==> vsphere-iso.cleanuptest: Creating snapshot...
==> vsphere-iso.cleanuptest: Convert VM into template...
==> vsphere-iso.cleanuptest: Clear boot order...
Build 'vsphere-iso.cleanuptest' finished after 5 minutes 58 seconds.

==> Wait completed after 5 minutes 58 seconds

==> Builds finished. The artifacts of successful builds are:
--> vsphere-iso.cleanuptest: isoforcecleanuptest
```


### Issues

Closes #26 

