### PR TITLE
feat: add support for dynamic directpath i/o

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -750,7 +750,11 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 - `displays` (int32) - Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
   for supported maximums. Defaults to 1.
 
-- `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
+- `pci_passthrough_allowed_device` ([]PCIPassthroughAllowedDevice) - Configure Dynamic DirectPath I/O [PCI Passthrough](#pci-passthrough-configuration) for
+  virtual machine. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5B3CAB26-5D06-4A99-92A0-3A04C69CE64B.html)
+
+- `vgpu_profile` (string) - vGPU profile for accelerated graphics.
+  vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
   for examples of profile names. Defaults to none.
 
 - `NestedHV` (bool) - Enable nested hardware virtualization for VM. Defaults to `false`.

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -416,7 +416,11 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 - `displays` (int32) - Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
   for supported maximums. Defaults to 1.
 
-- `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
+- `pci_passthrough_allowed_device` ([]PCIPassthroughAllowedDevice) - Configure Dynamic DirectPath I/O [PCI Passthrough](#pci-passthrough-configuration) for
+  virtual machine. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5B3CAB26-5D06-4A99-92A0-3A04C69CE64B.html)
+
+- `vgpu_profile` (string) - vGPU profile for accelerated graphics.
+  vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
   for examples of profile names. Defaults to none.
 
 - `NestedHV` (bool) - Enable nested hardware virtualization for VM. Defaults to `false`.
@@ -430,6 +434,59 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 - `precision_clock` (string) - Add a precision clock device for virtual machine. Defaults to `none`.
 
 <!-- End of code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; -->
+
+
+### PCI Passthrough Configuration
+
+<!-- Code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
+
+Dynamic DirectPath I/O is component of the Assignable Hardware framework in VMware vSphere.
+Dynamic DirectPath I/O enables the Assignable Hardware intelligence for passthrough devices and
+the hardware address of the PCIe device is no longer directly mapped to the virtual machine
+configuration. Instead, the attributes, or capabilities, are exposed to the virtual machine.
+
+# JSON
+
+```json
+
+	{
+	  "pci_passthrough_allowed_device": {
+	    "vendor_id": "8086",
+	    "device_id": "100e",
+	    "sub_device_id": "8086",
+	    "sub_vendor_id": "100e"
+	  }
+	}
+
+```
+
+# HCL2
+
+```hcl
+
+	pci_passthrough_allowed_device {
+	  "vendor_id": "8086",
+	  "device_id": "100e",
+	  "sub_device_id": "8086",
+	  "sub_vendor_id": "100e"
+	}
+
+```
+
+<!-- End of code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; -->
+
+
+<!-- Code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
+
+- `vendor_id` (string) - The sub-vendor ID of the PCI device.
+
+- `device_id` (string) - The vendor ID of the PCI device.
+
+- `sub_vendor_id` (string) - The sub-vendor ID of the PCI device.
+
+- `sub_device_id` (string) - The sub-device ID of the PCI device.
+
+<!-- End of code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; -->
 
 
 ## Location Configuration
