### PR TITLE
Updated branch from master to main

### DIFF
--- a/docs/builders/vsphere-clone.mdx
+++ b/docs/builders/vsphere-clone.mdx
@@ -23,7 +23,7 @@ This builder clones VMs from existing templates.
 
 ## Examples
 
-See complete Ubuntu, Windows, and macOS templates in the [examples folder](https://github.com/hashicorp/packer-plugin-vsphere/tree/master/builder/vsphere/examples/).
+See complete Ubuntu, Windows, and macOS templates in the [examples folder](https://github.com/hashicorp/packer-plugin-vsphere/tree/main/builder/vsphere/examples/).
 
 ## Configuration Reference
 

--- a/docs/builders/vsphere-iso.mdx
+++ b/docs/builders/vsphere-iso.mdx
@@ -23,7 +23,7 @@ starts from an ISO file and creates new VMs from scratch.
 
 ## Examples
 
-See complete Ubuntu, Windows, and macOS templates in the [examples folder](https://github.com/hashicorp/packer-plugin-vsphere/tree/master/builder/vsphere/examples/).
+See complete Ubuntu, Windows, and macOS templates in the [examples folder](https://github.com/hashicorp/packer-plugin-vsphere/tree/main/builder/vsphere/examples/).
 
 # Configuration Reference
 


### PR DESCRIPTION
Some links were still pointing to the old default branch "master". They have been updated to "main".