### PR TITLE
Hardware version post processor option

### DIFF
--- a/docs/post-processors/vsphere.mdx
+++ b/docs/post-processors/vsphere.mdx
@@ -69,6 +69,13 @@ Optional:
 - `overwrite` (boolean) - If it's true force the system to overwrite the
   existing files instead create new ones. Default is `false`
 
+- `hardware_version` (string) - The virtual hardware version that the VM
+  should be deployed with.  Use when deploying to vsphere/esxi host 
+  whose version is different than the vsphere/esxi host used to create
+  the artifact.  See [VMWare's virtual hardware KB article] 
+  (Virtual machine hardware versions) for more information about the 
+  virtual hardware versions supported by the versions of Vsphere.
+
 - `options` (array of strings) - Custom options to add in `ovftool`. See
   `ovftool --help` to list all the options
 

--- a/docs/post-processors/vsphere.mdx
+++ b/docs/post-processors/vsphere.mdx
@@ -70,10 +70,10 @@ Optional:
   existing files instead create new ones. Default is `false`
 
 - `hardware_version` (string) - The virtual hardware version that the VM
-  should be deployed with.  Use when deploying to vsphere/esxi host 
-  whose version is different than the vsphere/esxi host used to create
-  the artifact.  See [VMWare's virtual hardware KB article] 
-  (Virtual machine hardware versions) for more information about the 
+  should be deployed with. Use when deploying to vsphere/esxi host whose version
+  is different than the vsphere/esxi host used to create the artifact. See
+  [VMWare's virtual hardware KB article]
+  (https://kb.vmware.com/s/article/1003746) for more information about the
   virtual hardware versions supported by the versions of Vsphere.
 
 - `options` (array of strings) - Custom options to add in `ovftool`. See

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -37,21 +37,22 @@ var (
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
-	Cluster      string   `mapstructure:"cluster"`
-	Datacenter   string   `mapstructure:"datacenter"`
-	Datastore    string   `mapstructure:"datastore"`
-	DiskMode     string   `mapstructure:"disk_mode"`
-	Host         string   `mapstructure:"host"`
-	ESXiHost     string   `mapstructure:"esxi_host"`
-	Insecure     bool     `mapstructure:"insecure"`
-	Options      []string `mapstructure:"options"`
-	Overwrite    bool     `mapstructure:"overwrite"`
-	Password     string   `mapstructure:"password"`
-	ResourcePool string   `mapstructure:"resource_pool"`
-	Username     string   `mapstructure:"username"`
-	VMFolder     string   `mapstructure:"vm_folder"`
-	VMName       string   `mapstructure:"vm_name"`
-	VMNetwork    string   `mapstructure:"vm_network"`
+	Cluster         string   `mapstructure:"cluster"`
+	Datacenter      string   `mapstructure:"datacenter"`
+	Datastore       string   `mapstructure:"datastore"`
+	DiskMode        string   `mapstructure:"disk_mode"`
+	Host            string   `mapstructure:"host"`
+	ESXiHost        string   `mapstructure:"esxi_host"`
+	Insecure        bool     `mapstructure:"insecure"`
+	Options         []string `mapstructure:"options"`
+	Overwrite       bool     `mapstructure:"overwrite"`
+	Password        string   `mapstructure:"password"`
+	ResourcePool    string   `mapstructure:"resource_pool"`
+	Username        string   `mapstructure:"username"`
+	VMFolder        string   `mapstructure:"vm_folder"`
+	VMName          string   `mapstructure:"vm_name"`
+	VMNetwork       string   `mapstructure:"vm_network"`
+	HardwareVersion string   `mapstructure:"hardware_version"`
 
 	ctx interpolate.Context
 }
@@ -259,6 +260,10 @@ func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) 
 
 	if p.config.VMFolder != "" {
 		args = append(args, fmt.Sprintf(`--vmFolder=%s`, p.config.VMFolder))
+	}
+
+	if p.config.HardwareVersion != "" {
+		args = append(args, fmt.Sprintf(`--maxVirtualHardwareVersion=%s`, p.config.HardwareVersion))
 	}
 
 	if p.config.VMNetwork != "" {

--- a/post-processor/vsphere/post-processor.hcl2spec.go
+++ b/post-processor/vsphere/post-processor.hcl2spec.go
@@ -33,6 +33,7 @@ type FlatConfig struct {
 	VMFolder            *string           `mapstructure:"vm_folder" cty:"vm_folder" hcl:"vm_folder"`
 	VMName              *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMNetwork           *string           `mapstructure:"vm_network" cty:"vm_network" hcl:"vm_network"`
+	HardwareVersion     *string           `mapstructure:"hardware_version" cty:"hardware_version" hcl:"hardware_version"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -70,6 +71,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_folder":                  &hcldec.AttrSpec{Name: "vm_folder", Type: cty.String, Required: false},
 		"vm_name":                    &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_network":                 &hcldec.AttrSpec{Name: "vm_network", Type: cty.String, Required: false},
+		"hardware_version":           &hcldec.AttrSpec{Name: "hardware_version", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
The change that I am making involves adding an additional configuration option to the vsphere post processor which would allow the user to specify the virtual hardware version of the virtual machine that will be deployed.  Nothing particularly complicated, as ovftool includes an argument which allows for this. and I simply take advantage of the aforementioned argument.  I also modified the help content to incorporate this new configuration option.  I had to modify the plugin because of a need for my particular project, and I figured that I would make the modification part of the official plugin.

