### PR TITLE
docs: Add HCL examples for the `vsphere-template` post-processor

### DIFF
--- a/docs/post-processors/vsphere-template.mdx
+++ b/docs/post-processors/vsphere-template.mdx
@@ -14,36 +14,19 @@ Type: `vsphere-template`
 Artifact BuilderId: `packer.post-processor.vsphere`
 
 The Packer vSphere Template post-processor takes an artifact from the
-VMware-iso builder, built on ESXi (i.e. remote) or an artifact from the
+`vmware-iso` builder, built on ESXi (i.e. remote) or an artifact from the
 [vSphere](/docs/post-processors/vsphere) post-processor, marks the VM as a
-template, and leaves it in the path of your choice.
-
-## Example
-
-An example is shown below, showing only the post-processor configuration:
-
-```json
-{
-  "type": "vsphere-template",
-  "host": "vcenter.local",
-  "insecure": true,
-  "username": "root",
-  "password": "secret",
-  "datacenter": "mydatacenter",
-  "folder": "/packer-templates/os/distro-7"
-}
-```
+template, and places it in the path of your choice.
 
 ## Configuration
 
 There are many configuration options available for the post-processor. They are
-segmented below into two categories: required and optional parameters. Within
-each category, the available configuration keys are alphabetized.
+provided below in two categories: required and optional parameters.
 
 Required:
 
-- `host` (string) - The vSphere host that contains the VM built by the
-  vmware-iso.
+- `host` (string) - The vSphere endpoint that contains the VM built by the
+  `vmware-iso` builder.
 
 - `password` (string) - Password to use to authenticate to the vSphere
   endpoint.
@@ -58,41 +41,134 @@ Optional:
 
 - `folder` (string) - Target path where the template will be created.
 
-- `insecure` (boolean) - If it's true skip verification of server
-  certificate. Default is false
+- `insecure` (boolean) - If `true`, skips the verification of the server
+  certificate. Default is `false`.
 
 - `keep_input_artifact` (boolean) - Unlike most post-processors, this option
-  has no effect for vsphere-template. This is because in order for a template
+  has no effect for `vsphere-template`. This is because in order for a template
   to work, you can't delete the vm that you generate the template from. The
-  vsphere template post-processor will therefore always preserve the original
-  vm.
+  vSphere Template post-processor will therefore always preserve the original
+  VM.
 
 - `snapshot_enable` (boolean) - Create a snapshot before marking as a
-  template. Default is false
+  template. Default is `false`.
 
 - `snapshot_name` (string) - Name for the snapshot. Required when
-  `snapshot_enable` is `true`
+  `snapshot_enable` is `true`.
 
 - `snapshot_description` (string) - Description for the snapshot. Required
-  when `snapshot_enable` is `true`
+  when `snapshot_enable` is `true`.
 
 - `reregister_vm` (boolean) - Use the method of unregister VM and reregister
-  as a template, rather than using the markAsTemplate method in vmWare.
+  as a template, rather than using the `markAsTemplate` method.
+
   NOTE: If you are getting permission denied errors when trying to mark as a
   template, but it works fine in the vSphere UI, try setting this to `false`.
   Default is `true`.
 
-## Using the vSphere Template with local builders
+## Example
 
-Once the [vSphere](/docs/post-processors/vsphere) takes an artifact from
-the VMware builder and uploads it to a vSphere endpoint, you will likely want
-to mark that VM as template. Packer can do this for you automatically using a
-sequence definition (a collection of post-processors that are treated as as
-single pipeline, see [Post-Processors](/docs/templates/legacy_json_templates/post-processors)
-for more information):
+An example is shown below, showing only the post-processor configuration:
+
+<Tabs>
+<Tab heading="HCL2">
+
+```hcl
+source "null" "example" {
+    communicator = "none"
+}
+
+build {
+    sources = [
+        "source.null.example"
+    ]
+
+    post-processors {
+      post-processor "vsphere-template"{
+          host                = "vcenter.example.com"
+          insecure            = false
+          username            = "administrator@vsphere.local"
+          password            = "VMw@re1!"
+          datacenter          = "dc-01"   
+          folder              = "/templates/os/distro"
+      }
+    }
+}
+```
+
+</Tab>
+
+<Tab heading="JSON">
 
 ```json
 {
+  "builders": [
+    {
+      "type": "null",
+      "communicator": "none"
+    }
+  ],
+  "post-processors": [
+    [
+      {
+        "type": "vsphere-template",
+        "host": "vcenter.example.com",
+        "insecure": true,
+        "username": "administrator@vsphere.local",
+        "password": "VMw@re1!",
+        "datacenter": "dc-01",
+        "folder": "/templates/os/distro"
+      }
+    ]
+  ]
+}
+```
+
+</Tab>
+</Tabs>
+
+## Using the vSphere Template with local builders
+
+Once the [vSphere](/docs/post-processors/vsphere) post-processor takes an
+artifact from the builder and uploads it to a vSphere endpoint, you may want
+the VM to be marked as a template. Packer can do this for you automatically
+using a sequence definition (a collection of post-processors that are treated
+as as single pipeline, see [Post-Processors](/docs/templates/legacy_json_templates/post-processors)
+for more information):
+
+<Tabs>
+<Tab heading="HCL2">
+
+```hcl
+build {
+    sources = [
+        "source.null.example"
+    ]
+
+  post-processors {
+    post-processor "vsphere" {
+      # ...
+    }
+
+    post-processor "vsphere-template" {
+      # ...
+    }
+  }
+}
+```
+
+</Tab>
+
+<Tab heading="JSON">
+
+```json
+{
+  "builders": [
+    {
+      "type": "null",
+      "communicator": "none"
+    }
+  ],
   "post-processors": [
     [
       {
@@ -110,53 +186,58 @@ for more information):
     }
   ]
 }
+
+
 ```
