### PR TITLE
fix: log level messages closing sessions

### DIFF
--- a/builder/vsphere/common/step_connect.go
+++ b/builder/vsphere/common/step_connect.go
@@ -9,6 +9,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -71,9 +72,9 @@ func (s *StepConnect) Cleanup(state multistep.StateBag) {
 	driver := state.Get("driver").(driver.Driver)
 	errorRestClient, errorSoapClient := driver.Cleanup()
 	if errorRestClient != nil {
-		ui.Message("Error closing rest client session: " + errorRestClient.Error())
+		log.Printf("[WARN] Couldn't close rest client session. Could be already closed: %s", errorRestClient.Error())
 	}
 	if errorSoapClient != nil {
-		ui.Message("Error closing soap client session: " + errorRestClient.Error())
+		log.Printf("[WARN] Couldn't close rest client session. %s", errorRestClient.Error())
 	}
 }


### PR DESCRIPTION
The cleanup method executed at the end of the process calls always an API REST method to delete the active session through a driver's logout:
`DELETE https://${vSphere}/rest/com/vmware/cis/session`

If this the logout is called twice for a user_id session, it shows in the UI an error in the step_connect. 
The first time, the session is cleaned, but the second gives an `401 Unauthorized`, doing nothing. This call is innocuous.

In the cleanup method of step_connect, whenever there is an problem calling to the API REST it is showed to the user, giving a false positive error.

The aim of this PR is to dump the message to the log as a warning, and don't show in the UI.


Closes #286


