### PR TITLE
Added snapshot_name option for vsphere-clone and vsphere-iso builders

### DIFF
--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -129,6 +129,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
+			SnapshotName: b.config.SnapshotName,
 		},
 		&common.StepConvertToTemplate{
 			ConvertToTemplate: b.config.ConvertToTemplate,

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// Create a snapshot when set to `true`, so the VM can be used as a base
 	// for linked clones. Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
+	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+	// Defaults to `Created By Packer`.
+	SnapshotName string `mapstructure:"snapshot_name"`
 	// Convert VM to a template. Defaults to `false`.
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
 	// Configuration for exporting VM to an ovf file.

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -134,6 +134,7 @@ type FlatConfig struct {
 	Timeout                         *string                                     `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	DisableShutdown                 *bool                                       `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
 	CreateSnapshot                  *bool                                       `mapstructure:"create_snapshot" cty:"create_snapshot" hcl:"create_snapshot"`
+	SnapshotName                    *string                                     `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	ConvertToTemplate               *bool                                       `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
 	Export                          *common.FlatExportConfig                    `mapstructure:"export" cty:"export" hcl:"export"`
 	ContentLibraryDestinationConfig *common.FlatContentLibraryDestinationConfig `mapstructure:"content_library_destination" cty:"content_library_destination" hcl:"content_library_destination"`
@@ -275,6 +276,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shutdown_timeout":               &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"disable_shutdown":               &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"create_snapshot":                &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
+		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"convert_to_template":            &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"export":                         &hcldec.BlockSpec{TypeName: "export", Nested: hcldec.ObjectSpec((*common.FlatExportConfig)(nil).HCL2Spec())},
 		"content_library_destination":    &hcldec.BlockSpec{TypeName: "content_library_destination", Nested: hcldec.ObjectSpec((*common.FlatContentLibraryDestinationConfig)(nil).HCL2Spec())},

--- a/builder/vsphere/common/step_snapshot.go
+++ b/builder/vsphere/common/step_snapshot.go
@@ -10,6 +10,7 @@ import (
 
 type StepCreateSnapshot struct {
 	CreateSnapshot bool
+	SnapshotName string
 }
 
 func (s *StepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -19,7 +20,13 @@ func (s *StepCreateSnapshot) Run(_ context.Context, state multistep.StateBag) mu
 	if s.CreateSnapshot {
 		ui.Say("Creating snapshot...")
 
-		err := vm.CreateSnapshot("Created by Packer")
+		snapshotName := "Created By Packer"
+
+		if s.SnapshotName != "" {
+			snapshotName = s.SnapshotName
+		}
+
+		err := vm.CreateSnapshot(snapshotName)
 		if err != nil {
 			state.Put("error", err)
 			return multistep.ActionHalt

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -131,6 +131,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
+			SnapshotName: b.config.SnapshotName,
 		},
 		&common.StepConvertToTemplate{
 			ConvertToTemplate: b.config.ConvertToTemplate,

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// Create a snapshot when set to `true`, so the VM can be used as a base
 	// for linked clones. Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
+	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+	// Defaults to `Created By Packer`.
+	SnapshotName string `mapstructure:"snapshot_name"`
 	// Convert VM to a template. Defaults to `false`.
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
 	// Configuration for exporting VM to an ovf file.

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -137,6 +137,7 @@ type FlatConfig struct {
 	Timeout                         *string                                     `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	DisableShutdown                 *bool                                       `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
 	CreateSnapshot                  *bool                                       `mapstructure:"create_snapshot" cty:"create_snapshot" hcl:"create_snapshot"`
+	SnapshotName                    *string                                     `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	ConvertToTemplate               *bool                                       `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
 	Export                          *common.FlatExportConfig                    `mapstructure:"export" cty:"export" hcl:"export"`
 	ContentLibraryDestinationConfig *common.FlatContentLibraryDestinationConfig `mapstructure:"content_library_destination" cty:"content_library_destination" hcl:"content_library_destination"`
@@ -280,6 +281,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shutdown_timeout":               &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"disable_shutdown":               &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
 		"create_snapshot":                &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
+		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"convert_to_template":            &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},
 		"export":                         &hcldec.BlockSpec{TypeName: "export", Nested: hcldec.ObjectSpec((*common.FlatExportConfig)(nil).HCL2Spec())},
 		"content_library_destination":    &hcldec.BlockSpec{TypeName: "content_library_destination", Nested: hcldec.ObjectSpec((*common.FlatContentLibraryDestinationConfig)(nil).HCL2Spec())},

--- a/docs-partials/builder/vsphere/clone/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/Config-not-required.mdx
@@ -1,7 +1,10 @@
-<!-- Code generated from the comments of the Config struct in builder/vsphere/clone/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in builder\vsphere\clone\config.go; DO NOT EDIT MANUALLY -->
 
 - `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
   for linked clones. Defaults to `false`.
+
+- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+  Defaults to `Created By Packer`.
 
 - `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
 
@@ -14,4 +17,4 @@
 
 - `customize` (\*CustomizeConfig) - Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).
 
-<!-- End of code generated from the comments of the Config struct in builder/vsphere/clone/config.go; -->
+<!-- End of code generated from the comments of the Config struct in builder\vsphere\clone\config.go; -->

--- a/docs-partials/builder/vsphere/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/Config-not-required.mdx
@@ -1,7 +1,10 @@
-<!-- Code generated from the comments of the Config struct in builder/vsphere/iso/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in builder\vsphere\iso\config.go; DO NOT EDIT MANUALLY -->
 
 - `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
   for linked clones. Defaults to `false`.
+
+- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+  Defaults to `Created By Packer`.
 
 - `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
 
@@ -12,4 +15,4 @@
   The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
   The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
 
-<!-- End of code generated from the comments of the Config struct in builder/vsphere/iso/config.go; -->
+<!-- End of code generated from the comments of the Config struct in builder\vsphere\iso\config.go; -->


### PR DESCRIPTION
Adds a snapshot_name option to allow specifying the name of the snapshot created by create_snapshot in both vsphere-clone and vsphere-iso builders.

Closes #65

