### PR TITLE
Modify Documentation to Add lsilogic-sas As Storage Controller Option

### DIFF
--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -91,7 +91,7 @@ type DiskConfig struct {
 }
 
 type StorageConfig struct {
-	// Set VM disk controller type. Example `lsilogic`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
+	// Set VM disk controller type. Example `lsilogic`, `lsilogic-sas`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
 	// Defaults to `lsilogic`. See
 	// [SCSI, SATA, and NVMe Storage Controller Conditions, Limitations, and Compatibility](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362.html#GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362)
 	// for additional details.

--- a/docs-partials/builder/vsphere/common/StorageConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/StorageConfig-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the StorageConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_controller_type` ([]string) - Set VM disk controller type. Example `lsilogic`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
+- `disk_controller_type` ([]string) - Set VM disk controller type. Example `lsilogic`, `lsilogic-sas`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
   Defaults to `lsilogic`. See
   [SCSI, SATA, and NVMe Storage Controller Conditions, Limitations, and Compatibility](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362.html#GUID-5872D173-A076-42FE-8D0B-9DB0EB0E7362)
   for additional details.


### PR DESCRIPTION
The documentation does not include the valid `disk_controller_type` of lsilogic-sas. There was an issue/pr mentioned in the jetbrains repo (https://github.com/jetbrains-infra/packer-builder-vsphere/issues/188) that led me to this conclusion.

