### PR TITLE
Add skip_import parameter

### DIFF
--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -63,6 +63,8 @@ type ContentLibraryDestinationConfig struct {
 	Destroy bool `mapstructure:"destroy"`
 	// When set to true, Packer will import and OVF template to the content library item. Defaults to `false`.
 	Ovf bool `mapstructure:"ovf"`
+	// When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
+	SkipImport bool `mapstructure:"skip_import"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -118,6 +120,11 @@ type StepImportToContentLibrary struct {
 
 func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
+	if s.ContentLibConfig.SkipImport {
+		ui.Say("Skipping import...")
+		return multistep.ActionContinue
+	}
+
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
 	var err error
 

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -20,6 +20,7 @@ type FlatContentLibraryDestinationConfig struct {
 	Datastore    *string `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
 	Destroy      *bool   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
 	Ovf          *bool   `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
+	SkipImport   *bool   `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -44,6 +45,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"datastore":     &hcldec.AttrSpec{Name: "datastore", Type: cty.String, Required: false},
 		"destroy":       &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 		"ovf":           &hcldec.AttrSpec{Name: "ovf", Type: cty.Bool, Required: false},
+		"skip_import":   &hcldec.AttrSpec{Name: "skip_import", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -45,4 +45,6 @@
 
 - `ovf` (bool) - When set to true, Packer will import and OVF template to the content library item. Defaults to `false`.
 
+- `skip_import` (bool) - When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
+
 <!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->


### PR DESCRIPTION
Add `skip_import` parameter in `content_library_destination` configuration.

Closes #119


