### PR TITLE
Fix lint checker errors

### DIFF
--- a/builder/vsphere/common/artifact_test.go
+++ b/builder/vsphere/common/artifact_test.go
@@ -32,7 +32,7 @@ func TestArtifactHCPPackerMetadata(t *testing.T) {
 		"memory_mb":                   fmt.Sprintf("%d", vmSim.Config.Hardware.MemoryMB),
 		"host":                        host.Name,
 		"datastore":                   datastore.Name,
-		"content_library_destination": fmt.Sprintf("Library-Name/Item-Name"),
+		"content_library_destination": "Library-Name/Item-Name",
 		"network":                     "DC0_DVPG0",
 		"vsphere_uuid":                vmSim.Config.Uuid,
 	}

--- a/builder/vsphere/driver/vm_clone_acc_test.go
+++ b/builder/vsphere/driver/vm_clone_acc_test.go
@@ -1,3 +1,4 @@
+//nolint:unused // The majority of helper functions are used as functional arguments in test cases
 package driver
 
 import (

--- a/builder/vsphere/driver/vm_create_acc_test.go
+++ b/builder/vsphere/driver/vm_create_acc_test.go
@@ -36,6 +36,7 @@ func TestVMAcc_create(t *testing.T) {
 	}
 }
 
+//nolint:unused // createDefaultCheck is used as a functional argument
 func createDefaultCheck(t *testing.T, vm VirtualMachine, config *CreateConfig) {
 	d := vm.(*VirtualMachineDriver).driver
 

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -105,7 +105,7 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 func TestGetEncodedPassword(t *testing.T) {
 
 	// Password is encoded, and contains a colon
-	ovftool_uri := fmt.Sprintf("vi://hostname/Datacenter/host/cluster")
+	ovftool_uri := "vi://hostname/Datacenter/host/cluster"
 
 	u, _ := url.Parse(ovftool_uri)
 	u.User = url.UserPassword("us:ername", "P@ssW:rd")


### PR DESCRIPTION
* Add nolint:unused for defined functions that are used as functional arguments.
* Remove unneeded calls to Sprintf(...)
