### PR TITLE
feat: add support for number of `displays` in the `vsphere` builders

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -59,6 +59,7 @@ type FlatConfig struct {
 	RAMReserveAll                   *bool                                       `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
 	MemoryHotAddEnabled             *bool                                       `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
 	VideoRAM                        *int64                                      `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
+	Displays                        *int32                                      `mapstructure:"displays" cty:"displays" hcl:"displays"`
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
@@ -203,6 +204,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"RAM_reserve_all":                &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
 		"RAM_hot_plug":                   &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
 		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
+		"displays":                       &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -32,11 +32,11 @@ type HardwareConfig struct {
 	RAMReserveAll bool `mapstructure:"RAM_reserve_all"`
 	// Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
-	// Amount of video memory in KB. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
-	// for supported maximums. Defaults to 4096 KB. 
+	// Amount of video memory in KB. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 4096 KB.
 	VideoRAM int64 `mapstructure:"video_ram"`
-	// Number of video displays. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
-	// for supported maximums. Defaults to 1. 
+	// Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 1.
 	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -32,9 +32,11 @@ type HardwareConfig struct {
 	RAMReserveAll bool `mapstructure:"RAM_reserve_all"`
 	// Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
-	// Amount of video memory in KB.
+	// Amount of video memory in KB. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 4096 KB. 
 	VideoRAM int64 `mapstructure:"video_ram"`
-	// Number of video displays. Defaults to 1. 
+	// Number of video displays. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 1. 
 	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.
@@ -59,6 +61,7 @@ func (c *HardwareConfig) Prepare() []error {
 	if c.Firmware != "" && c.Firmware != "bios" && c.Firmware != "efi" && c.Firmware != "efi-secure" {
 		errs = append(errs, fmt.Errorf("'firmware' must be '', 'bios', 'efi' or 'efi-secure'"))
 	}
+
 	if c.VTPMEnabled && c.Firmware != "efi" && c.Firmware != "efi-secure" {
 		errs = append(errs, fmt.Errorf("'vTPM' could be enabled only when 'firmware' set to 'efi' or 'efi-secure'"))
 	}

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -34,7 +34,7 @@ type HardwareConfig struct {
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
 	// Amount of video memory in KB.
 	VideoRAM int64 `mapstructure:"video_ram"`
-	// Number of video displays.
+	// Number of video displays. Defaults to 1. 
 	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -32,9 +32,11 @@ type HardwareConfig struct {
 	RAMReserveAll bool `mapstructure:"RAM_reserve_all"`
 	// Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
-	// Amount of video memory in KB. Defaults to 4096 KB.
+	// Amount of video memory in KB. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 4096 KB.
 	VideoRAM int64 `mapstructure:"video_ram"`
-	// Number of video displays. Defaults to 1.
+	// Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+	// for supported maximums. Defaults to 1.
 	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -34,6 +34,8 @@ type HardwareConfig struct {
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
 	// Amount of video memory in KB.
 	VideoRAM int64 `mapstructure:"video_ram"`
+	// Number of video displays.
+	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.
 	VGPUProfile string `mapstructure:"vgpu_profile"`
@@ -87,6 +89,7 @@ func (s *StepConfigureHardware) Run(_ context.Context, state multistep.StateBag)
 			CpuHotAddEnabled:    s.Config.CpuHotAddEnabled,
 			MemoryHotAddEnabled: s.Config.MemoryHotAddEnabled,
 			VideoRAM:            s.Config.VideoRAM,
+			Displays:            s.Config.Displays,
 			VGPUProfile:         s.Config.VGPUProfile,
 			Firmware:            s.Config.Firmware,
 			ForceBIOSSetup:      s.Config.ForceBIOSSetup,

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -32,11 +32,9 @@ type HardwareConfig struct {
 	RAMReserveAll bool `mapstructure:"RAM_reserve_all"`
 	// Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 	MemoryHotAddEnabled bool `mapstructure:"RAM_hot_plug"`
-	// Amount of video memory in KB. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
-	// for supported maximums. Defaults to 4096 KB.
+	// Amount of video memory in KB. Defaults to 4096 KB.
 	VideoRAM int64 `mapstructure:"video_ram"`
-	// Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
-	// for supported maximums. Defaults to 1.
+	// Number of video displays. Defaults to 1.
 	Displays int32 `mapstructure:"displays"`
 	// vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
 	// for examples of profile names. Defaults to none.

--- a/builder/vsphere/common/step_hardware.hcl2spec.go
+++ b/builder/vsphere/common/step_hardware.hcl2spec.go
@@ -20,6 +20,7 @@ type FlatHardwareConfig struct {
 	RAMReserveAll       *bool   `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
 	MemoryHotAddEnabled *bool   `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
 	VideoRAM            *int64  `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
+	Displays            *int32  `mapstructure:"displays" cty:"displays" hcl:"displays"`
 	VGPUProfile         *string `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV            *bool   `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware            *string `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
@@ -49,6 +50,7 @@ func (*FlatHardwareConfig) HCL2Spec() map[string]hcldec.Spec {
 		"RAM_reserve_all":  &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
 		"RAM_hot_plug":     &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
 		"video_ram":        &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
+		"displays":         &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
 		"vgpu_profile":     &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":         &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":         &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -567,23 +567,23 @@ func (vm *VirtualMachineDriver) Configure(config *HardwareConfig) error {
 	}
 
 	if config.VideoRAM != 0 || config.Displays != 0 {
-			devices, err := vm.vm.Device(vm.driver.ctx)
-			if err != nil {
-				return err
-			}
-			l := devices.SelectByType((*types.VirtualMachineVideoCard)(nil))
-			if len(l) != 1 {
-				return err
-			}
-			card := l[0].(*types.VirtualMachineVideoCard)
-			card.VideoRamSizeInKB = config.VideoRAM
-			card.NumDisplays = config.Displays
-			spec := &types.VirtualDeviceConfigSpec{
-				Device:    card,
-				Operation: types.VirtualDeviceConfigSpecOperationEdit,
-			}
-			confSpec.DeviceChange = append(confSpec.DeviceChange, spec)
+		devices, err := vm.vm.Device(vm.driver.ctx)
+		if err != nil {
+			return err
 		}
+		l := devices.SelectByType((*types.VirtualMachineVideoCard)(nil))
+		if len(l) != 1 {
+			return err
+		}
+		card := l[0].(*types.VirtualMachineVideoCard)
+		card.VideoRamSizeInKB = config.VideoRAM
+		card.NumDisplays = config.Displays
+		spec := &types.VirtualDeviceConfigSpec{
+			Device:    card,
+			Operation: types.VirtualDeviceConfigSpecOperationEdit,
+		}
+		confSpec.DeviceChange = append(confSpec.DeviceChange, spec)
+	}
 
 	if config.VGPUProfile != "" {
 		devices, err := vm.vm.Device(vm.driver.ctx)

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -57,6 +57,7 @@ type FlatConfig struct {
 	RAMReserveAll                   *bool                                       `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
 	MemoryHotAddEnabled             *bool                                       `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
 	VideoRAM                        *int64                                      `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
+	Displays                        *int32                                      `mapstructure:"displays" cty:"displays" hcl:"displays"`
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
@@ -203,6 +204,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"RAM_reserve_all":                &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
 		"RAM_hot_plug":                   &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
 		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
+		"displays":                       &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -21,6 +21,8 @@
 
 - `video_ram` (int64) - Amount of video memory in KB.
 
+- `displays` (int32) - Number of video displays.
+
 - `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
   for examples of profile names. Defaults to none.
 

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -19,10 +19,10 @@
 
 - `RAM_hot_plug` (bool) - Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 
-- `video_ram` (int64) - Amount of video memory in KB. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+- `video_ram` (int64) - Amount of video memory in KB. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
   for supported maximums. Defaults to 4096 KB.
 
-- `displays` (int32) - Number of video displays. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+- `displays` (int32) - Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
   for supported maximums. Defaults to 1.
 
 - `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -19,9 +19,11 @@
 
 - `RAM_hot_plug` (bool) - Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 
-- `video_ram` (int64) - Amount of video memory in KB.
+- `video_ram` (int64) - Amount of video memory in KB. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+  for supported maximums. Defaults to 4096 KB.
 
-- `displays` (int32) - Number of video displays.
+- `displays` (int32) - Number of video displays. [See vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
+  for supported maximums. Defaults to 1.
 
 - `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
   for examples of profile names. Defaults to none.


### PR DESCRIPTION
### Description

Adds add support for number of `displays` in the `vsphere` builders.

The number of supported displays for vSphere 7.0 `== 10`.
- If `displays` is omitted, the default number `= 1`.
- If `displays` is set to `0`, it is an invalid value and will set the default (`1`)
- If `displays` is set to `>10` (e.g., `11`), the API configuration the API will report an invalid configuration. This is dictated by the virtual hardware version. 

### Release Note

Adds support for configuring the number of displays by @tenthirtyam in https://github.com/hashicorp/packer-plugin-vsphere/pull/201.

### References

Closes #80

**Ryan Johnson**
Staff II Solutions Architect | VMware, Inc.