@@ -687,7 +744,6 @@ iso_paths = [
     "[] /usr/lib/vmware/isoimages/windows.iso"
 ]
 ```
-
 
 <!-- Code generated from the comments of the CDRomConfig struct in builder/vsphere/common/step_add_cdrom.go; DO NOT EDIT MANUALLY -->
 

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -61,6 +61,7 @@ type FlatConfig struct {
 	MemoryHotAddEnabled             *bool                                       `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
 	VideoRAM                        *int64                                      `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
 	Displays                        *int32                                      `mapstructure:"displays" cty:"displays" hcl:"displays"`
+	AllowedDevices                  []common.FlatPCIPassthroughAllowedDevice    `mapstructure:"pci_passthrough_allowed_device" cty:"pci_passthrough_allowed_device" hcl:"pci_passthrough_allowed_device"`
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
@@ -211,6 +212,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"RAM_hot_plug":                   &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
 		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
 		"displays":                       &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
+		"pci_passthrough_allowed_device": &hcldec.BlockListSpec{TypeName: "pci_passthrough_allowed_device", Nested: hcldec.ObjectSpec((*common.FlatPCIPassthroughAllowedDevice)(nil).HCL2Spec())},
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},

--- a/builder/vsphere/common/step_hardware.hcl2spec.go
+++ b/builder/vsphere/common/step_hardware.hcl2spec.go
@@ -10,23 +10,24 @@ import (
 // FlatHardwareConfig is an auto-generated flat version of HardwareConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatHardwareConfig struct {
-	CPUs                  *int32  `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
-	CpuCores              *int32  `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
-	CPUReservation        *int64  `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
-	CPULimit              *int64  `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
-	CpuHotAddEnabled      *bool   `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`
-	RAM                   *int64  `mapstructure:"RAM" cty:"RAM" hcl:"RAM"`
-	RAMReservation        *int64  `mapstructure:"RAM_reservation" cty:"RAM_reservation" hcl:"RAM_reservation"`
-	RAMReserveAll         *bool   `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
-	MemoryHotAddEnabled   *bool   `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
-	VideoRAM              *int64  `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
-	Displays              *int32  `mapstructure:"displays" cty:"displays" hcl:"displays"`
-	VGPUProfile           *string `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
-	NestedHV              *bool   `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
-	Firmware              *string `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
-	ForceBIOSSetup        *bool   `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
-	VTPMEnabled           *bool   `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
-	VirtualPrecisionClock *string `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
+	CPUs                  *int32                            `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
+	CpuCores              *int32                            `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
+	CPUReservation        *int64                            `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
+	CPULimit              *int64                            `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
+	CpuHotAddEnabled      *bool                             `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`
+	RAM                   *int64                            `mapstructure:"RAM" cty:"RAM" hcl:"RAM"`
+	RAMReservation        *int64                            `mapstructure:"RAM_reservation" cty:"RAM_reservation" hcl:"RAM_reservation"`
+	RAMReserveAll         *bool                             `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
+	MemoryHotAddEnabled   *bool                             `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
+	VideoRAM              *int64                            `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
+	Displays              *int32                            `mapstructure:"displays" cty:"displays" hcl:"displays"`
+	AllowedDevices        []FlatPCIPassthroughAllowedDevice `mapstructure:"pci_passthrough_allowed_device" cty:"pci_passthrough_allowed_device" hcl:"pci_passthrough_allowed_device"`
+	VGPUProfile           *string                           `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
+	NestedHV              *bool                             `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
+	Firmware              *string                           `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
+	ForceBIOSSetup        *bool                             `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
+	VTPMEnabled           *bool                             `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
+	VirtualPrecisionClock *string                           `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 }
 
 // FlatMapstructure returns a new FlatHardwareConfig.
@@ -41,23 +42,53 @@ func (*HardwareConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hclde
 // The decoded values from this spec will then be applied to a FlatHardwareConfig.
 func (*FlatHardwareConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"CPUs":             &hcldec.AttrSpec{Name: "CPUs", Type: cty.Number, Required: false},
-		"cpu_cores":        &hcldec.AttrSpec{Name: "cpu_cores", Type: cty.Number, Required: false},
-		"CPU_reservation":  &hcldec.AttrSpec{Name: "CPU_reservation", Type: cty.Number, Required: false},
-		"CPU_limit":        &hcldec.AttrSpec{Name: "CPU_limit", Type: cty.Number, Required: false},
-		"CPU_hot_plug":     &hcldec.AttrSpec{Name: "CPU_hot_plug", Type: cty.Bool, Required: false},
-		"RAM":              &hcldec.AttrSpec{Name: "RAM", Type: cty.Number, Required: false},
-		"RAM_reservation":  &hcldec.AttrSpec{Name: "RAM_reservation", Type: cty.Number, Required: false},
-		"RAM_reserve_all":  &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
-		"RAM_hot_plug":     &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
-		"video_ram":        &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
-		"displays":         &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
-		"vgpu_profile":     &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
-		"NestedHV":         &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
-		"firmware":         &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
-		"force_bios_setup": &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
-		"vTPM":             &hcldec.AttrSpec{Name: "vTPM", Type: cty.Bool, Required: false},
-		"precision_clock":  &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
+		"CPUs":                           &hcldec.AttrSpec{Name: "CPUs", Type: cty.Number, Required: false},
+		"cpu_cores":                      &hcldec.AttrSpec{Name: "cpu_cores", Type: cty.Number, Required: false},
+		"CPU_reservation":                &hcldec.AttrSpec{Name: "CPU_reservation", Type: cty.Number, Required: false},
+		"CPU_limit":                      &hcldec.AttrSpec{Name: "CPU_limit", Type: cty.Number, Required: false},
+		"CPU_hot_plug":                   &hcldec.AttrSpec{Name: "CPU_hot_plug", Type: cty.Bool, Required: false},
+		"RAM":                            &hcldec.AttrSpec{Name: "RAM", Type: cty.Number, Required: false},
+		"RAM_reservation":                &hcldec.AttrSpec{Name: "RAM_reservation", Type: cty.Number, Required: false},
+		"RAM_reserve_all":                &hcldec.AttrSpec{Name: "RAM_reserve_all", Type: cty.Bool, Required: false},
+		"RAM_hot_plug":                   &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
+		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
+		"displays":                       &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
+		"pci_passthrough_allowed_device": &hcldec.BlockListSpec{TypeName: "pci_passthrough_allowed_device", Nested: hcldec.ObjectSpec((*FlatPCIPassthroughAllowedDevice)(nil).HCL2Spec())},
+		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
+		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
+		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"force_bios_setup":               &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
+		"vTPM":                           &hcldec.AttrSpec{Name: "vTPM", Type: cty.Bool, Required: false},
+		"precision_clock":                &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
+	}
+	return s
+}
+
+// FlatPCIPassthroughAllowedDevice is an auto-generated flat version of PCIPassthroughAllowedDevice.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatPCIPassthroughAllowedDevice struct {
+	VendorId    *string `mapstructure:"vendor_id" cty:"vendor_id" hcl:"vendor_id"`
+	DeviceId    *string `mapstructure:"device_id" cty:"device_id" hcl:"device_id"`
+	SubVendorId *string `mapstructure:"sub_vendor_id" cty:"sub_vendor_id" hcl:"sub_vendor_id"`
+	SubDeviceId *string `mapstructure:"sub_device_id" cty:"sub_device_id" hcl:"sub_device_id"`
+}
+
+// FlatMapstructure returns a new FlatPCIPassthroughAllowedDevice.
+// FlatPCIPassthroughAllowedDevice is an auto-generated flat version of PCIPassthroughAllowedDevice.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*PCIPassthroughAllowedDevice) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatPCIPassthroughAllowedDevice)
+}
+
+// HCL2Spec returns the hcl spec of a PCIPassthroughAllowedDevice.
+// This spec is used by HCL to read the fields of PCIPassthroughAllowedDevice.
+// The decoded values from this spec will then be applied to a FlatPCIPassthroughAllowedDevice.
+func (*FlatPCIPassthroughAllowedDevice) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"vendor_id":     &hcldec.AttrSpec{Name: "vendor_id", Type: cty.String, Required: false},
+		"device_id":     &hcldec.AttrSpec{Name: "device_id", Type: cty.String, Required: false},
+		"sub_vendor_id": &hcldec.AttrSpec{Name: "sub_vendor_id", Type: cty.String, Required: false},
+		"sub_device_id": &hcldec.AttrSpec{Name: "sub_device_id", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_hardware_test.go
+++ b/builder/vsphere/common/step_hardware_test.go
@@ -208,11 +208,31 @@ func basicStepConfigureHardware() *StepConfigureHardware {
 			RAMReserveAll:  true,
 			Firmware:       "efi-secure",
 			ForceBIOSSetup: true,
+			AllowedDevices: []PCIPassthroughAllowedDevice{
+				{
+					VendorId:    "8086",
+					DeviceId:    "100e",
+					SubVendorId: "8086",
+					SubDeviceId: "100e",
+				},
+				{
+					VendorId:    "8087",
+					DeviceId:    "100f",
+					SubVendorId: "8087",
+					SubDeviceId: "100f",
+				},
+			},
 		},
 	}
 }
 
 func driverHardwareConfigFromConfig(config *HardwareConfig) *driver.HardwareConfig {
+
+	var allowedDevices []driver.PCIPassthroughAllowedDevice
+	for _, device := range config.AllowedDevices {
+		allowedDevices = append(allowedDevices, driver.PCIPassthroughAllowedDevice(device))
+	}
+
 	return &driver.HardwareConfig{
 		CPUs:                config.CPUs,
 		CpuCores:            config.CpuCores,
@@ -225,6 +245,7 @@ func driverHardwareConfigFromConfig(config *HardwareConfig) *driver.HardwareConf
 		CpuHotAddEnabled:    config.CpuHotAddEnabled,
 		MemoryHotAddEnabled: config.MemoryHotAddEnabled,
 		VideoRAM:            config.VideoRAM,
+		AllowedDevices:      allowedDevices,
 		VGPUProfile:         config.VGPUProfile,
 		Firmware:            config.Firmware,
 		ForceBIOSSetup:      config.ForceBIOSSetup,

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -59,6 +59,7 @@ type FlatConfig struct {
 	MemoryHotAddEnabled             *bool                                       `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
 	VideoRAM                        *int64                                      `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
 	Displays                        *int32                                      `mapstructure:"displays" cty:"displays" hcl:"displays"`
+	AllowedDevices                  []common.FlatPCIPassthroughAllowedDevice    `mapstructure:"pci_passthrough_allowed_device" cty:"pci_passthrough_allowed_device" hcl:"pci_passthrough_allowed_device"`
 	VGPUProfile                     *string                                     `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
 	NestedHV                        *bool                                       `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
@@ -216,6 +217,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"RAM_hot_plug":                   &hcldec.AttrSpec{Name: "RAM_hot_plug", Type: cty.Bool, Required: false},
 		"video_ram":                      &hcldec.AttrSpec{Name: "video_ram", Type: cty.Number, Required: false},
 		"displays":                       &hcldec.AttrSpec{Name: "displays", Type: cty.Number, Required: false},
+		"pci_passthrough_allowed_device": &hcldec.BlockListSpec{TypeName: "pci_passthrough_allowed_device", Nested: hcldec.ObjectSpec((*common.FlatPCIPassthroughAllowedDevice)(nil).HCL2Spec())},
 		"vgpu_profile":                   &hcldec.AttrSpec{Name: "vgpu_profile", Type: cty.String, Required: false},
 		"NestedHV":                       &hcldec.AttrSpec{Name: "NestedHV", Type: cty.Bool, Required: false},
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -25,7 +25,11 @@
 - `displays` (int32) - Number of video displays. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-789C3913-1053-4850-A0F0-E29C3D32B6DA.html)
   for supported maximums. Defaults to 1.
 
-- `vgpu_profile` (string) - vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
+- `pci_passthrough_allowed_device` ([]PCIPassthroughAllowedDevice) - Configure Dynamic DirectPath I/O [PCI Passthrough](#pci-passthrough-configuration) for
+  virtual machine. See [vSphere documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-5B3CAB26-5D06-4A99-92A0-3A04C69CE64B.html)
+
+- `vgpu_profile` (string) - vGPU profile for accelerated graphics.
+  vGPU profile for accelerated graphics. See [NVIDIA GRID vGPU documentation](https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#configure-vmware-vsphere-vm-with-vgpu)
   for examples of profile names. Defaults to none.
 
 - `NestedHV` (bool) - Enable nested hardware virtualization for VM. Defaults to `false`.

--- a/docs-partials/builder/vsphere/common/PCIPassthroughAllowedDevice-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/PCIPassthroughAllowedDevice-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
+
+- `vendor_id` (string) - The sub-vendor ID of the PCI device.
+
+- `device_id` (string) - The vendor ID of the PCI device.
+
+- `sub_vendor_id` (string) - The sub-vendor ID of the PCI device.
+
+- `sub_device_id` (string) - The sub-device ID of the PCI device.
+
+<!-- End of code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; -->

--- a/docs-partials/builder/vsphere/common/PCIPassthroughAllowedDevice.mdx
+++ b/docs-partials/builder/vsphere/common/PCIPassthroughAllowedDevice.mdx
@@ -1,0 +1,36 @@
+<!-- Code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; DO NOT EDIT MANUALLY -->
+
+Dynamic DirectPath I/O is component of the Assignable Hardware framework in VMware vSphere.
+Dynamic DirectPath I/O enables the Assignable Hardware intelligence for passthrough devices and
+the hardware address of the PCIe device is no longer directly mapped to the virtual machine
+configuration. Instead, the attributes, or capabilities, are exposed to the virtual machine.
+
+# JSON
+
+```json
+
+	{
+	  "pci_passthrough_allowed_device": {
+	    "vendor_id": "8086",
+	    "device_id": "100e",
+	    "sub_device_id": "8086",
+	    "sub_vendor_id": "100e"
+	  }
+	}
+
+```
+
+# HCL2
+
+```hcl
+
+	pci_passthrough_allowed_device {
+	  "vendor_id": "8086",
+	  "device_id": "100e",
+	  "sub_device_id": "8086",
+	  "sub_vendor_id": "100e"
+	}
+
+```
+
+<!-- End of code generated from the comments of the PCIPassthroughAllowedDevice struct in builder/vsphere/common/step_hardware.go; -->

--- a/docs/builders/vsphere-iso.mdx
+++ b/docs/builders/vsphere-iso.mdx
@@ -103,6 +103,12 @@ source "vsphere-iso" "example" {
 
 @include 'builder/vsphere/common/HardwareConfig-not-required.mdx'
 
+### PCI Passthrough Configuration
+
+@include 'builder/vsphere/common/PCIPassthroughAllowedDevice.mdx'
+
+@include 'builder/vsphere/common/PCIPassthroughAllowedDevice-not-required.mdx'
+
 ## Location Configuration
 
 @include 'builder/vsphere/common/LocationConfig-not-required.mdx'
@@ -162,7 +168,6 @@ iso_paths = [
     "[] /usr/lib/vmware/isoimages/windows.iso"
 ]
 ```
