### PR TITLE
[WIP] Port terraform customize `windows_options` to packer and other improvements

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -135,6 +135,8 @@ type FlatConfig struct {
 	Command                         *string                                     `mapstructure:"shutdown_command" cty:"shutdown_command" hcl:"shutdown_command"`
 	Timeout                         *string                                     `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	DisableShutdown                 *bool                                       `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
+	PollingInterval                 *string                                     `mapstructure:"shutdown_polling_interval" cty:"shutdown_polling_interval" hcl:"shutdown_polling_interval"`
+	PauseBeforeShutdown             *string                                     `mapstructure:"pause_before_shutdown" cty:"pause_before_shutdown" hcl:"pause_before_shutdown"`
 	CreateSnapshot                  *bool                                       `mapstructure:"create_snapshot" cty:"create_snapshot" hcl:"create_snapshot"`
 	SnapshotName                    *string                                     `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	ConvertToTemplate               *bool                                       `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
@@ -279,6 +281,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shutdown_command":               &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":               &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"disable_shutdown":               &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
+		"shutdown_polling_interval":      &hcldec.AttrSpec{Name: "shutdown_polling_interval", Type: cty.String, Required: false},
+		"pause_before_shutdown":          &hcldec.AttrSpec{Name: "pause_before_shutdown", Type: cty.String, Required: false},
 		"create_snapshot":                &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
 		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"convert_to_template":            &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},

