### PR TITLE
Pass cd_content config in vsphere iso and clone builder

### DIFF
--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -42,8 +42,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config: &b.config.ConnectConfig,
 		},
 		&commonsteps.StepCreateCD{
-			Files: b.config.CDConfig.CDFiles,
-			Label: b.config.CDConfig.CDLabel,
+			Files:   b.config.CDConfig.CDFiles,
+			Content: b.config.CDConfig.CDContent,
+			Label:   b.config.CDConfig.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -129,7 +130,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
-			SnapshotName: b.config.SnapshotName,
+			SnapshotName:   b.config.SnapshotName,
 		},
 		&common.StepConvertToTemplate{
 			ConvertToTemplate: b.config.ConvertToTemplate,

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -55,8 +55,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Host:      b.config.Host,
 		},
 		&commonsteps.StepCreateCD{
-			Files: b.config.CDConfig.CDFiles,
-			Label: b.config.CDConfig.CDLabel,
+			Files:   b.config.CDConfig.CDFiles,
+			Content: b.config.CDConfig.CDContent,
+			Label:   b.config.CDConfig.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -131,7 +132,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
-			SnapshotName: b.config.SnapshotName,
+			SnapshotName:   b.config.SnapshotName,
 		},
 		&common.StepConvertToTemplate{
 			ConvertToTemplate: b.config.ConvertToTemplate,


### PR DESCRIPTION
In the documentation there was a cd_content setting but this wasn't working, because it seems to be forgotten in the StepCreateCD step config of the iso and clone builder.
