### PR TITLE
Add description of OVF content library item

### DIFF
--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -31,7 +31,6 @@ type ContentLibraryDestinationConfig struct {
 	//
 	Name string `mapstructure:"name"`
 	// Description of the library item that will be created.
-	// This option is not used when importing OVF templates.
 	// Defaults to "Packer imported [vm_name](#vm_name) VM template".
 	Description string `mapstructure:"description"`
 	// Cluster onto which the virtual machine template should be placed.
@@ -104,9 +103,9 @@ func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
 		if c.ResourcePool == "" {
 			c.ResourcePool = lc.ResourcePool
 		}
-		if c.Description == "" {
-			c.Description = fmt.Sprintf("Packer imported %s VM template", lc.VMName)
-		}
+	}
+	if c.Description == "" {
+		c.Description = fmt.Sprintf("Packer imported %s VM template", lc.VMName)
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {
@@ -137,11 +136,15 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 		return multistep.ActionHalt
 	}
 
+	vmTypeLabel := "VM"
 	if s.ContentLibConfig.Ovf {
-		ui.Say(fmt.Sprintf("Importing VM OVF template %s to Content Library...", s.ContentLibConfig.Name))
+		vmTypeLabel = "VM OVF"
+	}
+	ui.Say(fmt.Sprintf("Importing %s template %s to Content Library '%s' as the item '%s' with the description '%s'...",
+		vmTypeLabel, s.ContentLibConfig.Name, s.ContentLibConfig.Library, s.ContentLibConfig.Name, s.ContentLibConfig.Description))
+	if s.ContentLibConfig.Ovf {
 		err = s.importOvfTemplate(vm)
 	} else {
-		ui.Say(fmt.Sprintf("Importing VM template %s to Content Library...", s.ContentLibConfig.Name))
 		err = s.importVmTemplate(vm)
 	}
 
@@ -169,8 +172,9 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 func (s *StepImportToContentLibrary) importOvfTemplate(vm *driver.VirtualMachineDriver) error {
 	ovf := vcenter.OVF{
 		Spec: vcenter.CreateSpec{
-			Name:  s.ContentLibConfig.Name,
-			Flags: s.ContentLibConfig.OvfFlags,
+			Name:        s.ContentLibConfig.Name,
+			Description: s.ContentLibConfig.Description,
+			Flags:       s.ContentLibConfig.OvfFlags,
 		},
 		Target: vcenter.LibraryTarget{
 			LibraryID: s.ContentLibConfig.Library,

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -43,6 +43,7 @@ type Driver interface {
 	FindContentLibraryByName(name string) (*Library, error)
 	FindContentLibraryItem(libraryId string, name string) (*library.Item, error)
 	FindContentLibraryFileDatastorePath(isoPath string) (string, error)
+	UpdateContentLibraryItem(item *library.Item, name string, description string) error
 }
 
 type VCenterDriver struct {

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -117,3 +117,7 @@ func (d *DriverMock) FindContentLibraryItem(libraryId string, name string) (*lib
 func (d *DriverMock) FindContentLibraryFileDatastorePath(isoPath string) (string, error) {
 	return "", nil
 }
+
+func (d *DriverMock) UpdateContentLibraryItem(item *library.Item, name string, description string) error {
+	return nil
+}

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -87,6 +87,16 @@ func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (str
 	return path.Join(libItemDir, isoFilePath), nil
 }
 
+func (d *VCenterDriver) UpdateContentLibraryItem(item *library.Item, name string, description string) error {
+	lm := library.NewManager(d.restClient.client)
+	item.Patch(&library.Item{
+		ID:          item.ID,
+		Name:        name,
+		Description: description,
+	})
+	return lm.UpdateLibraryItem(d.ctx, item)
+}
+
 type LibraryFilePath struct {
 	path string
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -844,6 +844,12 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 	if err == nil {
 		// Updates existing library item
 		ovf.Target.LibraryItemID = item.ID
+		if ovf.Spec.Description != item.Description {
+			err = vm.driver.UpdateContentLibraryItem(item, ovf.Spec.Name, ovf.Spec.Description)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	ovf.Target.LibraryID = l.library.ID

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -23,7 +23,7 @@ func (vm *ReconfigureFail) ReconfigVMTask(req *types.ReconfigVM_Task) soap.HasFa
 
 	return &methods.ReconfigVM_TaskBody{
 		Res: &types.ReconfigVM_TaskResponse{
-			Returnval: task.Run(),
+			Returnval: task.Run(simulator.SpoofContext()),
 		},
 	}
 }

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -13,7 +13,6 @@
   item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
 - `description` (string) - Description of the library item that will be created.
-  This option is not used when importing OVF templates.
   Defaults to "Packer imported [vm_name](#vm_name) VM template".
 
 - `cluster` (string) - Cluster onto which the virtual machine template should be placed.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/packer-plugin-sdk v0.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware/govmomi v0.24.1
+	github.com/vmware/govmomi v0.26.1
 	github.com/zclconf/go-cty v1.10.0
 	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1
 )

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,7 @@ github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuN
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/a8m/tree v0.0.0-20210115125333-10a5fd5b637d/go.mod h1:FSdwKX97koS5efgm8WevNf7XS3PqtyFkKDDXrz778cg=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -262,8 +263,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
-github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -537,8 +538,8 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/govmomi v0.24.1 h1:ecVvrxF28/5g738gLTiYgc62fpGfIPRKheQ1Dj1p35w=
-github.com/vmware/govmomi v0.24.1/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
+github.com/vmware/govmomi v0.26.1 h1:awC7cFIT0SOCt3A6rbUCCEtFdt+X1L6Nppm0mkL7zQk=
+github.com/vmware/govmomi v0.26.1/go.mod h1:daTuJEcQosNMXYJOeku0qdBJP9SOLLWB3Mqz8THtv6o=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Closes #175

Enable setting the description field of an OVF template
published into a content library.

Requires updating govmomi to 0.27 where the UpdateLibraryItem
is supported.

