### PR TITLE
Add support for specifying flags when importing an OVF template into a content library

### DIFF
--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -65,6 +65,8 @@ type ContentLibraryDestinationConfig struct {
 	Ovf bool `mapstructure:"ovf"`
 	// When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
 	SkipImport bool `mapstructure:"skip_import"`
+	// Flags to use for OVF package creation. The supported flags can be obtained using ExportFlag.list. If unset, no flags will be used. Known values: EXTRA_CONFIG, PRESERVE_MAC
+	OvfFlags []string `mapstructure:"ovf_flags"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -167,7 +169,8 @@ func (s *StepImportToContentLibrary) Run(_ context.Context, state multistep.Stat
 func (s *StepImportToContentLibrary) importOvfTemplate(vm *driver.VirtualMachineDriver) error {
 	ovf := vcenter.OVF{
 		Spec: vcenter.CreateSpec{
-			Name: s.ContentLibConfig.Name,
+			Name:  s.ContentLibConfig.Name,
+			Flags: s.ContentLibConfig.OvfFlags,
 		},
 		Target: vcenter.LibraryTarget{
 			LibraryID: s.ContentLibConfig.Library,

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -10,17 +10,18 @@ import (
 // FlatContentLibraryDestinationConfig is an auto-generated flat version of ContentLibraryDestinationConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatContentLibraryDestinationConfig struct {
-	Library      *string `mapstructure:"library" cty:"library" hcl:"library"`
-	Name         *string `mapstructure:"name" cty:"name" hcl:"name"`
-	Description  *string `mapstructure:"description" cty:"description" hcl:"description"`
-	Cluster      *string `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
-	Folder       *string `mapstructure:"folder" cty:"folder" hcl:"folder"`
-	Host         *string `mapstructure:"host" cty:"host" hcl:"host"`
-	ResourcePool *string `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
-	Datastore    *string `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
-	Destroy      *bool   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
-	Ovf          *bool   `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
-	SkipImport   *bool   `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
+	Library      *string  `mapstructure:"library" cty:"library" hcl:"library"`
+	Name         *string  `mapstructure:"name" cty:"name" hcl:"name"`
+	Description  *string  `mapstructure:"description" cty:"description" hcl:"description"`
+	Cluster      *string  `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
+	Folder       *string  `mapstructure:"folder" cty:"folder" hcl:"folder"`
+	Host         *string  `mapstructure:"host" cty:"host" hcl:"host"`
+	ResourcePool *string  `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
+	Datastore    *string  `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
+	Destroy      *bool    `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	Ovf          *bool    `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
+	SkipImport   *bool    `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
+	OvfFlags     []string `mapstructure:"ovf_flags" cty:"ovf_flags" hcl:"ovf_flags"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -46,6 +47,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"destroy":       &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 		"ovf":           &hcldec.AttrSpec{Name: "ovf", Type: cty.Bool, Required: false},
 		"skip_import":   &hcldec.AttrSpec{Name: "skip_import", Type: cty.Bool, Required: false},
+		"ovf_flags":     &hcldec.AttrSpec{Name: "ovf_flags", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -47,4 +47,6 @@
 
 - `skip_import` (bool) - When set to true, the VM won't be imported to the content library item. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
+- `ovf_flags` ([]string) - Flags to use for OVF package creation. The supported flags can be obtained using ExportFlag.list. If unset, no flags will be used. Known values: EXTRA_CONFIG, PRESERVE_MAC
+
 <!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->


### PR DESCRIPTION
Support for specifying the `Flags` parameter of the OVF CreateSpec.

Closes #186 

I suggest a syntax that mirrors how the OVF CreateSpec API is defined:
- https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/api/vcenter/ovf/library-item/post/
- https://developer.vmware.com/apis/vsphere-automation/latest/vcenter/data-structures/Ovf/LibraryItem/CreateSpec/

```hcl
content_library_destination {
      name = template_name
      library = content_library
      ovf = true
      ovf_flags = [ "EXTRA_CONFIG" ]
}
```