### PR TITLE
Allow destroy VM after vsphere-clone successful build (#168)

### DIFF
--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -39,6 +39,7 @@ type FlatConfig struct {
 	Network                         *string                                     `mapstructure:"network" cty:"network" hcl:"network"`
 	MacAddress                      *string                                     `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
 	Notes                           *string                                     `mapstructure:"notes" cty:"notes" hcl:"notes"`
+	Destroy                         *bool                                       `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
 	VAppConfig                      *FlatvAppConfig                             `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 	DiskControllerType              []string                                    `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage                         []common.FlatDiskConfig                     `mapstructure:"storage" cty:"storage" hcl:"storage"`
@@ -184,6 +185,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"network":                        &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"mac_address":                    &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"notes":                          &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
+		"destroy":                        &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 		"vapp":                           &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 		"disk_controller_type":           &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":                        &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*common.FlatDiskConfig)(nil).HCL2Spec())},

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -42,6 +42,8 @@ type CloneConfig struct {
 	MacAddress string `mapstructure:"mac_address"`
 	// VM notes.
 	Notes string `mapstructure:"notes"`
+	// If set to true, the VM will be destroyed after the builder completes
+	Destroy bool `mapstructure:"destroy"`
 	// Set the vApp Options to a virtual machine.
 	// See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
 	// to know the available options and how to use it.
@@ -127,6 +129,9 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 	if vm == nil {
 		return multistep.ActionHalt
+	}
+	if s.Config.Destroy {
+		state.Put("destroy_vm", s.Config.Destroy)
 	}
 	state.Put("vm", vm)
 	return multistep.ActionContinue

--- a/builder/vsphere/clone/step_clone.hcl2spec.go
+++ b/builder/vsphere/clone/step_clone.hcl2spec.go
@@ -17,6 +17,7 @@ type FlatCloneConfig struct {
 	Network            *string                 `mapstructure:"network" cty:"network" hcl:"network"`
 	MacAddress         *string                 `mapstructure:"mac_address" cty:"mac_address" hcl:"mac_address"`
 	Notes              *string                 `mapstructure:"notes" cty:"notes" hcl:"notes"`
+	Destroy            *bool                   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
 	VAppConfig         *FlatvAppConfig         `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 	DiskControllerType []string                `mapstructure:"disk_controller_type" cty:"disk_controller_type" hcl:"disk_controller_type"`
 	Storage            []common.FlatDiskConfig `mapstructure:"storage" cty:"storage" hcl:"storage"`
@@ -40,6 +41,7 @@ func (*FlatCloneConfig) HCL2Spec() map[string]hcldec.Spec {
 		"network":              &hcldec.AttrSpec{Name: "network", Type: cty.String, Required: false},
 		"mac_address":          &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"notes":                &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
+		"destroy":              &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
 		"vapp":                 &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 		"disk_controller_type": &hcldec.AttrSpec{Name: "disk_controller_type", Type: cty.List(cty.String), Required: false},
 		"storage":              &hcldec.BlockListSpec{TypeName: "storage", Nested: hcldec.ObjectSpec((*common.FlatDiskConfig)(nil).HCL2Spec())},

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -15,6 +15,8 @@
 
 - `notes` (string) - VM notes.
 
+- `destroy` (bool) - If set to true, the VM will be destroyed after the builder completes
+
 - `vapp` (vAppConfig) - Set the vApp Options to a virtual machine.
   See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
   to know the available options and how to use it.


### PR DESCRIPTION
Added a support for destroying VM after vsphere-clone builder is completed successfully.
Using `destroy: true` flag under the plugin configuration.
Example:
```
source "vsphere-clone" "my_clone" {
  communicator         = "something"
  insecure_connection  = "something"
  password             = "something"
  username             = "something"
  ssh_private_key_file = "something"
  ssh_username         = "something"
  boot_wait            = "something"
  ip_wait_timeout      = "something"
  template             = "something"
  vcenter_server       = "something"
  datacenter           = "something"
  cluster              = "something"
  host                 = "something"
  datastore            = "something"
  vm_name              = "something"
  folder               = "something"
  destroy              = true
}
```
Tests:
output of `packer build` with `destroy: true`:
```
==> vsphere-clone.ova_clone: Deleting Floppy drives...
==> vsphere-clone.ova_clone: Eject CD-ROM drives...
==> vsphere-clone.ova_clone: Destroying VM...
2023/02/11 14:23:45 [INFO] (telemetry) ending vsphere-clone.ova_clone
==> Wait completed after 7 minutes 31 seconds
==> Builds finished. The artifacts of successful builds are:
2023/02/11 14:23:45 machine readable: vsphere-clone.ova_clone,artifact-count []string{"1"}
Build 'vsphere-clone.ova_clone' finished after 7 minutes 31 seconds.
```

Closes: #168 