### PR TITLE
Support floppy_content

### DIFF
--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -78,6 +78,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			&commonsteps.StepCreateFloppy{
 				Files:       b.config.FloppyFiles,
 				Directories: b.config.FloppyDirectories,
+				Content:     b.config.FloppyContent,
 				Label:       b.config.FloppyLabel,
 			},
 			&common.StepAddFloppy{

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -72,6 +72,7 @@ type FlatConfig struct {
 	FloppyIMGPath                   *string                                     `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
 	FloppyFiles                     []string                                    `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories               []string                                    `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
+	FloppyContent                   map[string]string                           `mapstructure:"floppy_content" cty:"floppy_content" hcl:"floppy_content"`
 	FloppyLabel                     *string                                     `mapstructure:"floppy_label" cty:"floppy_label" hcl:"floppy_label"`
 	BootOrder                       *string                                     `mapstructure:"boot_order" cty:"boot_order" hcl:"boot_order"`
 	BootGroupInterval               *string                                     `mapstructure:"boot_keygroup_interval" cty:"boot_keygroup_interval" hcl:"boot_keygroup_interval"`
@@ -214,6 +215,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_img_path":                &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":                   &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                    &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
+		"floppy_content":                 &hcldec.AttrSpec{Name: "floppy_content", Type: cty.Map(cty.String), Required: false},
 		"floppy_label":                   &hcldec.AttrSpec{Name: "floppy_label", Type: cty.String, Required: false},
 		"boot_order":                     &hcldec.AttrSpec{Name: "boot_order", Type: cty.String, Required: false},
 		"boot_keygroup_interval":         &hcldec.AttrSpec{Name: "boot_keygroup_interval", Type: cty.String, Required: false},

--- a/builder/vsphere/common/step_add_floppy.go
+++ b/builder/vsphere/common/step_add_floppy.go
@@ -21,6 +21,21 @@ type FloppyConfig struct {
 	FloppyFiles []string `mapstructure:"floppy_files"`
 	// List of directories to copy files from.
 	FloppyDirectories []string `mapstructure:"floppy_dirs"`
+	// Key/Values to add to the floppy disk. The keys represent the paths, and
+	// the values contents. It can be used alongside `floppy_files` or
+	// `floppy_dirs`, which is useful to add large files without loading them
+	// into memory. If any paths are specified by both, the contents in
+	// `floppy_content` will take precedence.
+	//
+	// Usage example (HCL):
+	//
+	// ```hcl
+	// floppy_content = {
+	//   "meta-data" = jsonencode(local.instance_data)
+	//   "user-data" = templatefile("user-data", { packages = ["nginx"] })
+	// }
+	// ```
+	FloppyContent map[string]string `mapstructure:"floppy_content"`
 	// The label to use for the floppy disk that
 	// is attached when the VM is booted. This is most useful for cloud-init,
 	// Kickstart or other early initialization tools, which can benefit from labelled floppy disks.

--- a/builder/vsphere/common/step_add_floppy.hcl2spec.go
+++ b/builder/vsphere/common/step_add_floppy.hcl2spec.go
@@ -10,10 +10,11 @@ import (
 // FlatFloppyConfig is an auto-generated flat version of FloppyConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatFloppyConfig struct {
-	FloppyIMGPath     *string  `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
-	FloppyFiles       []string `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
-	FloppyDirectories []string `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
-	FloppyLabel       *string  `mapstructure:"floppy_label" cty:"floppy_label" hcl:"floppy_label"`
+	FloppyIMGPath     *string           `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
+	FloppyFiles       []string          `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
+	FloppyDirectories []string          `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
+	FloppyContent     map[string]string `mapstructure:"floppy_content" cty:"floppy_content" hcl:"floppy_content"`
+	FloppyLabel       *string           `mapstructure:"floppy_label" cty:"floppy_label" hcl:"floppy_label"`
 }
 
 // FlatMapstructure returns a new FlatFloppyConfig.
@@ -31,6 +32,7 @@ func (*FlatFloppyConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_img_path": &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":    &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":     &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
+		"floppy_content":  &hcldec.AttrSpec{Name: "floppy_content", Type: cty.Map(cty.String), Required: false},
 		"floppy_label":    &hcldec.AttrSpec{Name: "floppy_label", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -81,6 +81,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyFiles,
 			Directories: b.config.FloppyDirectories,
+			Content:     b.config.FloppyContent,
 			Label:       b.config.FloppyLabel,
 		},
 		&common.StepAddFloppy{

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -75,6 +75,7 @@ type FlatConfig struct {
 	FloppyIMGPath                   *string                                     `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
 	FloppyFiles                     []string                                    `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories               []string                                    `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
+	FloppyContent                   map[string]string                           `mapstructure:"floppy_content" cty:"floppy_content" hcl:"floppy_content"`
 	FloppyLabel                     *string                                     `mapstructure:"floppy_label" cty:"floppy_label" hcl:"floppy_label"`
 	BootOrder                       *string                                     `mapstructure:"boot_order" cty:"boot_order" hcl:"boot_order"`
 	BootGroupInterval               *string                                     `mapstructure:"boot_keygroup_interval" cty:"boot_keygroup_interval" hcl:"boot_keygroup_interval"`
@@ -219,6 +220,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"floppy_img_path":                &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":                   &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                    &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},
+		"floppy_content":                 &hcldec.AttrSpec{Name: "floppy_content", Type: cty.Map(cty.String), Required: false},
 		"floppy_label":                   &hcldec.AttrSpec{Name: "floppy_label", Type: cty.String, Required: false},
 		"boot_order":                     &hcldec.AttrSpec{Name: "boot_order", Type: cty.String, Required: false},
 		"boot_keygroup_interval":         &hcldec.AttrSpec{Name: "boot_keygroup_interval", Type: cty.String, Required: false},

--- a/docs-partials/builder/vsphere/common/FloppyConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/FloppyConfig-not-required.mdx
@@ -8,6 +8,21 @@
 
 - `floppy_dirs` ([]string) - List of directories to copy files from.
 
+- `floppy_content` (map[string]string) - Key/Values to add to the floppy disk. The keys represent the paths, and
+  the values contents. It can be used alongside `floppy_files` or
+  `floppy_dirs`, which is useful to add large files without loading them
+  into memory. If any paths are specified by both, the contents in
+  `floppy_content` will take precedence.
+  
+  Usage example (HCL):
+  
+  ```hcl
+  floppy_content = {
+    "meta-data" = jsonencode(local.instance_data)
+    "user-data" = templatefile("user-data", { packages = ["nginx"] })
+  }
+  ```
+
 - `floppy_label` (string) - The label to use for the floppy disk that
   is attached when the VM is booted. This is most useful for cloud-init,
   Kickstart or other early initialization tools, which can benefit from labelled floppy disks.


### PR DESCRIPTION
Add similar parameter as `http_content` and `cd_content`, but for floppy.

Requires packer-plugin-sdk with following PR https://github.com/hashicorp/packer-plugin-sdk/pull/82
Closes #110


