### PR TITLE
feat: Config all net adapters instead only first one

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -378,11 +378,13 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 	virtualDisks := devices.SelectByType((*types.VirtualDisk)(nil))
 	virtualControllers := devices.SelectByType((*types.VirtualController)(nil))
+	virtualNetworkAdapters := devices.SelectByType((*types.VirtualEthernetCard)(nil))
 
 	// Use existing devices to avoid overlapping configuration
 	existingDevices := object.VirtualDeviceList{}
 	existingDevices = append(existingDevices, virtualDisks...)
 	existingDevices = append(existingDevices, virtualControllers...)
+	existingDevices = append(existingDevices, virtualNetworkAdapters...)
 
 	storageConfigSpec, err := config.StorageConfig.AddStorageDevices(existingDevices)
 	if err != nil {
@@ -390,40 +392,42 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 	}
 	configSpec.DeviceChange = append(configSpec.DeviceChange, storageConfigSpec...)
 
-	if config.Network != "" {
-		net, err := vm.driver.FindNetwork(config.Network)
-		if err != nil {
-			return nil, fmt.Errorf("Error finding network: %s", err)
-		}
-		backing, err := net.network.EthernetCardBackingInfo(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Error finding ethernet card backing info: %s", err)
+	networkNames := splitTrim(config.Network)
+	if len(networkNames) > 0 {
+		if len(networkNames) > len(virtualNetworkAdapters) {
+			return nil, fmt.Errorf("%d network names defined but only %d network adapters exist", len(networkNames), len(virtualNetworkAdapters))
 		}
 
-		devices, err := vm.vm.Device(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Error finding vm devices: %s", err)
+		macAddresses := splitTrim(config.MacAddress)
+		for i, networkName := range networkNames {
+			// empty network name means don't touch it
+			if networkName == "" {
+				continue
+			}
+
+			net, err := vm.driver.FindNetwork(networkName)
+			if err != nil {
+				return nil, fmt.Errorf("Error finding network: %s", err)
+			}
+			backing, err := net.network.EthernetCardBackingInfo(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("Error finding ethernet card backing info: %s", err)
+			}
+
+			adapter := virtualNetworkAdapters[i].(types.BaseVirtualEthernetCard)
+			card := adapter.GetVirtualEthernetCard()
+			card.Backing = backing
+			if len(macAddresses) > i && macAddresses[i] != "" {
+				card.AddressType = string(types.VirtualEthernetCardMacTypeManual)
+				card.MacAddress = macAddresses[i]
+			}
+
+			config := &types.VirtualDeviceConfigSpec{
+				Device:    adapter.(types.BaseVirtualDevice),
+				Operation: types.VirtualDeviceConfigSpecOperationEdit,
+			}
+			configSpec.DeviceChange = append(configSpec.DeviceChange, config)
 		}
-
-		adapter, err := findNetworkAdapter(devices)
-		if err != nil {
-			return nil, fmt.Errorf("Error finding network adapter: %s", err)
-		}
-
-		current := adapter.GetVirtualEthernetCard()
-		current.Backing = backing
-
-		if config.MacAddress != "" {
-			current.AddressType = string(types.VirtualEthernetCardMacTypeManual)
-			current.MacAddress = config.MacAddress
-		}
-
-		config := &types.VirtualDeviceConfigSpec{
-			Device:    adapter.(types.BaseVirtualDevice),
-			Operation: types.VirtualDeviceConfigSpecOperationEdit,
-		}
-
-		configSpec.DeviceChange = append(configSpec.DeviceChange, config)
 	}
 
 	vAppConfig, err := vm.updateVAppConfig(ctx, config.VAppProperties)
@@ -1241,4 +1245,12 @@ func findNetworkAdapter(l object.VirtualDeviceList) (types.BaseVirtualEthernetCa
 	}
 
 	return c[0].(types.BaseVirtualEthernetCard), nil
+}
+
+func splitTrim(s string) []string {
+	slc := strings.Split(s, ",")
+	for i := range slc {
+		slc[i] = strings.TrimSpace(slc[i])
+	}
+	return slc
 }

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -6,12 +6,14 @@
 
 - `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
+- `network` (string) - Sets the network in which the VM will be connected to. If no network is
   specified, `host` must be specified to allow Packer to look for the
   available network. If the network is inside a network folder in vSphere inventory,
   you need to provide the full path to the network.
+  A comma separated list sets the network for each  network adapter individually.
 
 - `mac_address` (string) - Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+  A comma separated list sets a custom Mac Address for each network adapter individually.
 
 - `notes` (string) - VM notes.
 

--- a/docs/builders/vsphere-clone.mdx
+++ b/docs/builders/vsphere-clone.mdx
@@ -45,6 +45,59 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builder/vsphere/clone/CloneConfig-not-required.mdx'
 
+**Examples of usage:**
+
+Backwards compatible reconfiguring first network adapter only:
+
+<Tabs>
+<Tab heading="JSON">
+```json
+"network": "new_network",
+"mac_address": "..."
+```
+</Tab>
+<Tab heading="HCL2">
+```hcl
+network = new_network,
+mac_address = '...'
+```
+</Tab>
+</Tabs>
+
+Reconfiguring all network adapters:
+
+<Tabs>
+<Tab heading="JSON">
+```json
+"network": "new_network_for_network_adapter_0, new_network_for_network_adapter_1, new_network_for_network_adapter_2",
+"mac_address": "<mac_address_for_network_adapter_0>, <mac_address_for_network_adapter_1>, <mac_address_for_network_adapter_2>"
+```
+</Tab>
+<Tab heading="HCL2">
+```hcl
+network = 'new_network_for_network_adapter_0, new_network_for_network_adapter_1, new_network_for_network_adapter_2'
+mac_address = '<mac_address_for_network_adapter_0>, <mac_address_for_network_adapter_1>, <mac_address_for_network_adapter_2>'
+```
+</Tab>
+</Tabs>
+
+Reconfiguring only some network adapters:
+
+<Tabs>
+<Tab heading="JSON">
+```json
+"network": "new_network_for_network_adapter_0, , new_network_for_network_adapter_2",
+"mac_address": "<mac_address_for_network_adapter_0>, , <mac_address_for_network_adapter_2>"
+```
+</Tab>
+<Tab heading="HCL2">
+```hcl
+network = 'new_network_for_network_adapter_0, , new_network_for_network_adapter_2'
+mac_address = '<mac_address_for_network_adapter_0>, , <mac_address_for_network_adapter_2>'
+```
+</Tab>
+</Tabs>
+
 @include 'builder/vsphere/common/StorageConfig-not-required.mdx'
 
 ### Storage Configuration


### PR DESCRIPTION
[Copy of packer pull request 10393](https://github.com/hashicorp/packer/pull/10393).
Wasn't able to apply the patching stuff as sent by email notification. Therefore, did it manually.

### Why
vsphere-clone allows to reconfigure the first existing network adapter with network and mac_address.
With this PR vsphere-clone now supports reconfiguring all network adapters.

### Scenario: Template with multiple networks to be reconfigured
Given VMware vSphere template
And template network adapter A connected to network11
And template network adapter B connected to network12
And packer script reconfiguring both network adapters (see examples below)
When I clone template
Then VM is created
But VM network adapter A is connected to network21
But VM network adapter B is connected to network22

### Notes
For backward compatibility I decided to extend the meaning of network and mac_address.
First I though about introducing network_adapters from vsphere-iso, but didn't wanna complicate things more than required for me. Being able to change the network names is enough for me.
To include reconfiguring the MAC addresses as well is a bonus and done to keep thinks aligned.

### Examples
**Backwards compatible reconfiguring first network adapter only:**
"network": "new_network",
"mac_address": "..."

**Reconfiguring all network adapters:**
"network": "new_network_for_network_adapter_0, new_network_for_network_adapter_1, new_network_for_network_adapter_2",
"mac_address": "<mac_address_for_network_adapter_0>, <mac_address_for_network_adapter_1>, <mac_address_for_network_adapter_2>"

**Reconfiguring only some network adapters:**
"network": "new_network_for_network_adapter_0, , new_network_for_network_adapter_2",
"mac_address": "<mac_address_for_network_adapter_0>, , <mac_address_for_network_adapter_2>"