### PR TITLE
export options update

### DIFF
--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -146,12 +146,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	if b.config.Export != nil {
 		steps = append(steps, &common.StepExport{
-			Name:      b.config.Export.Name,
-			Force:     b.config.Export.Force,
-			Images:    b.config.Export.Images,
-			Manifest:  b.config.Export.Manifest,
-			OutputDir: b.config.Export.OutputDir.OutputDir,
-			Options:   b.config.Export.Options,
+			Name:       b.config.Export.Name,
+			Force:      b.config.Export.Force,
+			ImageFiles: b.config.Export.Images,
+			Manifest:   b.config.Export.Manifest,
+			OutputDir:  b.config.Export.OutputDir.OutputDir,
+			Options:    b.config.Export.Options,
 		})
 	}
 

--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -59,13 +59,13 @@ import (
 // ./output_vsphere/example-ubuntu.ovf
 // ```
 type ExportConfig struct {
-	// name of the ovf. defaults to the name of the VM
+	// Name of the ovf. defaults to the name of the VM
 	Name string `mapstructure:"name"`
-	// overwrite ovf if it exists
+	// Overwrite ovf if it exists
 	Force bool `mapstructure:"force"`
-	// include iso and img image files that are attached to the VM
+	// Include additional image files that are attached to the VM, such as nvram, iso, img.
 	Images bool `mapstructure:"images"`
-	// generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
+	// Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
 	Manifest string `mapstructure:"manifest"`
 	// Directory on the computer running Packer to export files to
 	OutputDir OutputConfig `mapstructure:",squash"`
@@ -111,7 +111,7 @@ func (c *ExportConfig) Prepare(ctx *interpolate.Context, lc *LocationConfig, pc 
 		c.Manifest = "sha256"
 	}
 	if _, ok := sha[c.Manifest]; !ok {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("unknown hash: %s. available options include available options being 'none', 'sha1', 'sha256', 'sha512'", c.Manifest))
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("unknown hash: %s: available options include available options being 'none', 'sha1', 'sha256', 'sha512'", c.Manifest))
 	}
 
 	if c.Name == "" {

--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -65,7 +65,7 @@ type ExportConfig struct {
 	Force bool `mapstructure:"force"`
 	// Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
 	Images bool `mapstructure:"images"`
-	// Include additional image files that are attached to the VM, such as nvram, iso, img.
+	// In exported files, include additional image files that are attached to the VM, such as nvram, iso, img.
 	ImageFiles bool `mapstructure:"image_files"`
 	// Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
 	Manifest string `mapstructure:"manifest"`

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -12,13 +12,14 @@ import (
 // FlatExportConfig is an auto-generated flat version of ExportConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatExportConfig struct {
-	Name      *string      `mapstructure:"name" cty:"name" hcl:"name"`
-	Force     *bool        `mapstructure:"force" cty:"force" hcl:"force"`
-	Images    *bool        `mapstructure:"images" cty:"images" hcl:"images"`
-	Manifest  *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
-	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
-	Options   []string     `mapstructure:"options" cty:"options" hcl:"options"`
+	Name       *string      `mapstructure:"name" cty:"name" hcl:"name"`
+	Force      *bool        `mapstructure:"force" cty:"force" hcl:"force"`
+	Images     *bool        `mapstructure:"images" cty:"images" hcl:"images"`
+	ImageFiles *bool        `mapstructure:"image_files" cty:"image_files" hcl:"image_files"`
+	Manifest   *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
+	OutputDir  *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	DirPerm    *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	Options    []string     `mapstructure:"options" cty:"options" hcl:"options"`
 }
 
 // FlatMapstructure returns a new FlatExportConfig.
@@ -36,6 +37,7 @@ func (*FlatExportConfig) HCL2Spec() map[string]hcldec.Spec {
 		"name":                 &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 		"force":                &hcldec.AttrSpec{Name: "force", Type: cty.Bool, Required: false},
 		"images":               &hcldec.AttrSpec{Name: "images", Type: cty.Bool, Required: false},
+		"image_files":          &hcldec.AttrSpec{Name: "image_files", Type: cty.Bool, Required: false},
 		"manifest":             &hcldec.AttrSpec{Name: "manifest", Type: cty.String, Required: false},
 		"output_directory":     &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"directory_permission": &hcldec.AttrSpec{Name: "directory_permission", Type: cty.Number, Required: false},

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -148,12 +148,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	if b.config.Export != nil {
 		steps = append(steps, &common.StepExport{
-			Name:      b.config.Export.Name,
-			Force:     b.config.Export.Force,
-			Images:    b.config.Export.Images,
-			Manifest:  b.config.Export.Manifest,
-			OutputDir: b.config.Export.OutputDir.OutputDir,
-			Options:   b.config.Export.Options,
+			Name:       b.config.Export.Name,
+			Force:      b.config.Export.Force,
+			ImageFiles: b.config.Export.Images,
+			Manifest:   b.config.Export.Manifest,
+			OutputDir:  b.config.Export.OutputDir.OutputDir,
+			Options:    b.config.Export.Options,
 		})
 	}
 

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -4,7 +4,9 @@
 
 - `force` (bool) - Overwrite ovf if it exists
 
-- `images` (bool) - Include additional image files that are attached to the VM, such as nvram, iso, img.
+- `images` (bool) - Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
+
+- `image_files` (bool) - Include additional image files that are attached to the VM, such as nvram, iso, img.
 
 - `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
 

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -1,12 +1,12 @@
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-- `name` (string) - name of the ovf. defaults to the name of the VM
+- `name` (string) - Name of the ovf. defaults to the name of the VM
 
-- `force` (bool) - overwrite ovf if it exists
+- `force` (bool) - Overwrite ovf if it exists
 
-- `images` (bool) - include iso and img image files that are attached to the VM
+- `images` (bool) - Include additional image files that are attached to the VM, such as nvram, iso, img.
 
-- `manifest` (string) - generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
+- `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
 
 - `options` ([]string) - Advanced ovf export options. Options can include:
   * mac - MAC address is exported for all ethernet devices

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -6,7 +6,7 @@
 
 - `images` (bool) - Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
 
-- `image_files` (bool) - Include additional image files that are attached to the VM, such as nvram, iso, img.
+- `image_files` (bool) - In exported files, include additional image files that are attached to the VM, such as nvram, iso, img.
 
 - `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
 


### PR DESCRIPTION
- Update documentation for export.images argument
- Add image_files configuration argument

The existing argument for including image files is called `images`,
which is a bit misleading. This commit adds a new argument
`image_files` and deprecates the old one.

Closes #95 