+
+</Tab>
+</Tabs>
 
 In the example above, the result of each builder is passed through the defined
 sequence of post-processors starting with the `vsphere` post-processor which
 will upload the artifact to a vSphere endpoint. The resulting artifact is then
 passed on to the `vsphere-template` post-processor which handles marking a VM
-as a template. Note that the `vsphere` and `vsphere-template` post-processors
-are paired together in their own JSON array.
+as a template. In JSON, note that the `vsphere` and `vsphere-template`
+post-processors can be paired together in their own array.
 
 ## Permissions
 
-The vsphere post processor needs several permissions to be able to mark the
+The vSphere post processor needs several privileges to be able to mark the
 vm as a template. Rather than giving full administrator access, you can create
-a role to give the post-processor the permissions necessary to run. Here is an
+a role to give the post-processor the privileges necessary to run. Here is an
 example role that will work. Please note that this is a user-supplied list so
-there may be a few extraneous permissions that are not strictly required.
+there may be a few extraneous privilegess that are not strictly required.
 
-For Vsphere 5.5 the role needs the following privileges:
+For vSphere, the role needs the following privileges:
 
-    Datastore.AllocateSpace
-    Host.Config.AdvancedConfig
-    Host.Config.NetService
-    Host.Config.Network
-    Network.Assign
-    System.Anonymous
-    System.Read
-    System.View
-    VApp.Import
-    VirtualMachine.Config.AddNewDisk
-    VirtualMachine.Config.AdvancedConfig
-    VirtualMachine.Inventory.Delete
+    `Datastore.AllocateSpace`
+    `Host.Config.AdvancedConfig`
+    `Host.Config.NetService`
+    `Host.Config.Network`
+    `Network.Assign`
+    `System.Anonymous`
+    `System.Read`
+    `System.View`
+    `VApp.Import`
+    `VirtualMachine.Config.AddNewDisk`
+    `VirtualMachine.Config.AdvancedConfig`
+    `VirtualMachine.Inventory.Delete`
 
-and either (If reregister_vm is false):
+and either (if `reregister_vm` is `false`):
 
-    VirtualMachine.Provisioning.MarkAsTemplate
+    `VirtualMachine.Provisioning.MarkAsTemplate`
 
-or (if reregister_vm is true or unset):
+or (if `reregister_vm` is `true` or unset):
 
-    VirtualMachine.Inventory.Register
-    VirtualMachine.Inventory.Unregister
+    `VirtualMachine.Inventory.Register`
+    `VirtualMachine.Inventory.Unregister`
 
-And this role must be authorized on the:
+The role must be authorized on the:
 
-    Cluster of the host
-    The destination folder (not on Datastore, on the Vsphere logical view)
-    The network to be assigned
-    The destination datastore.
+    `Cluster of the host`
+    `The destination folder`
+    `The destination datastore`
+    `The network to be assigned`
 
 # Troubleshooting
 

--- a/docs/post-processors/vsphere.mdx
+++ b/docs/post-processors/vsphere.mdx
@@ -77,10 +77,9 @@ Optional:
 # Example
 
 The following is an example of the vSphere post-processor being used in
-conjunction with the null builder and artifice post-processor to upload a vmx
-to a vSphere cluster.
+conjunction with the null builder to upload a vmx to a vSphere cluster.
 
-You can also use this post-processor with the vmx artifact from a VMware build.
+You can also use this post-processor with the vmx artifact from a build.
 
 <Tabs>
 <Tab heading="HCL2">
@@ -95,11 +94,7 @@ build {
         "source.null.example"
     ]
 
-    post-processors{
-      post-processor "artifice"{
-          files = ["output-vmware-iso/packer-vmware-iso.vmx"]
-      }
-
+    post-processors {
       post-processor "vsphere"{
           vm_name             = "packer"
           host                = "vcenter.example.com"
@@ -128,10 +123,6 @@ build {
   ],
   "post-processors": [
     [
-      {
-        "type": "artifice",
-        "files": ["output-vmware-iso/packer-vmware-iso.vmx"]
-      },
       {
         "type": "vsphere",
         "vm_name": "packer",


### PR DESCRIPTION
- Adds HCL examples for the `vsphere-template` post-processor.
- Minor edits and formatting of the documentation.

Closes: #205