### PR TITLE
feat: improve session handling to mitigate session saturation

### DIFF
--- a/builder/vsphere/common/step_connect.go
+++ b/builder/vsphere/common/step_connect.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
@@ -64,4 +65,15 @@ func (s *StepConnect) Run(_ context.Context, state multistep.StateBag) multistep
 	return multistep.ActionContinue
 }
 
-func (s *StepConnect) Cleanup(multistep.StateBag) {}
+func (s *StepConnect) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packersdk.Ui)
+	ui.Message("Closing sessions ....")
+	driver := state.Get("driver").(driver.Driver)
+	errorRestClient, errorSoapClient := driver.Cleanup()
+	if errorRestClient != nil {
+		ui.Message("Error closing rest client session: " + errorRestClient.Error())
+	}
+	if errorSoapClient != nil {
+		ui.Message("Error closing soap client session: " + errorRestClient.Error())
+	}
+}

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -47,6 +47,7 @@ type Driver interface {
 	FindContentLibraryItem(libraryId string, name string) (*library.Item, error)
 	FindContentLibraryFileDatastorePath(isoPath string) (string, error)
 	UpdateContentLibraryItem(item *library.Item, name string, description string) error
+	Cleanup() (error, error)
 }
 
 type VCenterDriver struct {
@@ -127,6 +128,10 @@ func NewDriver(config *ConnectConfig) (Driver, error) {
 		finder:     finder,
 	}
 	return d, nil
+}
+
+func (d *VCenterDriver) Cleanup() (error, error) {
+	return d.restClient.client.Logout(d.ctx), d.client.SessionManager.Logout(d.ctx)
 }
 
 // The rest.Client requires vCenter.

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -124,3 +124,7 @@ func (d *DriverMock) FindContentLibraryFileDatastorePath(isoPath string) (string
 func (d *DriverMock) UpdateContentLibraryItem(item *library.Item, name string, description string) error {
 	return nil
 }
+
+func (d *DriverMock) Cleanup() (error, error) {
+	return nil, nil
+}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -838,7 +838,7 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 	l, err := vm.driver.FindContentLibraryByName(ovf.Target.LibraryID)
 	if err != nil {
 		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-		fmt.Printf("can not logout due to %s ", errLogout.Error())
+		log.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -854,7 +854,7 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 			err = vm.driver.UpdateContentLibraryItem(item, ovf.Spec.Name, ovf.Spec.Description)
 			if err != nil {
 				errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-				fmt.Printf("can not logout due to %s ", errLogout.Error())
+				log.Printf("can not logout due to %s ", errLogout.Error())
 				return err
 			}
 		}
@@ -882,7 +882,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	l, err := vm.driver.FindContentLibraryByName(template.Library)
 	if err != nil {
 		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-		fmt.Printf("can not logout due to %s ", errLogout.Error())
+		log.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -897,7 +897,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 		rp, err := vm.driver.FindResourcePool(template.Placement.Cluster, template.Placement.Host, template.Placement.ResourcePool)
 		if err != nil {
 			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-			fmt.Printf("can not logout due to %s ", errLogout.Error())
+			log.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.ResourcePool = rp.pool.Reference().Value
@@ -906,7 +906,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 		d, err := vm.driver.FindDatastore(template.VMHomeStorage.Datastore, template.Placement.Host)
 		if err != nil {
 			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-			fmt.Printf("can not logout due to %s ", errLogout.Error())
+			log.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.VMHomeStorage.Datastore = d.Reference().Value
@@ -923,7 +923,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 		f, err := vm.driver.FindFolder(template.Placement.Folder)
 		if err != nil {
 			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-			fmt.Printf("can not logout due to %s ", errLogout.Error())
+			log.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.Folder = f.folder.Reference().Value
@@ -932,7 +932,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 		h, err := vm.driver.FindHost(template.Placement.Host)
 		if err != nil {
 			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-			fmt.Printf("can not logout due to %s ", errLogout.Error())
+			log.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.Host = h.host.Reference().Value
@@ -942,7 +942,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	_, err = vcm.CreateTemplate(vm.driver.ctx, template)
 	if err != nil {
 		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-		fmt.Printf("can not logout due to %s ", errLogout.Error())
+		log.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 
@@ -1237,7 +1237,7 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 	l, err := vm.driver.FindContentLibraryByName(library)
 	if err != nil {
 		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
-		fmt.Printf("can not logout due to %s ", errLogout.Error())
+		log.Printf("can not logout due to %s ", errLogout.Error())
 		return nil, err
 	}
 	datastores := []string{}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -837,7 +837,8 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 
 	l, err := vm.driver.FindContentLibraryByName(ovf.Target.LibraryID)
 	if err != nil {
-		vm.driver.restClient.Logout(vm.driver.ctx)
+		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+		fmt.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -852,7 +853,8 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 		if ovf.Spec.Description != item.Description {
 			err = vm.driver.UpdateContentLibraryItem(item, ovf.Spec.Name, ovf.Spec.Description)
 			if err != nil {
-				vm.driver.restClient.Logout(vm.driver.ctx)
+				errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+				fmt.Printf("can not logout due to %s ", errLogout.Error())
 				return err
 			}
 		}
@@ -879,7 +881,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 
 	l, err := vm.driver.FindContentLibraryByName(template.Library)
 	if err != nil {
-		vm.driver.restClient.Logout(vm.driver.ctx)
+		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+		fmt.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -893,7 +896,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.ResourcePool != "" {
 		rp, err := vm.driver.FindResourcePool(template.Placement.Cluster, template.Placement.Host, template.Placement.ResourcePool)
 		if err != nil {
-			vm.driver.restClient.Logout(vm.driver.ctx)
+			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+			fmt.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.ResourcePool = rp.pool.Reference().Value
@@ -901,7 +905,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.VMHomeStorage != nil {
 		d, err := vm.driver.FindDatastore(template.VMHomeStorage.Datastore, template.Placement.Host)
 		if err != nil {
-			vm.driver.restClient.Logout(vm.driver.ctx)
+			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+			fmt.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.VMHomeStorage.Datastore = d.Reference().Value
@@ -917,7 +922,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.Folder != "" {
 		f, err := vm.driver.FindFolder(template.Placement.Folder)
 		if err != nil {
-			vm.driver.restClient.Logout(vm.driver.ctx)
+			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+			fmt.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.Folder = f.folder.Reference().Value
@@ -925,7 +931,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.Host != "" {
 		h, err := vm.driver.FindHost(template.Placement.Host)
 		if err != nil {
-			vm.driver.restClient.Logout(vm.driver.ctx)
+			errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+			fmt.Printf("can not logout due to %s ", errLogout.Error())
 			return err
 		}
 		template.Placement.Host = h.host.Reference().Value
@@ -934,7 +941,8 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	vcm := vcenter.NewManager(vm.driver.restClient.client)
 	_, err = vcm.CreateTemplate(vm.driver.ctx, template)
 	if err != nil {
-		vm.driver.restClient.Logout(vm.driver.ctx)
+		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+		fmt.Printf("can not logout due to %s ", errLogout.Error())
 		return err
 	}
 
@@ -1228,7 +1236,8 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 
 	l, err := vm.driver.FindContentLibraryByName(library)
 	if err != nil {
-		vm.driver.restClient.Logout(vm.driver.ctx)
+		errLogout := vm.driver.restClient.Logout(vm.driver.ctx)
+		fmt.Printf("can not logout due to %s ", errLogout.Error())
 		return nil, err
 	}
 	datastores := []string{}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -837,6 +837,7 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 
 	l, err := vm.driver.FindContentLibraryByName(ovf.Target.LibraryID)
 	if err != nil {
+		vm.driver.restClient.Logout(vm.driver.ctx)
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -851,6 +852,7 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 		if ovf.Spec.Description != item.Description {
 			err = vm.driver.UpdateContentLibraryItem(item, ovf.Spec.Name, ovf.Spec.Description)
 			if err != nil {
+				vm.driver.restClient.Logout(vm.driver.ctx)
 				return err
 			}
 		}
@@ -877,6 +879,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 
 	l, err := vm.driver.FindContentLibraryByName(template.Library)
 	if err != nil {
+		vm.driver.restClient.Logout(vm.driver.ctx)
 		return err
 	}
 	if l.library.Type != "LOCAL" {
@@ -890,6 +893,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.ResourcePool != "" {
 		rp, err := vm.driver.FindResourcePool(template.Placement.Cluster, template.Placement.Host, template.Placement.ResourcePool)
 		if err != nil {
+			vm.driver.restClient.Logout(vm.driver.ctx)
 			return err
 		}
 		template.Placement.ResourcePool = rp.pool.Reference().Value
@@ -897,6 +901,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.VMHomeStorage != nil {
 		d, err := vm.driver.FindDatastore(template.VMHomeStorage.Datastore, template.Placement.Host)
 		if err != nil {
+			vm.driver.restClient.Logout(vm.driver.ctx)
 			return err
 		}
 		template.VMHomeStorage.Datastore = d.Reference().Value
@@ -912,6 +917,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.Folder != "" {
 		f, err := vm.driver.FindFolder(template.Placement.Folder)
 		if err != nil {
+			vm.driver.restClient.Logout(vm.driver.ctx)
 			return err
 		}
 		template.Placement.Folder = f.folder.Reference().Value
@@ -919,6 +925,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	if template.Placement.Host != "" {
 		h, err := vm.driver.FindHost(template.Placement.Host)
 		if err != nil {
+			vm.driver.restClient.Logout(vm.driver.ctx)
 			return err
 		}
 		template.Placement.Host = h.host.Reference().Value
@@ -927,6 +934,7 @@ func (vm *VirtualMachineDriver) ImportToContentLibrary(template vcenter.Template
 	vcm := vcenter.NewManager(vm.driver.restClient.client)
 	_, err = vcm.CreateTemplate(vm.driver.ctx, template)
 	if err != nil {
+		vm.driver.restClient.Logout(vm.driver.ctx)
 		return err
 	}
 
@@ -1220,6 +1228,7 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 
 	l, err := vm.driver.FindContentLibraryByName(library)
 	if err != nil {
+		vm.driver.restClient.Logout(vm.driver.ctx)
 		return nil, err
 	}
 	datastores := []string{}
@@ -1231,7 +1240,7 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 		}
 		datastores = append(datastores, name)
 	}
-	return datastores, nil
+	return datastores, vm.driver.restClient.Logout(vm.driver.ctx)
 }
 
 func findNetworkAdapter(l object.VirtualDeviceList) (types.BaseVirtualEthernetCard, error) {


### PR DESCRIPTION
vSphere CLS API has a limit of 150 concurrents session users. Each session is released automatically after 1 hour.
The Driver is creating new sessions in every packer execution through `client.SessionManager.Login(ctx, credentials)` method, but not closing it.

The changes are mainly:
* Create a new method in Driver Interface to logout from vSphere soap and rest client.
* In the cleanup of `step_connect.go` retrieve the Driver from the state and do the Driver cleanup also.
* In vm.go, this PR adds `logout` when something fails. 



Closes #217

