### PR TITLE
enhancement: make assignment of network_adapters optional

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -939,10 +939,6 @@ func (vm *VirtualMachineDriver) GetDir() (string, error) {
 }
 
 func addNetwork(d *VCenterDriver, devices object.VirtualDeviceList, config *CreateConfig) (object.VirtualDeviceList, error) {
-	if len(config.NICs) == 0 {
-		return nil, errors.New("no network adapters have been defined")
-	}
-
 	for _, nic := range config.NICs {
 		network, err := findNetwork(nic.Network, config.Host, d)
 		if err != nil {

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -69,7 +69,7 @@ type CreateConfig struct {
 	// for a full list of possible values.
 	GuestOSType   string               `mapstructure:"guest_os_type"`
 	StorageConfig common.StorageConfig `mapstructure:",squash"`
-	//Sets the network adapters, if no adapter is specified, every network related task is not applicable.
+	// Sets the network adapters, if no adapter is specified, every network related task is not applicable.
 	NICs []NIC `mapstructure:"network_adapters"`
 	// Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 	USBController []string `mapstructure:"usb_controller"`

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -69,7 +69,7 @@ type CreateConfig struct {
 	// for a full list of possible values.
 	GuestOSType   string               `mapstructure:"guest_os_type"`
 	StorageConfig common.StorageConfig `mapstructure:",squash"`
-	//Sets the network adapters, if no adapter is specified, every network related task is not possible.
+	//Sets the network adapters, if no adapter is specified, every network related task is not applicable.
 	NICs []NIC `mapstructure:"network_adapters"`
 	// Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 	USBController []string `mapstructure:"usb_controller"`

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -16,6 +16,7 @@ import (
 )
 
 // Defines a Network Adapter
+// If no adapter is defined, network tasks (communicators, most provisioners) won't work, so it's advised to define one.
 //
 // Example that creates two network adapters:
 //
@@ -68,7 +69,7 @@ type CreateConfig struct {
 	// for a full list of possible values.
 	GuestOSType   string               `mapstructure:"guest_os_type"`
 	StorageConfig common.StorageConfig `mapstructure:",squash"`
-	// Network adapters
+	//Sets the network adapters, if no adapter is specified, every network related task is not possible.
 	NICs []NIC `mapstructure:"network_adapters"`
 	// Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 	USBController []string `mapstructure:"usb_controller"`

--- a/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -9,7 +9,7 @@
   here](https://developer.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
   for a full list of possible values.
 
-- `network_adapters` ([]NIC) - Network adapters
+- `network_adapters` ([]NIC) - Sets the network adapters, if no adapter is specified, every network related task is not possible.
 
 - `usb_controller` ([]string) - Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 

--- a/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -9,7 +9,7 @@
   here](https://developer.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
   for a full list of possible values.
 
-- `network_adapters` ([]NIC) - Sets the network adapters, if no adapter is specified, every network related task is not possible.
+- `network_adapters` ([]NIC) - Sets the network adapters, if no adapter is specified, every network related task is not applicable.
 
 - `usb_controller` ([]string) - Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
 

--- a/docs-partials/builder/vsphere/iso/NIC.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC.mdx
@@ -1,6 +1,7 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
 Defines a Network Adapter
+If no adapter is defined, network tasks (communicators, most provisioners) won't work, so it's advised to define one.
 
 Example that creates two network adapters:
 


### PR DESCRIPTION
Removes the check that prevents the creation of a VM without a network adapter, thus allowing to create a VM without network adapters 

Closes #202

