### PR TITLE
docs: update support references

### DIFF
--- a/docs/builders/vsphere-clone.mdx
+++ b/docs/builders/vsphere-clone.mdx
@@ -17,9 +17,10 @@ This builder clones VMs from existing templates.
 
 - VMware Player is not required.
 - It uses the official vCenter Server API, and does not require ESXi host [modification](/packer/plugins/builders/vsphere/vsphere-iso#building-on-a-remote-vsphere-hypervisor)
-- This builder is supported for vSphere version 6.5 and greater. Builds on lower
-  versions may work, but some configuration options may throw errors because they
-  do not exist in the older versions of the vSphere API.
+- The builder supports versions following the VMware Product Lifecycle Matrix
+  from General Availability to End of General Support. Builds on versions that
+  are end of support may work, but configuration options may throw errors if
+  they do not exist in the vSphere API for those versions.
 
 ## Examples
 

--- a/docs/builders/vsphere-iso.mdx
+++ b/docs/builders/vsphere-iso.mdx
@@ -17,9 +17,10 @@ starts from an ISO file and creates new VMs from scratch.
 
 - VMware Player is not required.
 - It uses the official vCenter Server API, and does not require ESXi host [modification](/packer/plugins/builders/vsphere/vsphere-iso#building-on-a-remote-vsphere-hypervisor)
-- This builder is supported for vSphere version 6.5 and greater. Builds on lower
-  versions may work, but some configuration options may throw errors because they
-  do not exist in the older versions of the vSphere API.
+- The builder supports versions following the VMware Product Lifecycle Matrix
+  from General Availability to End of General Support. Builds on versions that
+  are end of support may work, but configuration options may throw errors if
+  they do not exist in the vSphere API for those versions.
 
 ## Examples
 

--- a/docs/builders/vsphere-supervisor.mdx
+++ b/docs/builders/vsphere-supervisor.mdx
@@ -17,7 +17,12 @@ This builder deploys new VMs to a vSphere Supervisor cluster.
 - It uses kubeconfig file to connect to the vSphere Supervisor cluster.
 - It uses the VM-Service API to deploy and configure the source VM.
 - It uses the Packer provisioners to customize the VM after deployment.
-- Planned enhancements that will introduce the ability to publish the customized VM as a new VM image to the vSphere endpoint.
+- Planned enhancements that will introduce the ability to publish the
+  customized VM as a new VM image to the vSphere endpoint.
+- The builder supports versions following the VMware Product Lifecycle Matrix
+  from General Availability to End of General Support. Builds on versions that
+  are end of support may work, but configuration options may throw errors if
+  they do not exist in the vSphere API for those versions.
 
 ## Examples
 


### PR DESCRIPTION
### Description

Updates the documentation for each builder to note that support follows the the VMware Product Lifecycle Matrix from General Availability to End of General Support.

> _The builder supports versions following the VMware Product Lifecycle Matrix from General Availability to End of General Support. Builds on versions that are end of support may work, but configuration options may throw errors if they do not exist in the vSphere API for those versions._

### Reference

GH-238

