### PR TITLE
Take the host configuration into account while cloning a VM

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -311,6 +311,15 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 	datastoreRef := datastore.Reference()
 	relocateSpec.Datastore = &datastoreRef
 
+	if config.Cluster != "" && config.Host != "" {
+		h, err := vm.driver.FindHost(config.Host)
+		if err != nil {
+			return nil, err
+		}
+		hostRef := h.host.Reference()
+		relocateSpec.Host = &hostRef
+	}
+
 	var cloneSpec types.VirtualMachineCloneSpec
 	cloneSpec.Location = relocateSpec
 	cloneSpec.PowerOn = false


### PR DESCRIPTION
This fixes the case when we want to target a specific host within a cluster as given in the documentation:

```json
"cluster": "cluster1",
"host": "esxi-2.vsphere65.test",
```

The **spec.location.host** SOAP parameter was not set in that case.

This has been tested on a real vCenter and it works fine. 

I created a test for this, but unfortunately the govmomi vCenter Simulator is buggy on that matter and just ignores this parameter, so I did not include it in this PR. 

I did write a patch for the govmomi simulator and will shortly submit a pull request. 