-
 
 @include 'builder/vsphere/common/CDRomConfig-not-required.mdx'
 


### PR DESCRIPTION
## Description

As a part of the Assignable Hardware framework in vSphere 7, Dynamic DirectPath I/O is introduced. When configuring a virtual machine to use a PCIe device using Dynamic Direct I/O path, enables the Assignable Hardware intelligence for passthrough devices. No longer is the hardware address of the PCIe device directly mapped to the virtual machine configuration file (the .vmx file). Instead, the attributes, or capabilities, are exposed to the virtual machine.

### Example

```hcl
source "vsphere-iso" "example" {
  vcenter_server       = var.vsphere_server
  username             = var.vsphere_username
  password             = var.vsphere_password
  datacenter           = var.vsphere_datacenter
  cluster              = var.vsphere_cluster
  datastore            = var.vsphere_datastore
  network              = var.vsphere_network
  iso_paths            = [var.iso_path]
  iso_checksum         = var.iso_checksum
  iso_checksum_type    = "sha256"
  ssh_username         = var.ssh_username
  ssh_password         = var.ssh_password
  guest_os_type        = "windows9Server64Guest"
  disk_controller_type = "pvscsi"
  disk_size            = "60000"
  vm_name              = "my-vm"
  floppy_files         = ["path/to/floppyfile.txt"]
  pci_passthrough_allowed_device {
    "vendor_id": "8086",
    "device_id": "100e",
    "sub_device_id": "8086",
    "sub_vendor_id": "100e"
  }
}
```

### Tests

```console
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.419s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.157s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.149s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  0.927s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   2.654s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       0.461s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      1.103s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```

### Reference

Closes #268
