### PR TITLE
Added a link to term "linked clones"

### DIFF
--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -34,7 +34,7 @@ type Config struct {
 	common.ShutdownConfig    `mapstructure:",squash"`
 
 	// Create a snapshot when set to `true`, so the VM can be used as a base
-	// for linked clones. Defaults to `false`.
+	// for [linked clones](https://docs.vmware.com/en/vCenter-Converter-Standalone/6.2/com.vmware.convsa.guide/GUID-93894315-EFCA-4DD8-B583-FA24272DA180.html). Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
 	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
 	// Defaults to `Created By Packer`.

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -31,7 +31,7 @@ type CloneConfig struct {
 	Template string `mapstructure:"template"`
 	// The size of the disk in MB.
 	DiskSize int64 `mapstructure:"disk_size"`
-	// Create VM as a linked clone from latest snapshot. Defaults to `false`.
+	// Create VM as a [linked clone](https://docs.vmware.com/en/vCenter-Converter-Standalone/6.2/com.vmware.convsa.guide/GUID-93894315-EFCA-4DD8-B583-FA24272DA180.html) from latest snapshot. Defaults to `false`.
 	LinkedClone bool `mapstructure:"linked_clone"`
 	// Set the network in which the VM will be connected to. If no network is
 	// specified, `host` must be specified to allow Packer to look for the

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	common.ShutdownConfig `mapstructure:",squash"`
 
 	// Create a snapshot when set to `true`, so the VM can be used as a base
-	// for linked clones. Defaults to `false`.
+	// for [linked clones](https://docs.vmware.com/en/vCenter-Converter-Standalone/6.2/com.vmware.convsa.guide/GUID-93894315-EFCA-4DD8-B583-FA24272DA180.html). Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
 	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
 	// Defaults to `Created By Packer`.


### PR DESCRIPTION
For someone unfamiliar with the term _"linked clones"_ it would be helpful to have that term hyperlinked so they could quickly learn about it.

Not sure if the tools that generate docs from the `.mdx` format provides a way to define a link in one place and reference it multiple times so I made the change in three (3) places with the same link. If there is a cleaner way to do this I would be happy to clean it up.

