### PR TITLE
Fixed URL to vsphere-clone

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -19,7 +19,7 @@ the following vSphere builders:
   ISO file and utilizes the vSphere API to build on a remote esx instance.
   This allows you to build vms even if you do not have SSH access to your vSphere cluster.
 
-- [vsphere-clone](docs/builders/vsphere/vsphere-clone) - This builder clones a
+- [vsphere-clone](/docs/builders/vsphere/vsphere-clone) - This builder clones a
   vm from an existing template, then modifies it and saves it as a new
   template. It uses the vSphere API to build on a remote esx instance.
   This allows you to build vms even if you do not have SSH access to your vSphere cluster.


### PR DESCRIPTION
This PR fixes the URL for vsphere-clone.

Without this commit, it would result in the nonexisting URL:

https://www.packer.io/docs/builders/docs/builders/vsphere/vsphere-clone

With this fix, it results in the existing URL:

https://www.packer.io/docs/builders/vsphere/vsphere-clone