--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -26,8 +26,6 @@ import (
 //
 // The settings for customize are as follows:
 type CustomizeConfig struct {
-	// Use a customization profile already defined on the vCenter
-	CustomizationSpecName string `mapstructure:"customization_spec_name"`
 	// Settings to Linux guest OS customization. See [Linux customization settings](#linux-customization-settings).
 	LinuxOptions *LinuxOptions `mapstructure:"linux_options"`
 	// Settings to Linux guest OS customization.
@@ -186,11 +184,10 @@ func (s *StepCustomize) Run(ctx context.Context, state multistep.StateBag) multi
 	ui.Say("Customizing VM...")
 	err = vm.Customize(spec)
 	if err != nil {
-		ui.Say("there was an error during customization")
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
-	ui.Say("Customization did not return an error")
+
 	return multistep.ActionContinue
 }
 

--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -1,5 +1,5 @@
 //go:generate packer-sdc struct-markdown
-//go:generate packer-sdc mapstructure-to-hcl2 -type CustomizeConfig,LinuxOptions,NetworkInterfaces,NetworkInterface,GlobalDnsSettings,GlobalRoutingSettings
+//go:generate packer-sdc mapstructure-to-hcl2 -type CustomizeConfig,LinuxOptions,WindowsOptions,WindowsOptionsGuiUnattended,WindowsOptionsUserData,WindowsOptionsGuiRunOnce,WindowsOptionsIdentification,WindowsOptionsLicenseFilePrintData,NetworkInterfaces,NetworkInterface,GlobalDnsSettings,GlobalRoutingSettings
 package clone
 
 import (
@@ -26,10 +26,16 @@ import (
 //
 // The settings for customize are as follows:
 type CustomizeConfig struct {
+	// Use a customization profile already defined on the vCenter
+	CustomizationSpecName string `mapstructure:"customization_spec_name"`
 	// Settings to Linux guest OS customization. See [Linux customization settings](#linux-customization-settings).
 	LinuxOptions *LinuxOptions `mapstructure:"linux_options"`
+	// Settings to Linux guest OS customization.
+	WindowsOptions *WindowsOptions `mapstructure:"windows_options"`
 	// Supply your own sysprep.xml file to allow full control of the customization process out-of-band of vSphere.
 	WindowsSysPrepFile string `mapstructure:"windows_sysprep_file"`
+	// Supply your own sysprep.xml text to allow full control of the customization process out-of-band of vSphere.
+	WindowsSysPrepText string `mapstructure:"windows_sysprep_text"`
 	// Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
 	// To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.
 	// See [Network interface settings](#network-interface-settings).
@@ -47,6 +53,39 @@ type LinuxOptions struct {
 	HWClockUTC config.Trilean `mapstructure:"hw_clock_utc"`
 	// Sets the time zone. The default is UTC.
 	Timezone string `mapstructure:"time_zone"`
+}
+
+type WindowsOptions struct {
+	// CustomizationGuiRunOnce
+	// A list of commands to run at first user logon, after guest customization.
+	RunOnceCommandList *[]string `mapstructure:"run_once_command_list"`
+	// CustomizationGuiUnattended
+	// Specifies whether or not the VM automatically logs on as Administrator.
+	AutoLogon *bool `mapstructure:"auto_logon"`
+	// Specifies how many times the VM should auto-logon the Administrator account when auto_logon is true. Default 1
+	AutoLogonCount *int32 `mapstructure:"auto_logon_count"`
+	// The new administrator password for this virtual machine.
+	AdminPassword *string `mapstructure:"admin_password"`
+	// The new time zone for the virtual machine. This is a sysprep-dictated timezone code. Default 85 (GMT)
+	TimeZone *int32 `mapstructure:"time_zone"`
+	// CustomizationIdentification
+	// The user account of the domain administrator used to join this virtual machine to the domain.
+	DomainAdminUser string `mapstructure:"domain_admin_user"`
+	// The password of the domain administrator used to join this virtual machine to the domain.
+	DomainAdminPassword string `mapstructure:"domain_admin_password"`
+	// The domain that the virtual machine should join.
+	JoinDomain string `mapstructure:"join_domain"`
+	// The workgroup for this virtual machine if not joining a domain.
+	Workgroup string `mapstructure:"workgroup"`
+	// CustomizationUserData
+	// The host name for this virtual machine.
+	ComputerName string `mapstructure:"computer_name"`
+	// The full name of the user of this virtual machine. Default: "Administrator"
+	FullName string `mapstructure:"full_name"`
+	// The organization name this virtual machine is being installed for. Default: "Managed by Packer"
+	OrganizationName string `mapstructure:"organization_name"`
+	// The product key for this virtual machine.
+	ProductKey string `mapstructure:"product_key"`
 }
 
 type NetworkInterface struct {
@@ -92,37 +131,41 @@ type StepCustomize struct {
 func (c *CustomizeConfig) Prepare() []error {
 	var errs []error
 
-	if c.LinuxOptions == nil && c.WindowsSysPrepFile == "" {
-		errs = append(errs, fmt.Errorf("customize is empty"))
+	options_number := 0
+	if c.LinuxOptions != nil {
+		options_number = options_number + 1
 	}
-	if c.LinuxOptions != nil && c.WindowsSysPrepFile != "" {
-		errs = append(errs, fmt.Errorf("`linux_options` and `windows_sysprep_text` both set - one must not be included if the other is specified"))
+	if c.WindowsOptions != nil {
+		options_number = options_number + 1
+	}
+	if c.WindowsSysPrepFile != "" {
+		options_number = options_number + 1
+	}
+	if c.WindowsSysPrepText != "" {
+		options_number = options_number + 1
+	}
+
+	if options_number > 1 {
+		errs = append(errs, fmt.Errorf("Only one of `linux_options`, `windows_options`, `windows_sysprep_text`, `windows_sysprep_file` can be set"))
+	} else if options_number == 0 {
+		errs = append(errs, fmt.Errorf("One of `linux_options`, `windows_options`, `windows_sysprep_text`, `windows_sysprep_file` must be set"))
 	}
 
 	if c.LinuxOptions != nil {
-		if c.LinuxOptions.Hostname == "" {
-			errs = append(errs, fmt.Errorf("linux options `host_name` is empty"))
-		}
-		if c.LinuxOptions.Domain == "" {
-			errs = append(errs, fmt.Errorf("linux options `domain` is empty"))
-		}
-
-		if c.LinuxOptions.HWClockUTC == config.TriUnset {
-			c.LinuxOptions.HWClockUTC = config.TriTrue
-		}
-		if c.LinuxOptions.Timezone == "" {
-			c.LinuxOptions.Timezone = "UTC"
-		}
+		errs = c.LinuxOptions.prepare(errs)
+	}
+	if c.WindowsOptions != nil {
+		errs = c.WindowsOptions.prepare(errs)
 	}
 
-	if len(c.NetworkInterfaces) == 0 {
-		errs = append(errs, fmt.Errorf("one or more `network_interface` must be provided"))
-	}
+	// if len(c.NetworkInterfaces) == 0 {
+	// 	errs = append(errs, fmt.Errorf("one or more `network_interface` must be provided"))
+	// }
 
 	return errs
 }
 
-func (s *StepCustomize) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepCustomize) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
 	ui := state.Get("ui").(packersdk.Ui)
 
@@ -143,32 +186,34 @@ func (s *StepCustomize) Run(_ context.Context, state multistep.StateBag) multist
 	ui.Say("Customizing VM...")
 	err = vm.Customize(spec)
 	if err != nil {
+		ui.Say("there was an error during customization")
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
-
+	ui.Say("Customization did not return an error")
 	return multistep.ActionContinue
 }
 
 func (s *StepCustomize) identitySettings() (types.BaseCustomizationIdentitySettings, error) {
 	if s.Config.LinuxOptions != nil {
-		return &types.CustomizationLinuxPrep{
-			HostName: &types.CustomizationFixedName{
-				Name: s.Config.LinuxOptions.Hostname,
-			},
-			Domain:     s.Config.LinuxOptions.Domain,
-			TimeZone:   s.Config.LinuxOptions.Timezone,
-			HwClockUTC: s.Config.LinuxOptions.HWClockUTC.ToBoolPointer(),
-		}, nil
+		return s.Config.LinuxOptions.linuxPrep(), nil
 	}
 
+	if s.Config.WindowsOptions != nil {
+		return s.Config.WindowsOptions.sysprep(), nil
+	}
+
+	sysPrep := s.Config.WindowsSysPrepText
 	if s.Config.WindowsSysPrepFile != "" {
-		sysPrep, err := ioutil.ReadFile(s.Config.WindowsSysPrepFile)
+		sysPrepBytes, err := ioutil.ReadFile(s.Config.WindowsSysPrepFile)
 		if err != nil {
 			return nil, fmt.Errorf("error on reading %s: %s", s.Config.WindowsSysPrepFile, err)
 		}
+		sysPrep = string(sysPrepBytes)
+	}
+	if sysPrep != "" {
 		return &types.CustomizationSysprepText{
-			Value: string(sysPrep),
+			Value: sysPrep,
 		}, nil
 	}
 
@@ -202,6 +247,7 @@ func (s *StepCustomize) ipSettings(n int, ipv4gwAdd bool, ipv6gwAdd bool) (types
 		}
 		obj.SubnetMask = v4CIDRMaskToDotted(ipv4mask)
 		// Check for the gateway
+
 		if ipv4gwAdd && ipv4Gateway != "" && matchGateway(ipv4Address, ipv4mask, ipv4Gateway) {
 			obj.Gateway = []string{ipv4Gateway}
 			v4gwFound = true
@@ -271,6 +317,144 @@ func (s *StepCustomize) globalIpSettings() types.CustomizationGlobalIPSettings {
 		DnsServerList: s.Config.DnsServerList,
 		DnsSuffixList: s.Config.DnsSuffixList,
 	}
+}
+
+func (l *LinuxOptions) prepare(errs []error) []error {
+	if l.Hostname == "" {
+		errs = append(errs, fmt.Errorf("linux options `host_name` is empty"))
+	}
+	if l.Domain == "" {
+		errs = append(errs, fmt.Errorf("linux options `domain` is empty"))
+	}
+
+	if l.HWClockUTC == config.TriUnset {
+		l.HWClockUTC = config.TriTrue
+	}
+	if l.Timezone == "" {
+		l.Timezone = "UTC"
+	}
+	return errs
+}
+
+func (l *LinuxOptions) linuxPrep() *types.CustomizationLinuxPrep {
+	obj := &types.CustomizationLinuxPrep{
+		HostName: &types.CustomizationFixedName{
+			Name: l.Hostname,
+		},
+		Domain:     l.Domain,
+		TimeZone:   l.Timezone,
+		HwClockUTC: l.HWClockUTC.ToBoolPointer(),
+	}
+	return obj
+}
+
+func (w *WindowsOptions) prepare(errs []error) []error {
+	if w.ComputerName == "" {
+		errs = append(errs, fmt.Errorf("The `computer_name` is required"))
+	}
+	if w.Workgroup != "" {
+		if w.JoinDomain != "" {
+			errs = append(errs, fmt.Errorf("The `workgroup` and `join_domain` must not be set together"))
+		}
+	}
+	if w.JoinDomain != "" {
+		if w.DomainAdminUser == "" {
+			errs = append(errs, fmt.Errorf("The `domain_admin_user` is required when `join_domain` is specified"))
+		}
+		if w.DomainAdminPassword == "" {
+			errs = append(errs, fmt.Errorf("The `domain_admin_password` is required when `join_domain` is specified"))
+		}
+	}
+	if w.FullName == "" {
+		w.FullName = "Administrator"
+	}
+	if w.OrganizationName == "" {
+		w.OrganizationName = "Managed by Packer"
+	}
+	return errs
+}
+
+func (w *WindowsOptions) sysprep() *types.CustomizationSysprep {
+	obj := &types.CustomizationSysprep{
+		GuiUnattended:  w.guiUnattended(),
+		UserData:       w.userData(),
+		GuiRunOnce:     w.guiRunOnce(),
+		Identification: w.identification(),
+	}
+	return obj
+}
+
+func (w *WindowsOptions) guiRunOnce() *types.CustomizationGuiRunOnce {
+	obj := &types.CustomizationGuiRunOnce{
+		CommandList: *w.RunOnceCommandList,
+	}
+	if len(obj.CommandList) < 1 {
+		return nil
+	}
+	return obj
+}
+
+func boolValue(p *bool, fallback bool) bool {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+func intValue(p *int32, fallback int32) int32 {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+func stringValue(p *string, fallback string) string {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+func (w *WindowsOptions) guiUnattended() types.CustomizationGuiUnattended {
+	obj := types.CustomizationGuiUnattended{
+		TimeZone:       intValue(w.TimeZone, 85),
+		AutoLogon:      boolValue(w.AutoLogon, false),
+		AutoLogonCount: intValue(w.AutoLogonCount, 1),
+	}
+	if w.AdminPassword != nil {
+		obj.Password = &types.CustomizationPassword{
+			Value:     *w.AdminPassword,
+			PlainText: true,
+		}
+	}
+	return obj
+}
+
+func (w *WindowsOptions) identification() types.CustomizationIdentification {
+	obj := types.CustomizationIdentification{
+		JoinWorkgroup: w.Workgroup,
+		JoinDomain:    w.JoinDomain,
+		DomainAdmin:   w.DomainAdminUser,
+	}
+	if w.AdminPassword != nil {
+		obj.DomainAdminPassword = &types.CustomizationPassword{
+			Value:     *w.AdminPassword,
+			PlainText: true,
+		}
+	}
+	return obj
+}
+
+func (w *WindowsOptions) userData() types.CustomizationUserData {
+	obj := types.CustomizationUserData{
+		FullName: w.FullName,
+		OrgName:  w.OrganizationName,
+		ComputerName: &types.CustomizationFixedName{
+			Name: w.ComputerName,
+		},
+		ProductId: w.ProductKey,
+	}
+	return obj
 }
 
 func (s *StepCustomize) Cleanup(_ multistep.StateBag) {}

--- a/builder/vsphere/clone/step_customize.hcl2spec.go
+++ b/builder/vsphere/clone/step_customize.hcl2spec.go
@@ -10,16 +10,15 @@ import (
 // FlatCustomizeConfig is an auto-generated flat version of CustomizeConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatCustomizeConfig struct {
-	CustomizationSpecName *string                `mapstructure:"customization_spec_name" cty:"customization_spec_name" hcl:"customization_spec_name"`
-	LinuxOptions          *FlatLinuxOptions      `mapstructure:"linux_options" cty:"linux_options" hcl:"linux_options"`
-	WindowsOptions        *FlatWindowsOptions    `mapstructure:"windows_options" cty:"windows_options" hcl:"windows_options"`
-	WindowsSysPrepFile    *string                `mapstructure:"windows_sysprep_file" cty:"windows_sysprep_file" hcl:"windows_sysprep_file"`
-	WindowsSysPrepText    *string                `mapstructure:"windows_sysprep_text" cty:"windows_sysprep_text" hcl:"windows_sysprep_text"`
-	NetworkInterfaces     []FlatNetworkInterface `mapstructure:"network_interface" cty:"network_interface" hcl:"network_interface"`
-	Ipv4Gateway           *string                `mapstructure:"ipv4_gateway" cty:"ipv4_gateway" hcl:"ipv4_gateway"`
-	Ipv6Gateway           *string                `mapstructure:"ipv6_gateway" cty:"ipv6_gateway" hcl:"ipv6_gateway"`
-	DnsServerList         []string               `mapstructure:"dns_server_list" cty:"dns_server_list" hcl:"dns_server_list"`
-	DnsSuffixList         []string               `mapstructure:"dns_suffix_list" cty:"dns_suffix_list" hcl:"dns_suffix_list"`
+	LinuxOptions       *FlatLinuxOptions      `mapstructure:"linux_options" cty:"linux_options" hcl:"linux_options"`
+	WindowsOptions     *FlatWindowsOptions    `mapstructure:"windows_options" cty:"windows_options" hcl:"windows_options"`
+	WindowsSysPrepFile *string                `mapstructure:"windows_sysprep_file" cty:"windows_sysprep_file" hcl:"windows_sysprep_file"`
+	WindowsSysPrepText *string                `mapstructure:"windows_sysprep_text" cty:"windows_sysprep_text" hcl:"windows_sysprep_text"`
+	NetworkInterfaces  []FlatNetworkInterface `mapstructure:"network_interface" cty:"network_interface" hcl:"network_interface"`
+	Ipv4Gateway        *string                `mapstructure:"ipv4_gateway" cty:"ipv4_gateway" hcl:"ipv4_gateway"`
+	Ipv6Gateway        *string                `mapstructure:"ipv6_gateway" cty:"ipv6_gateway" hcl:"ipv6_gateway"`
+	DnsServerList      []string               `mapstructure:"dns_server_list" cty:"dns_server_list" hcl:"dns_server_list"`
+	DnsSuffixList      []string               `mapstructure:"dns_suffix_list" cty:"dns_suffix_list" hcl:"dns_suffix_list"`
 }
 
 // FlatMapstructure returns a new FlatCustomizeConfig.
@@ -34,16 +33,15 @@ func (*CustomizeConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcld
 // The decoded values from this spec will then be applied to a FlatCustomizeConfig.
 func (*FlatCustomizeConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"customization_spec_name": &hcldec.AttrSpec{Name: "customization_spec_name", Type: cty.String, Required: false},
-		"linux_options":           &hcldec.BlockSpec{TypeName: "linux_options", Nested: hcldec.ObjectSpec((*FlatLinuxOptions)(nil).HCL2Spec())},
-		"windows_options":         &hcldec.BlockSpec{TypeName: "windows_options", Nested: hcldec.ObjectSpec((*FlatWindowsOptions)(nil).HCL2Spec())},
-		"windows_sysprep_file":    &hcldec.AttrSpec{Name: "windows_sysprep_file", Type: cty.String, Required: false},
-		"windows_sysprep_text":    &hcldec.AttrSpec{Name: "windows_sysprep_text", Type: cty.String, Required: false},
-		"network_interface":       &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
-		"ipv4_gateway":            &hcldec.AttrSpec{Name: "ipv4_gateway", Type: cty.String, Required: false},
-		"ipv6_gateway":            &hcldec.AttrSpec{Name: "ipv6_gateway", Type: cty.String, Required: false},
-		"dns_server_list":         &hcldec.AttrSpec{Name: "dns_server_list", Type: cty.List(cty.String), Required: false},
-		"dns_suffix_list":         &hcldec.AttrSpec{Name: "dns_suffix_list", Type: cty.List(cty.String), Required: false},
+		"linux_options":        &hcldec.BlockSpec{TypeName: "linux_options", Nested: hcldec.ObjectSpec((*FlatLinuxOptions)(nil).HCL2Spec())},
+		"windows_options":      &hcldec.BlockSpec{TypeName: "windows_options", Nested: hcldec.ObjectSpec((*FlatWindowsOptions)(nil).HCL2Spec())},
+		"windows_sysprep_file": &hcldec.AttrSpec{Name: "windows_sysprep_file", Type: cty.String, Required: false},
+		"windows_sysprep_text": &hcldec.AttrSpec{Name: "windows_sysprep_text", Type: cty.String, Required: false},
+		"network_interface":    &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
+		"ipv4_gateway":         &hcldec.AttrSpec{Name: "ipv4_gateway", Type: cty.String, Required: false},
+		"ipv6_gateway":         &hcldec.AttrSpec{Name: "ipv6_gateway", Type: cty.String, Required: false},
+		"dns_server_list":      &hcldec.AttrSpec{Name: "dns_server_list", Type: cty.List(cty.String), Required: false},
+		"dns_suffix_list":      &hcldec.AttrSpec{Name: "dns_suffix_list", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/clone/step_customize.hcl2spec.go
+++ b/builder/vsphere/clone/step_customize.hcl2spec.go
@@ -10,13 +10,16 @@ import (
 // FlatCustomizeConfig is an auto-generated flat version of CustomizeConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatCustomizeConfig struct {
-	LinuxOptions       *FlatLinuxOptions      `mapstructure:"linux_options" cty:"linux_options" hcl:"linux_options"`
-	WindowsSysPrepFile *string                `mapstructure:"windows_sysprep_file" cty:"windows_sysprep_file" hcl:"windows_sysprep_file"`
-	NetworkInterfaces  []FlatNetworkInterface `mapstructure:"network_interface" cty:"network_interface" hcl:"network_interface"`
-	Ipv4Gateway        *string                `mapstructure:"ipv4_gateway" cty:"ipv4_gateway" hcl:"ipv4_gateway"`
-	Ipv6Gateway        *string                `mapstructure:"ipv6_gateway" cty:"ipv6_gateway" hcl:"ipv6_gateway"`
-	DnsServerList      []string               `mapstructure:"dns_server_list" cty:"dns_server_list" hcl:"dns_server_list"`
-	DnsSuffixList      []string               `mapstructure:"dns_suffix_list" cty:"dns_suffix_list" hcl:"dns_suffix_list"`
+	CustomizationSpecName *string                `mapstructure:"customization_spec_name" cty:"customization_spec_name" hcl:"customization_spec_name"`
+	LinuxOptions          *FlatLinuxOptions      `mapstructure:"linux_options" cty:"linux_options" hcl:"linux_options"`
+	WindowsOptions        *FlatWindowsOptions    `mapstructure:"windows_options" cty:"windows_options" hcl:"windows_options"`
+	WindowsSysPrepFile    *string                `mapstructure:"windows_sysprep_file" cty:"windows_sysprep_file" hcl:"windows_sysprep_file"`
+	WindowsSysPrepText    *string                `mapstructure:"windows_sysprep_text" cty:"windows_sysprep_text" hcl:"windows_sysprep_text"`
+	NetworkInterfaces     []FlatNetworkInterface `mapstructure:"network_interface" cty:"network_interface" hcl:"network_interface"`
+	Ipv4Gateway           *string                `mapstructure:"ipv4_gateway" cty:"ipv4_gateway" hcl:"ipv4_gateway"`
+	Ipv6Gateway           *string                `mapstructure:"ipv6_gateway" cty:"ipv6_gateway" hcl:"ipv6_gateway"`
+	DnsServerList         []string               `mapstructure:"dns_server_list" cty:"dns_server_list" hcl:"dns_server_list"`
+	DnsSuffixList         []string               `mapstructure:"dns_suffix_list" cty:"dns_suffix_list" hcl:"dns_suffix_list"`
 }
 
 // FlatMapstructure returns a new FlatCustomizeConfig.
@@ -31,13 +34,16 @@ func (*CustomizeConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcld
 // The decoded values from this spec will then be applied to a FlatCustomizeConfig.
 func (*FlatCustomizeConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"linux_options":        &hcldec.BlockSpec{TypeName: "linux_options", Nested: hcldec.ObjectSpec((*FlatLinuxOptions)(nil).HCL2Spec())},
-		"windows_sysprep_file": &hcldec.AttrSpec{Name: "windows_sysprep_file", Type: cty.String, Required: false},
-		"network_interface":    &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
-		"ipv4_gateway":         &hcldec.AttrSpec{Name: "ipv4_gateway", Type: cty.String, Required: false},
-		"ipv6_gateway":         &hcldec.AttrSpec{Name: "ipv6_gateway", Type: cty.String, Required: false},
-		"dns_server_list":      &hcldec.AttrSpec{Name: "dns_server_list", Type: cty.List(cty.String), Required: false},
-		"dns_suffix_list":      &hcldec.AttrSpec{Name: "dns_suffix_list", Type: cty.List(cty.String), Required: false},
+		"customization_spec_name": &hcldec.AttrSpec{Name: "customization_spec_name", Type: cty.String, Required: false},
+		"linux_options":           &hcldec.BlockSpec{TypeName: "linux_options", Nested: hcldec.ObjectSpec((*FlatLinuxOptions)(nil).HCL2Spec())},
+		"windows_options":         &hcldec.BlockSpec{TypeName: "windows_options", Nested: hcldec.ObjectSpec((*FlatWindowsOptions)(nil).HCL2Spec())},
+		"windows_sysprep_file":    &hcldec.AttrSpec{Name: "windows_sysprep_file", Type: cty.String, Required: false},
+		"windows_sysprep_text":    &hcldec.AttrSpec{Name: "windows_sysprep_text", Type: cty.String, Required: false},
+		"network_interface":       &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
+		"ipv4_gateway":            &hcldec.AttrSpec{Name: "ipv4_gateway", Type: cty.String, Required: false},
+		"ipv6_gateway":            &hcldec.AttrSpec{Name: "ipv6_gateway", Type: cty.String, Required: false},
+		"dns_server_list":         &hcldec.AttrSpec{Name: "dns_server_list", Type: cty.List(cty.String), Required: false},
+		"dns_suffix_list":         &hcldec.AttrSpec{Name: "dns_suffix_list", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }
@@ -150,6 +156,53 @@ func (*FlatNetworkInterface) HCL2Spec() map[string]hcldec.Spec {
 		"ipv4_netmask":    &hcldec.AttrSpec{Name: "ipv4_netmask", Type: cty.Number, Required: false},
 		"ipv6_address":    &hcldec.AttrSpec{Name: "ipv6_address", Type: cty.String, Required: false},
 		"ipv6_netmask":    &hcldec.AttrSpec{Name: "ipv6_netmask", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatWindowsOptions is an auto-generated flat version of WindowsOptions.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatWindowsOptions struct {
+	RunOnceCommandList  []string `mapstructure:"run_once_command_list" cty:"run_once_command_list" hcl:"run_once_command_list"`
+	AutoLogon           *bool    `mapstructure:"auto_logon" cty:"auto_logon" hcl:"auto_logon"`
+	AutoLogonCount      *int32   `mapstructure:"auto_logon_count" cty:"auto_logon_count" hcl:"auto_logon_count"`
+	AdminPassword       *string  `mapstructure:"admin_password" cty:"admin_password" hcl:"admin_password"`
+	TimeZone            *int32   `mapstructure:"time_zone" cty:"time_zone" hcl:"time_zone"`
+	DomainAdminUser     *string  `mapstructure:"domain_admin_user" cty:"domain_admin_user" hcl:"domain_admin_user"`
+	DomainAdminPassword *string  `mapstructure:"domain_admin_password" cty:"domain_admin_password" hcl:"domain_admin_password"`
+	JoinDomain          *string  `mapstructure:"join_domain" cty:"join_domain" hcl:"join_domain"`
+	Workgroup           *string  `mapstructure:"workgroup" cty:"workgroup" hcl:"workgroup"`
+	ComputerName        *string  `mapstructure:"computer_name" cty:"computer_name" hcl:"computer_name"`
+	FullName            *string  `mapstructure:"full_name" cty:"full_name" hcl:"full_name"`
+	OrganizationName    *string  `mapstructure:"organization_name" cty:"organization_name" hcl:"organization_name"`
+	ProductKey          *string  `mapstructure:"product_key" cty:"product_key" hcl:"product_key"`
+}
+
+// FlatMapstructure returns a new FlatWindowsOptions.
+// FlatWindowsOptions is an auto-generated flat version of WindowsOptions.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*WindowsOptions) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatWindowsOptions)
+}
+
+// HCL2Spec returns the hcl spec of a WindowsOptions.
+// This spec is used by HCL to read the fields of WindowsOptions.
+// The decoded values from this spec will then be applied to a FlatWindowsOptions.
+func (*FlatWindowsOptions) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"run_once_command_list": &hcldec.AttrSpec{Name: "run_once_command_list", Type: cty.List(cty.String), Required: false},
+		"auto_logon":            &hcldec.AttrSpec{Name: "auto_logon", Type: cty.Bool, Required: false},
+		"auto_logon_count":      &hcldec.AttrSpec{Name: "auto_logon_count", Type: cty.Number, Required: false},
+		"admin_password":        &hcldec.AttrSpec{Name: "admin_password", Type: cty.String, Required: false},
+		"time_zone":             &hcldec.AttrSpec{Name: "time_zone", Type: cty.Number, Required: false},
+		"domain_admin_user":     &hcldec.AttrSpec{Name: "domain_admin_user", Type: cty.String, Required: false},
+		"domain_admin_password": &hcldec.AttrSpec{Name: "domain_admin_password", Type: cty.String, Required: false},
+		"join_domain":           &hcldec.AttrSpec{Name: "join_domain", Type: cty.String, Required: false},
+		"workgroup":             &hcldec.AttrSpec{Name: "workgroup", Type: cty.String, Required: false},
+		"computer_name":         &hcldec.AttrSpec{Name: "computer_name", Type: cty.String, Required: false},
+		"full_name":             &hcldec.AttrSpec{Name: "full_name", Type: cty.String, Required: false},
+		"organization_name":     &hcldec.AttrSpec{Name: "organization_name", Type: cty.String, Required: false},
+		"product_key":           &hcldec.AttrSpec{Name: "product_key", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -63,6 +63,8 @@ type ContentLibraryDestinationConfig struct {
 	Ovf bool `mapstructure:"ovf"`
 	// When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
 	SkipImport bool `mapstructure:"skip_import"`
+	// Flags to use for OVF package creation. The supported flags can be obtained using ExportFlag.list. If unset, no flags will be used. Known values: EXTRA_CONFIG, PRESERVE_MAC
+	OvfFlags []string `mapstructure:"ovf_flags"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -171,6 +173,7 @@ func (s *StepImportToContentLibrary) importOvfTemplate(vm *driver.VirtualMachine
 		Spec: vcenter.CreateSpec{
 			Name:        s.ContentLibConfig.Name,
 			Description: s.ContentLibConfig.Description,
+			Flags:       s.ContentLibConfig.OvfFlags,
 		},
 		Target: vcenter.LibraryTarget{
 			LibraryID: s.ContentLibConfig.Library,

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -40,7 +40,6 @@ type ContentLibraryDestinationConfig struct {
 	// Defaults to [cluster](#cluster).
 	Cluster string `mapstructure:"cluster"`
 	// Virtual machine folder into which the virtual machine template should be placed.
-	// This option is not used when importing OVF templates.
 	// Defaults to the same folder as the source virtual machine.
 	Folder string `mapstructure:"folder"`
 	// Host onto which the virtual machine template should be placed.

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -10,17 +10,18 @@ import (
 // FlatContentLibraryDestinationConfig is an auto-generated flat version of ContentLibraryDestinationConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatContentLibraryDestinationConfig struct {
-	Library      *string `mapstructure:"library" cty:"library" hcl:"library"`
-	Name         *string `mapstructure:"name" cty:"name" hcl:"name"`
-	Description  *string `mapstructure:"description" cty:"description" hcl:"description"`
-	Cluster      *string `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
-	Folder       *string `mapstructure:"folder" cty:"folder" hcl:"folder"`
-	Host         *string `mapstructure:"host" cty:"host" hcl:"host"`
-	ResourcePool *string `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
-	Datastore    *string `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
-	Destroy      *bool   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
-	Ovf          *bool   `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
-	SkipImport   *bool   `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
+	Library      *string  `mapstructure:"library" cty:"library" hcl:"library"`
+	Name         *string  `mapstructure:"name" cty:"name" hcl:"name"`
+	Description  *string  `mapstructure:"description" cty:"description" hcl:"description"`
+	Cluster      *string  `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
+	Folder       *string  `mapstructure:"folder" cty:"folder" hcl:"folder"`
+	Host         *string  `mapstructure:"host" cty:"host" hcl:"host"`
+	ResourcePool *string  `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
+	Datastore    *string  `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
+	Destroy      *bool    `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	Ovf          *bool    `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
+	SkipImport   *bool    `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
+	OvfFlags     []string `mapstructure:"ovf_flags" cty:"ovf_flags" hcl:"ovf_flags"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -46,6 +47,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"destroy":       &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 		"ovf":           &hcldec.AttrSpec{Name: "ovf", Type: cty.Bool, Required: false},
 		"skip_import":   &hcldec.AttrSpec{Name: "skip_import", Type: cty.Bool, Required: false},
+		"ovf_flags":     &hcldec.AttrSpec{Name: "ovf_flags", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_shutdown.go
+++ b/builder/vsphere/common/step_shutdown.go
@@ -32,12 +32,26 @@ type ShutdownConfig struct {
 	// Packer will wait for a default of five minutes until the virtual machine is shutdown.
 	// The timeout can be changed using `shutdown_timeout` option.
 	DisableShutdown bool `mapstructure:"disable_shutdown"`
+	// Wait duration between polling if the VM is shutdown. Defaults to 10 seconds wait between each IsVMDown() call
+	PollingInterval time.Duration `mapstructure:"shutdown_polling_interval"`
+	// Time to wait before packer checks if the VM is off and send the shutdown command. Defaults to 0
+	PauseBeforeShutdown time.Duration `mapstructure:"pause_before_shutdown"`
 }
 
 func (c *ShutdownConfig) Prepare(comm communicator.Config) (warnings []string, errs []error) {
 
 	if c.Timeout == 0 {
 		c.Timeout = 5 * time.Minute
+	}
+
+	if c.PollingInterval > c.Timeout {
+		errs = append(errs, fmt.Errorf("The shutdown_interval=%s must be lesser than the shutdown_timeout=%s",
+			c.PollingInterval, c.Timeout))
+	} else if c.PollingInterval == 0 {
+		c.PollingInterval = 10 * time.Second
+		if c.PollingInterval > c.Timeout {
+			c.PollingInterval = 1 * time.Second
+		}
 	}
 
 	if comm.Type == "none" && c.Command != "" {
@@ -55,20 +69,32 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachineDriver)
 
+	if s.Config.PauseBeforeShutdown > 0 {
+		ui.Say(fmt.Sprintf("Waiting %s before checking if the VM is down", s.Config.PauseBeforeShutdown))
+		time.Sleep(s.Config.PauseBeforeShutdown)
+	}
 	if off, _ := vm.IsPoweredOff(); off {
-		// Probably power off initiated by last provisioner, though disable_shutdown is not set
-		ui.Say("VM is already powered off")
+		if s.Config.DisableShutdown {
+			ui.Say("VM is already powered off")
+		} else {
+			ui.Say("VM is already powered off though disable_shutdown is not true. Moving on")
+		}
 		return multistep.ActionContinue
 	}
 
 	comm, _ := state.Get("communicator").(packersdk.Communicator)
-	if comm == nil {
-
-		msg := fmt.Sprintf("Please shutdown virtual machine within %s.", s.Config.Timeout)
+	if s.Config.DisableShutdown {
+		msg := fmt.Sprintf("Automatic shutdown from vSphere is disabled. Please shutdown virtual machine within %s.",
+			s.Config.Timeout)
+		ui.Say(msg)
+	} else if comm == nil {
+		var msg string
+		if s.Config.Command != "" {
+			ui.Message("The custom shutdown_command is ignored as the VM `communicator` is not available.")
+		}
+		msg = fmt.Sprintf("Automatic shutdown via vSphere is disabled. "+
+			"Please shutdown virtual machine within %s.", s.Config.Timeout)
 		ui.Message(msg)
-
-	} else if s.Config.DisableShutdown {
-		ui.Say("Automatic shutdown disabled. Please shutdown virtual machine.")
 	} else if s.Config.Command != "" {
 		// Communicator is not needed unless shutdown_command is populated
 
@@ -97,7 +123,7 @@ func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	}
 
 	log.Printf("Waiting max %s for shutdown to complete", s.Config.Timeout)
-	err := vm.WaitForShutdown(ctx, s.Config.Timeout)
+	err := vm.WaitForShutdown(ctx, s.Config.Timeout, time.Duration(s.Config.PollingInterval))
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt

--- a/builder/vsphere/common/step_shutdown.hcl2spec.go
+++ b/builder/vsphere/common/step_shutdown.hcl2spec.go
@@ -10,9 +10,11 @@ import (
 // FlatShutdownConfig is an auto-generated flat version of ShutdownConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatShutdownConfig struct {
-	Command         *string `mapstructure:"shutdown_command" cty:"shutdown_command" hcl:"shutdown_command"`
-	Timeout         *string `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
-	DisableShutdown *bool   `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
+	Command             *string `mapstructure:"shutdown_command" cty:"shutdown_command" hcl:"shutdown_command"`
+	Timeout             *string `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
+	DisableShutdown     *bool   `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
+	PollingInterval     *string `mapstructure:"shutdown_polling_interval" cty:"shutdown_polling_interval" hcl:"shutdown_polling_interval"`
+	PauseBeforeShutdown *string `mapstructure:"pause_before_shutdown" cty:"pause_before_shutdown" hcl:"pause_before_shutdown"`
 }
 
 // FlatMapstructure returns a new FlatShutdownConfig.
@@ -27,9 +29,11 @@ func (*ShutdownConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hclde
 // The decoded values from this spec will then be applied to a FlatShutdownConfig.
 func (*FlatShutdownConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"shutdown_command": &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
-		"shutdown_timeout": &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
-		"disable_shutdown": &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
+		"shutdown_command":          &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
+		"shutdown_timeout":          &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
+		"disable_shutdown":          &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
+		"shutdown_polling_interval": &hcldec.AttrSpec{Name: "shutdown_polling_interval", Type: cty.String, Required: false},
+		"pause_before_shutdown":     &hcldec.AttrSpec{Name: "pause_before_shutdown", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -87,7 +87,11 @@ func (s *StepWaitForIp) Run(ctx context.Context, state multistep.StateBag) multi
 	}()
 
 	go func() {
-		ui.Say("Waiting for IP...")
+		ipAddress := ""
+		if s.Config.WaitAddress != nil {
+			ipAddress = *s.Config.WaitAddress
+		}
+		ui.Say("Waiting for IP..." + ipAddress)
 		ip, err = doGetIp(vm, sub, s.Config)
 		waitDone <- true
 	}()

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -43,6 +43,7 @@ type Driver interface {
 	FindContentLibraryByName(name string) (*Library, error)
 	FindContentLibraryItem(libraryId string, name string) (*library.Item, error)
 	FindContentLibraryFileDatastorePath(isoPath string) (string, error)
+	UpdateContentLibraryItem(item *library.Item, name string, description string) error
 }
 
 type VCenterDriver struct {

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -51,7 +51,7 @@ func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (str
 	libraryFilePath := &LibraryFilePath{path: isoPath}
 	err = libraryFilePath.Validate()
 	if err != nil {
-		log.Printf("ISO path not identified as a Content Library path")
+		log.Printf("ISO path not identified as a Content Library path as it does not follow the pattern libraryName/itemName/itemFilename")
 		return isoPath, err
 	}
 	libraryName := libraryFilePath.GetLibraryName()
@@ -60,7 +60,7 @@ func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (str
 
 	lib, err := d.FindContentLibraryByName(libraryName)
 	if err != nil {
-		log.Printf("ISO path not identified as a Content Library path")
+		log.Printf("ISO path assumed to not be a Content Library path as no Content Library named '%s' can be found", libraryName)
 		return isoPath, err
 	}
 	log.Printf("ISO path identified as a Content Library path")

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -51,6 +51,16 @@ func (d *VCenterDriver) FindContentLibraryItem(libraryId string, name string) (*
 	return nil, fmt.Errorf("Item %s not found - known items: %s", name, strings.Join(allNames, ", "))
 }
 
+func (d *VCenterDriver) UpdateContentLibraryItem(item *library.Item, name string, description string) error {
+	lm := library.NewManager(d.restClient.client)
+	item.Patch(&library.Item{
+		ID:          item.ID,
+		Name:        name,
+		Description: description,
+	})
+	return lm.UpdateLibraryItem(d.ctx, item)
+}
+
 func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (string, error) {
 	log.Printf("Check if ISO path is a Content Library path")
 	err := d.restClient.Login(d.ctx)

--- a/builder/vsphere/driver/vm_clone_acc_test.go
+++ b/builder/vsphere/driver/vm_clone_acc_test.go
@@ -247,9 +247,9 @@ func startAndStopCheck(t *testing.T, vm VirtualMachine, config *CloneConfig) {
 		t.Fatalf("Failed to initiate guest shutdown: %v", err)
 	}
 	log.Printf("[DEBUG] Waiting max 1m0s for shutdown to complete")
-	err = vm.WaitForShutdown(context.TODO(), 1*time.Minute)
+	err = vm.WaitForShutdown(context.TODO(), 1*time.Minute, 20*time.Second)
 	if err != nil {
-		t.Fatalf("Failed to wait for giest shutdown: %v", err)
+		t.Fatalf("Failed to wait for guest shutdown: %v", err)
 	}
 }
 

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -140,7 +140,7 @@ func (vm *VirtualMachineMock) StartShutdown() error {
 	return nil
 }
 
-func (vm *VirtualMachineMock) WaitForShutdown(ctx context.Context, timeout time.Duration) error {
+func (vm *VirtualMachineMock) WaitForShutdown(ctx context.Context, timeout time.Duration, pollingInterval time.Duration) error {
 	return nil
 }
 

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -249,3 +249,7 @@ func (vm *VirtualMachineMock) EjectCdroms() error {
 func (vm *VirtualMachineMock) Datacenter() *object.Datacenter {
 	return nil
 }
+
+func (vm *VirtualMachineMock) FindCustomizationSpec(name string) (*types.CustomizationSpec, error) {
+	return nil, nil
+}

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -138,6 +138,8 @@ type FlatConfig struct {
 	Command                         *string                                     `mapstructure:"shutdown_command" cty:"shutdown_command" hcl:"shutdown_command"`
 	Timeout                         *string                                     `mapstructure:"shutdown_timeout" cty:"shutdown_timeout" hcl:"shutdown_timeout"`
 	DisableShutdown                 *bool                                       `mapstructure:"disable_shutdown" cty:"disable_shutdown" hcl:"disable_shutdown"`
+	PollingInterval                 *string                                     `mapstructure:"shutdown_polling_interval" cty:"shutdown_polling_interval" hcl:"shutdown_polling_interval"`
+	PauseBeforeShutdown             *string                                     `mapstructure:"pause_before_shutdown" cty:"pause_before_shutdown" hcl:"pause_before_shutdown"`
 	CreateSnapshot                  *bool                                       `mapstructure:"create_snapshot" cty:"create_snapshot" hcl:"create_snapshot"`
 	SnapshotName                    *string                                     `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
 	ConvertToTemplate               *bool                                       `mapstructure:"convert_to_template" cty:"convert_to_template" hcl:"convert_to_template"`
@@ -284,6 +286,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shutdown_command":               &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
 		"shutdown_timeout":               &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"disable_shutdown":               &hcldec.AttrSpec{Name: "disable_shutdown", Type: cty.Bool, Required: false},
+		"shutdown_polling_interval":      &hcldec.AttrSpec{Name: "shutdown_polling_interval", Type: cty.String, Required: false},
+		"pause_before_shutdown":          &hcldec.AttrSpec{Name: "pause_before_shutdown", Type: cty.String, Required: false},
 		"create_snapshot":                &hcldec.AttrSpec{Name: "create_snapshot", Type: cty.Bool, Required: false},
 		"snapshot_name":                  &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},
 		"convert_to_template":            &hcldec.AttrSpec{Name: "convert_to_template", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CloneConfig struct in builder\vsphere\clone\step_clone.go; DO NOT EDIT MANUALLY -->
 
 - `template` (string) - Name of source VM. Path is optional.
 
@@ -19,4 +19,4 @@
   See the [vApp Options Configuration](/docs/builders/vmware/vsphere-clone#vapp-options-configuration)
   to know the available options and how to use it.
 
-<!-- End of code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; -->
+<!-- End of code generated from the comments of the CloneConfig struct in builder\vsphere\clone\step_clone.go; -->

--- a/docs-partials/builder/vsphere/clone/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/Config-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the Config struct in builder/vsphere/clone/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in builder\vsphere\clone\config.go; DO NOT EDIT MANUALLY -->
 
 - `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
   for linked clones. Defaults to `false`.
@@ -17,4 +17,4 @@
 
 - `customize` (\*CustomizeConfig) - Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).
 
-<!-- End of code generated from the comments of the Config struct in builder/vsphere/clone/config.go; -->
+<!-- End of code generated from the comments of the Config struct in builder\vsphere\clone\config.go; -->

--- a/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
@@ -1,7 +1,5 @@
 <!-- Code generated from the comments of the CustomizeConfig struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
-- `customization_spec_name` (string) - Use a customization profile already defined on the vCenter
-
 - `linux_options` (\*LinuxOptions) - Settings to Linux guest OS customization. See [Linux customization settings](#linux-customization-settings).
 
 - `windows_options` (\*WindowsOptions) - Settings to Linux guest OS customization.

--- a/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
@@ -1,11 +1,17 @@
-<!-- Code generated from the comments of the CustomizeConfig struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CustomizeConfig struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `customization_spec_name` (string) - Use a customization profile already defined on the vCenter
 
 - `linux_options` (\*LinuxOptions) - Settings to Linux guest OS customization. See [Linux customization settings](#linux-customization-settings).
 
+- `windows_options` (\*WindowsOptions) - Settings to Linux guest OS customization.
+
 - `windows_sysprep_file` (string) - Supply your own sysprep.xml file to allow full control of the customization process out-of-band of vSphere.
+
+- `windows_sysprep_text` (string) - Supply your own sysprep.xml text to allow full control of the customization process out-of-band of vSphere.
 
 - `network_interface` (NetworkInterfaces) - Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
   To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.
   See [Network interface settings](#network-interface-settings).
 
-<!-- End of code generated from the comments of the CustomizeConfig struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the CustomizeConfig struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/CustomizeConfig.mdx
+++ b/docs-partials/builder/vsphere/clone/CustomizeConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the CustomizeConfig struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CustomizeConfig struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 A cloned virtual machine can be [customized](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-58E346FF-83AE-42B8-BE58-253641D257BC.html)
 to configure host, network, or licensing settings.
@@ -11,4 +11,4 @@ See the [customization example](#customization-example) for a usage synopsis.
 
 The settings for customize are as follows:
 
-<!-- End of code generated from the comments of the CustomizeConfig struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the CustomizeConfig struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/GlobalDnsSettings-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/GlobalDnsSettings-not-required.mdx
@@ -1,7 +1,7 @@
-<!-- Code generated from the comments of the GlobalDnsSettings struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the GlobalDnsSettings struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 - `dns_server_list` ([]string) - The list of DNS servers to configure on a virtual machine.
 
 - `dns_suffix_list` ([]string) - A list of DNS search domains to add to the DNS configuration on the virtual machine.
 
-<!-- End of code generated from the comments of the GlobalDnsSettings struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the GlobalDnsSettings struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/GlobalDnsSettings.mdx
+++ b/docs-partials/builder/vsphere/clone/GlobalDnsSettings.mdx
@@ -1,6 +1,6 @@
-<!-- Code generated from the comments of the GlobalDnsSettings struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the GlobalDnsSettings struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 The following settings configure DNS globally, generally for Linux systems. For Windows systems,
 this is done per-interface, see [network interface](#network_interface) settings.
 
-<!-- End of code generated from the comments of the GlobalDnsSettings struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the GlobalDnsSettings struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/GlobalRoutingSettings-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/GlobalRoutingSettings-not-required.mdx
@@ -1,7 +1,7 @@
-<!-- Code generated from the comments of the GlobalRoutingSettings struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the GlobalRoutingSettings struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 - `ipv4_gateway` (string) - The IPv4 default gateway when using network_interface customization on the virtual machine.
 
 - `ipv6_gateway` (string) - The IPv6 default gateway when using network_interface customization on the virtual machine.
 
-<!-- End of code generated from the comments of the GlobalRoutingSettings struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the GlobalRoutingSettings struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/GlobalRoutingSettings.mdx
+++ b/docs-partials/builder/vsphere/clone/GlobalRoutingSettings.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the GlobalRoutingSettings struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the GlobalRoutingSettings struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 The settings here must match the IP/mask of at least one network_interface supplied to customization.
 
-<!-- End of code generated from the comments of the GlobalRoutingSettings struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the GlobalRoutingSettings struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/LinuxOptions-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/LinuxOptions-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the LinuxOptions struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the LinuxOptions struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 - `domain` (string) - The domain name for this machine. This, along with [host_name](#host_name), make up the FQDN of this virtual machine.
 
@@ -8,4 +8,4 @@
 
 - `time_zone` (string) - Sets the time zone. The default is UTC.
 
-<!-- End of code generated from the comments of the LinuxOptions struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the LinuxOptions struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/NetworkInterface-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/NetworkInterface-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the NetworkInterface struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the NetworkInterface struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
 
 - `dns_server_list` ([]string) - Network interface-specific DNS server settings for Windows operating systems.
   Ignored on Linux and possibly other operating systems - for those systems, please see the [global DNS settings](#global-dns-settings) section.
@@ -14,4 +14,4 @@
 
 - `ipv6_netmask` (int) - The IPv6 subnet mask, in bits (example: 32).
 
-<!-- End of code generated from the comments of the NetworkInterface struct in builder/vsphere/clone/step_customize.go; -->
+<!-- End of code generated from the comments of the NetworkInterface struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptions-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptions-not-required.mdx
@@ -1,0 +1,33 @@
+<!-- Code generated from the comments of the WindowsOptions struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `run_once_command_list` (\*[]string) - CustomizationGuiRunOnce
+  A list of commands to run at first user logon, after guest customization.
+
+- `auto_logon` (\*bool) - CustomizationGuiUnattended
+  Specifies whether or not the VM automatically logs on as Administrator.
+
+- `auto_logon_count` (\*int32) - Specifies how many times the VM should auto-logon the Administrator account when auto_logon is true. Default 1
+
+- `admin_password` (\*string) - The new administrator password for this virtual machine.
+
+- `time_zone` (\*int32) - The new time zone for the virtual machine. This is a sysprep-dictated timezone code. Default 85 (GMT)
+
+- `domain_admin_user` (string) - CustomizationIdentification
+  The user account of the domain administrator used to join this virtual machine to the domain.
+
+- `domain_admin_password` (string) - The password of the domain administrator used to join this virtual machine to the domain.
+
+- `join_domain` (string) - The domain that the virtual machine should join.
+
+- `workgroup` (string) - The workgroup for this virtual machine if not joining a domain.
+
+- `computer_name` (string) - CustomizationUserData
+  The host name for this virtual machine.
+
+- `full_name` (string) - The full name of the user of this virtual machine. Default: "Administrator"
+
+- `organization_name` (string) - The organization name this virtual machine is being installed for. Default: "Managed by Packer"
+
+- `product_key` (string) - The product key for this virtual machine.
+
+<!-- End of code generated from the comments of the WindowsOptions struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptionsGuiRunOnce-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptionsGuiRunOnce-not-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the WindowsOptionsGuiRunOnce struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `command_list` ([]string) - Command List
+
+<!-- End of code generated from the comments of the WindowsOptionsGuiRunOnce struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptionsGuiUnattended-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptionsGuiUnattended-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the WindowsOptionsGuiUnattended struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `password` (\*string) - Password
+
+- `auto_logon` (bool) - Auto Logon
+
+- `auto_logon_count` (int32) - Auto Logon Count
+
+- `time_zone` (int32) - Time Zone
+
+<!-- End of code generated from the comments of the WindowsOptionsGuiUnattended struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptionsIdentification-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptionsIdentification-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the WindowsOptionsIdentification struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `join_work_group` (string) - Join Workgroup
+
+- `join_domain` (string) - Join Domain
+
+- `domain_admin` (string) - Domain Admin
+
+- `gui_unattended` (\*string) - Domain Admin Password
+
+<!-- End of code generated from the comments of the WindowsOptionsIdentification struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptionsLicenseFilePrintData-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptionsLicenseFilePrintData-not-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the WindowsOptionsLicenseFilePrintData struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `auto_mode` (types.CustomizationLicenseDataMode) - Auto Mode
+
+- `auto_users` (int32) - Auto Users
+
+<!-- End of code generated from the comments of the WindowsOptionsLicenseFilePrintData struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/WindowsOptionsUserData-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptionsUserData-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the WindowsOptionsUserData struct in builder\vsphere\clone\step_customize.go; DO NOT EDIT MANUALLY -->
+
+- `full_name` (string) - Full Name
+
+- `org_name` (string) - Org Name
+
+- `computer_name` (string) - Computer Name
+
+- `product_id` (string) - Product Id
+
+<!-- End of code generated from the comments of the WindowsOptionsUserData struct in builder\vsphere\clone\step_customize.go; -->

--- a/docs-partials/builder/vsphere/clone/vAppConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/vAppConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the vAppConfig struct in builder\vsphere\clone\step_clone.go; DO NOT EDIT MANUALLY -->
 
 - `properties` (map[string]string) - Set values for the available vApp Properties to supply configuration parameters to a virtual machine cloned from
   a template that came from an imported OVF or OVA file.
@@ -8,4 +8,4 @@
   You cannot set values for vApp properties on virtual machines created from scratch,
   virtual machines lacking a vApp configuration, or on property keys that do not exist.
 
-<!-- End of code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; -->
+<!-- End of code generated from the comments of the vAppConfig struct in builder\vsphere\clone\step_clone.go; -->

--- a/docs-partials/builder/vsphere/common/BootConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/BootConfig-not-required.mdx
@@ -1,6 +1,6 @@
-<!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the BootConfig struct in builder\vsphere\common\step_boot_command.go; DO NOT EDIT MANUALLY -->
 
 - `http_ip` (string) - The IP address to use for the HTTP server started to serve the `http_directory`.
   If unset, Packer will automatically discover and assign an IP.
 
-<!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->
+<!-- End of code generated from the comments of the BootConfig struct in builder\vsphere\common\step_boot_command.go; -->

--- a/docs-partials/builder/vsphere/common/CDRomConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/CDRomConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the CDRomConfig struct in builder/vsphere/common/step_add_cdrom.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CDRomConfig struct in builder\vsphere\common\step_add_cdrom.go; DO NOT EDIT MANUALLY -->
 
 - `cdrom_type` (string) - Which controller to use. Example: `sata`. Defaults to `ide`.
 
@@ -11,4 +11,4 @@
   ]
   ```
 
-<!-- End of code generated from the comments of the CDRomConfig struct in builder/vsphere/common/step_add_cdrom.go; -->
+<!-- End of code generated from the comments of the CDRomConfig struct in builder\vsphere\common\step_add_cdrom.go; -->

--- a/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ConfigParamsConfig struct in builder\vsphere\common\step_config_params.go; DO NOT EDIT MANUALLY -->
 
 - `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the vSphere API's
   ConfigSpec: https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.ConfigSpec.html
@@ -8,4 +8,4 @@
 - `tools_upgrade_policy` (bool) - If sets to true, vSphere will automatically check and upgrade VMware Tools upon a system power cycle.
   If not set, defaults to manual upgrade.
 
-<!-- End of code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; -->
+<!-- End of code generated from the comments of the ConfigParamsConfig struct in builder\vsphere\common\step_config_params.go; -->

--- a/docs-partials/builder/vsphere/common/ConnectConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ConnectConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ConnectConfig struct in builder/vsphere/common/step_connect.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ConnectConfig struct in builder\vsphere\common\step_connect.go; DO NOT EDIT MANUALLY -->
 
 - `vcenter_server` (string) - vCenter Server hostname.
 
@@ -10,4 +10,4 @@
 
 - `datacenter` (string) - vSphere datacenter name. Required if there is more than one datacenter in the vSphere inventory.
 
-<!-- End of code generated from the comments of the ConnectConfig struct in builder/vsphere/common/step_connect.go; -->
+<!-- End of code generated from the comments of the ConnectConfig struct in builder\vsphere\common\step_connect.go; -->

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
 - `library` (string) - Name of the library in which the new library item containing the template should be created/updated.
   The Content Library should be of type Local to allow deploying virtual machines.
@@ -47,4 +47,4 @@
 
 - `skip_import` (bool) - When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
-<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->
+<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; -->

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
 - `library` (string) - Name of the library in which the new library item containing the template should be created/updated.
   The Content Library should be of type Local to allow deploying virtual machines.
@@ -13,7 +13,6 @@
   item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
 - `description` (string) - Description of the library item that will be created.
-  This option is not used when importing OVF templates.
   Defaults to "Packer imported [vm_name](#vm_name) VM template".
 
 - `cluster` (string) - Cluster onto which the virtual machine template should be placed.
@@ -23,7 +22,6 @@
   Defaults to [cluster](#cluster).
 
 - `folder` (string) - Virtual machine folder into which the virtual machine template should be placed.
-  This option is not used when importing OVF templates.
   Defaults to the same folder as the source virtual machine.
 
 - `host` (string) - Host onto which the virtual machine template should be placed.
@@ -47,4 +45,6 @@
 
 - `skip_import` (bool) - When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
-<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; -->
+- `ovf_flags` ([]string) - Flags to use for OVF package creation. The supported flags can be obtained using ExportFlag.list. If unset, no flags will be used. Known values: EXTRA_CONFIG, PRESERVE_MAC
+
+<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
@@ -1,7 +1,7 @@
-<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
 With this configuration Packer creates a library item in a content library whose content is a VM template
 or an OVF template created from the just built VM.
 The template is stored in a existing or newly created library item.
 
-<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; -->
+<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig.mdx
@@ -1,7 +1,7 @@
-<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; DO NOT EDIT MANUALLY -->
 
 With this configuration Packer creates a library item in a content library whose content is a VM template
 or an OVF template created from the just built VM.
 The template is stored in a existing or newly created library item.
 
-<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->
+<!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder\vsphere\common\step_import_to_content_library.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; DO NOT EDIT MANUALLY -->
 
 - `disk_thin_provisioned` (bool) - Enable VMDK thin provisioning for VM. Defaults to `false`.
 
@@ -6,4 +6,4 @@
 
 - `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0)
 
-<!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
+<!-- End of code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-required.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; DO NOT EDIT MANUALLY -->
 
 - `disk_size` (int64) - The size of the disk in MB.
 
-<!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
+<!-- End of code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; DO NOT EDIT MANUALLY -->
 
 Defines the disk storage for a VM.
 
@@ -73,4 +73,4 @@ In HCL2:
   }
 ```
 
-<!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
+<!-- End of code generated from the comments of the DiskConfig struct in builder\vsphere\common\storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ExportConfig struct in builder\vsphere\common\step_export.go; DO NOT EDIT MANUALLY -->
 
 - `name` (string) - Name of the ovf. defaults to the name of the VM
 
@@ -33,4 +33,4 @@
     }
   ```
 
-<!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
+<!-- End of code generated from the comments of the ExportConfig struct in builder\vsphere\common\step_export.go; -->

--- a/docs-partials/builder/vsphere/common/ExportConfig.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ExportConfig struct in builder\vsphere\common\step_export.go; DO NOT EDIT MANUALLY -->
 
 You may optionally export an ovf from vSphere to the instance running Packer.
 
@@ -32,4 +32,4 @@ The above configuration would create the following files:
 ./output_vsphere/example-ubuntu.ovf
 ```
 
-<!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
+<!-- End of code generated from the comments of the ExportConfig struct in builder\vsphere\common\step_export.go; -->

--- a/docs-partials/builder/vsphere/common/FloppyConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/FloppyConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the FloppyConfig struct in builder/vsphere/common/step_add_floppy.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the FloppyConfig struct in builder\vsphere\common\step_add_floppy.go; DO NOT EDIT MANUALLY -->
 
 - `floppy_img_path` (string) - Datastore path to a floppy image that will be mounted to the VM.
   Example: `[datastore1] ISO/pvscsi-Windows8.flp`.
@@ -28,4 +28,4 @@
   Kickstart or other early initialization tools, which can benefit from labelled floppy disks.
   By default, the floppy label will be 'packer'.
 
-<!-- End of code generated from the comments of the FloppyConfig struct in builder/vsphere/common/step_add_floppy.go; -->
+<!-- End of code generated from the comments of the FloppyConfig struct in builder\vsphere\common\step_add_floppy.go; -->

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the HardwareConfig struct in builder\vsphere\common\step_hardware.go; DO NOT EDIT MANUALLY -->
 
 - `CPUs` (int32) - Number of CPU cores.
 
@@ -32,4 +32,4 @@
 
 - `vTPM` (bool) - Add virtual TPM device for virtual machine. Defaults to `false`.
 
-<!-- End of code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; -->
+<!-- End of code generated from the comments of the HardwareConfig struct in builder\vsphere\common\step_hardware.go; -->

--- a/docs-partials/builder/vsphere/common/LocationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/LocationConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the LocationConfig struct in builder/vsphere/common/config_location.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the LocationConfig struct in builder\vsphere\common\config_location.go; DO NOT EDIT MANUALLY -->
 
 - `vm_name` (string) - Name of the new VM to create.
 
@@ -23,4 +23,4 @@
 - `set_host_for_datastore_uploads` (bool) - Set this to true if packer should use the host for uploading files
   to the datastore. Defaults to false.
 
-<!-- End of code generated from the comments of the LocationConfig struct in builder/vsphere/common/config_location.go; -->
+<!-- End of code generated from the comments of the LocationConfig struct in builder\vsphere\common\config_location.go; -->

--- a/docs-partials/builder/vsphere/common/OutputConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/OutputConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the OutputConfig struct in builder/vsphere/common/output_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the OutputConfig struct in builder\vsphere\common\output_config.go; DO NOT EDIT MANUALLY -->
 
 - `output_directory` (string) - This setting specifies the directory that
   artifacts from the build, such as the virtual machine files and disks,
@@ -15,4 +15,4 @@
   octal value. In Unix-like OS, the actual permission may differ from
   this value because of umask.
 
-<!-- End of code generated from the comments of the OutputConfig struct in builder/vsphere/common/output_config.go; -->
+<!-- End of code generated from the comments of the OutputConfig struct in builder\vsphere\common\output_config.go; -->

--- a/docs-partials/builder/vsphere/common/RemoveCDRomConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/RemoveCDRomConfig-not-required.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the RemoveCDRomConfig struct in builder/vsphere/common/step_remove_cdrom.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the RemoveCDRomConfig struct in builder\vsphere\common\step_remove_cdrom.go; DO NOT EDIT MANUALLY -->
 
 - `remove_cdrom` (bool) - Remove CD-ROM devices from template. Defaults to `false`.
 
-<!-- End of code generated from the comments of the RemoveCDRomConfig struct in builder/vsphere/common/step_remove_cdrom.go; -->
+<!-- End of code generated from the comments of the RemoveCDRomConfig struct in builder\vsphere\common\step_remove_cdrom.go; -->

--- a/docs-partials/builder/vsphere/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/RunConfig-not-required.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the RunConfig struct in builder/vsphere/common/step_run.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the RunConfig struct in builder\vsphere\common\step_run.go; DO NOT EDIT MANUALLY -->
 
 - `boot_order` (string) - Priority of boot devices. Defaults to `disk,cdrom`
 
-<!-- End of code generated from the comments of the RunConfig struct in builder/vsphere/common/step_run.go; -->
+<!-- End of code generated from the comments of the RunConfig struct in builder\vsphere\common\step_run.go; -->

--- a/docs-partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ShutdownConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the ShutdownConfig struct in builder/vsphere/common/step_shutdown.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the ShutdownConfig struct in builder\vsphere\common\step_shutdown.go; DO NOT EDIT MANUALLY -->
 
 - `shutdown_command` (string) - Specify a VM guest shutdown command. This command will be executed using
   the `communicator`. Otherwise, the VMware Tools are used to gracefully shutdown
@@ -15,4 +15,8 @@
   Packer will wait for a default of five minutes until the virtual machine is shutdown.
   The timeout can be changed using `shutdown_timeout` option.
 
-<!-- End of code generated from the comments of the ShutdownConfig struct in builder/vsphere/common/step_shutdown.go; -->
+- `shutdown_polling_interval` (duration string | ex: "1h5m2s") - Wait duration between polling if the VM is shutdown. Defaults to 10 seconds wait between each IsVMDown() call
+
+- `pause_before_shutdown` (duration string | ex: "1h5m2s") - Time to wait before packer checks if the VM is off and send the shutdown command. Defaults to 0
+
+<!-- End of code generated from the comments of the ShutdownConfig struct in builder\vsphere\common\step_shutdown.go; -->

--- a/docs-partials/builder/vsphere/common/StorageConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/StorageConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the StorageConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the StorageConfig struct in builder\vsphere\common\storage_config.go; DO NOT EDIT MANUALLY -->
 
 - `disk_controller_type` ([]string) - Set VM disk controller type. Example `lsilogic`, `lsilogic-sas`, `pvscsi`, `nvme`, or `scsi`. Use a list to define additional controllers.
   Defaults to `lsilogic`. See
@@ -7,4 +7,4 @@
 
 - `storage` ([]DiskConfig) - Configures a collection of one or more disks to be provisioned along with the VM. See the [Storage Configuration](#storage-configuration).
 
-<!-- End of code generated from the comments of the StorageConfig struct in builder/vsphere/common/storage_config.go; -->
+<!-- End of code generated from the comments of the StorageConfig struct in builder\vsphere\common\storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the WaitIpConfig struct in builder\vsphere\common\step_wait_for_ip.go; DO NOT EDIT MANUALLY -->
 
 - `ip_wait_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'.
   Defaults to 30m (30 minutes). See the Golang
@@ -19,4 +19,4 @@
   * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
   * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
 
-<!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->
+<!-- End of code generated from the comments of the WaitIpConfig struct in builder\vsphere\common\step_wait_for_ip.go; -->

--- a/docs-partials/builder/vsphere/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/Config-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the Config struct in builder/vsphere/iso/config.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the Config struct in builder\vsphere\iso\config.go; DO NOT EDIT MANUALLY -->
 
 - `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
   for linked clones. Defaults to `false`.
@@ -15,4 +15,4 @@
   The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
   The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
 
-<!-- End of code generated from the comments of the Config struct in builder/vsphere/iso/config.go; -->
+<!-- End of code generated from the comments of the Config struct in builder\vsphere\iso\config.go; -->

--- a/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the CreateConfig struct in builder\vsphere\iso\step_create.go; DO NOT EDIT MANUALLY -->
 
 - `vm_version` (uint) - Set VM hardware version. Defaults to the most current VM hardware
   version supported by the vCenter Server version. See
@@ -15,4 +15,4 @@
 
 - `notes` (string) - VM notes.
 
-<!-- End of code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; -->
+<!-- End of code generated from the comments of the CreateConfig struct in builder\vsphere\iso\step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; DO NOT EDIT MANUALLY -->
 
 - `network` (string) - Set the network in which the VM will be connected to. If no network is
   specified, `host` must be specified to allow Packer to look for the
@@ -9,4 +9,4 @@
 
 - `passthrough` (\*bool) - Enable DirectPath I/O passthrough
 
-<!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->
+<!-- End of code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC-required.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC-required.mdx
@@ -1,5 +1,5 @@
-<!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; DO NOT EDIT MANUALLY -->
 
 - `network_card` (string) - Set VM network card type. Example `vmxnet3`.
 
-<!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->
+<!-- End of code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC.mdx
@@ -1,4 +1,4 @@
-<!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
+<!-- Code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; DO NOT EDIT MANUALLY -->
 
 Defines a Network Adapter
 
@@ -29,4 +29,4 @@ In HCL2:
   }
 ```
 
-<!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->
+<!-- End of code generated from the comments of the NIC struct in builder\vsphere\iso\step_create.go; -->

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/hashicorp/packer-plugin-sdk v0.2.12
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/govmomi v0.27.4
+	github.com/vmware/govmomi v0.28.0
 	github.com/zclconf/go-cty v1.10.0
 	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.12.0
 	github.com/hashicorp/packer-plugin-sdk v0.2.12
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/govmomi v0.24.1
+	github.com/vmware/govmomi v0.27.4
 	github.com/zclconf/go-cty v1.10.0
 	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -266,6 +267,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -547,6 +549,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmware/govmomi v0.24.1 h1:ecVvrxF28/5g738gLTiYgc62fpGfIPRKheQ1Dj1p35w=
 github.com/vmware/govmomi v0.24.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=
+github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -547,10 +547,8 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/govmomi v0.24.1 h1:ecVvrxF28/5g738gLTiYgc62fpGfIPRKheQ1Dj1p35w=
-github.com/vmware/govmomi v0.24.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
-github.com/vmware/govmomi v0.27.4 h1:5kY8TAkhB20lsjzrjE073eRb8+HixBI29PVMG5lxq6I=
-github.com/vmware/govmomi v0.27.4/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
+github.com/vmware/govmomi v0.28.0 h1:VgeQ/Rvz79U9G8QIKLdgpsN9AndHJL+5iMJLgYIrBGI=
+github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Hi there, I needed a number of feature improvements to bake my windows templates with packer on the top of vsphere:
1- Port the customize `windows_options` of the vsphere terraform provider to packer: https://github.com/hashicorp/terraform-provider-vsphere/blob/773942213dd548ac5e864dc62816e97442cdda57/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go#L107
2- Supportthe `description` field when publishing ovf templates into a content library - requires an updated version of govmomi
3- Trivial logging improvements to the `iso_path` when searching content libraries

Is this interesting to the community?
I am opened to break this PR into multiple smaller ones and follow your guidance in general.
If my use cases are too far fetch for the mainstream plugin, let me know and I'll fork the plugin and document how I am setting it up for my bakes.