### PR TITLE
bump go 1.18 to 1.19

### DIFF
--- a/builder/vsphere/common/step_download_test.go
+++ b/builder/vsphere/common/step_download_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
-/// create mock step
+// / create mock step
 type MockDownloadStep struct {
 	RunCalled bool
 }
@@ -28,7 +28,7 @@ func (s *MockDownloadStep) UseSourceToFindCacheTarget(source string) (*url.URL, 
 	return nil, "sometarget", nil
 }
 
-/// start tests
+// / start tests
 func downloadStepState(exists bool) *multistep.BasicStateBag {
 	state := basicStateBag(nil)
 	dsMock := &driver.DatastoreMock{

--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -37,22 +37,28 @@ import (
 // In JSON:
 // ```json
 // ...
-//   "vm_name": "example-ubuntu",
+//
+//	"vm_name": "example-ubuntu",
+//
 // ...
-//   "export": {
-//     "force": true,
-//     "output_directory": "./output_vsphere"
-//   },
+//
+//	"export": {
+//	  "force": true,
+//	  "output_directory": "./output_vsphere"
+//	},
+//
 // ```
 // In HCL2:
 // ```hcl
-//   # ...
-//   vm_name = "example-ubuntu"
-//   # ...
-//   export {
-//     force = true
-//     output_directory = "./output_vsphere"
-//   }
+//
+//	# ...
+//	vm_name = "example-ubuntu"
+//	# ...
+//	export {
+//	  force = true
+//	  output_directory = "./output_vsphere"
+//	}
+//
 // ```
 // The above configuration would create the following files:
 //

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -16,71 +16,79 @@ import (
 //
 // In JSON:
 // ```json
-//   "storage": [
-//     {
-//       "disk_size": 15000
-//     },
-//     {
-//       "disk_size": 20000,
-//       "disk_thin_provisioned": true
-//     }
-//   ],
+//
+//	"storage": [
+//	  {
+//	    "disk_size": 15000
+//	  },
+//	  {
+//	    "disk_size": 20000,
+//	    "disk_thin_provisioned": true
+//	  }
+//	],
+//
 // ```
 // In HCL2:
 // ```hcl
-//   storage {
-//       disk_size = 15000
-//   }
-//   storage {
-//       disk_size = 20000
-//       disk_thin_provisioned = true
-//   }
+//
+//	storage {
+//	    disk_size = 15000
+//	}
+//	storage {
+//	    disk_size = 20000
+//	    disk_thin_provisioned = true
+//	}
+//
 // ```
 //
 // Example that creates 2 pvscsi controllers and adds 2 disks to each one:
 //
 // In JSON:
 // ```json
-//   "disk_controller_type": ["pvscsi", "pvscsi"],
-//   "storage": [
-//     {
-//       "disk_size": 15000,
-//       "disk_controller_index": 0
-//     },
-//     {
-//       "disk_size": 15000,
-//       "disk_controller_index": 0
-//     },
-//     {
-//       "disk_size": 15000,
-//       "disk_controller_index": 1
-//     },
-//     {
-//       "disk_size": 15000,
-//       "disk_controller_index": 1
-//     }
-//   ],
+//
+//	"disk_controller_type": ["pvscsi", "pvscsi"],
+//	"storage": [
+//	  {
+//	    "disk_size": 15000,
+//	    "disk_controller_index": 0
+//	  },
+//	  {
+//	    "disk_size": 15000,
+//	    "disk_controller_index": 0
+//	  },
+//	  {
+//	    "disk_size": 15000,
+//	    "disk_controller_index": 1
+//	  },
+//	  {
+//	    "disk_size": 15000,
+//	    "disk_controller_index": 1
+//	  }
+//	],
+//
 // ```
 //
 // In HCL2:
 // ```hcl
-//   disk_controller_type = ["pvscsi", "pvscsi"]
-//   storage {
-//      disk_size = 15000,
-//      disk_controller_index = 0
-//   }
-//   storage {
-//      disk_size = 15000
-//      disk_controller_index = 0
-//   }
-//   storage {
-//      disk_size = 15000
-//      disk_controller_index = 1
-//   }
-//   storage {
-//      disk_size = 15000
-//      disk_controller_index = 1
-//   }
+//
+//	disk_controller_type = ["pvscsi", "pvscsi"]
+//	storage {
+//	   disk_size = 15000,
+//	   disk_controller_index = 0
+//	}
+//	storage {
+//	   disk_size = 15000
+//	   disk_controller_index = 0
+//	}
+//	storage {
+//	   disk_size = 15000
+//	   disk_controller_index = 1
+//	}
+//	storage {
+//	   disk_size = 15000
+//	   disk_controller_index = 1
+//	}
+//
 // ```
 type DiskConfig struct {
 	// The size of the disk in MB.

--- a/builder/vsphere/driver/driver_test.go
+++ b/builder/vsphere/driver/driver_test.go
@@ -94,7 +94,7 @@ func (s *VCenterSimulator) Close() {
 	}
 }
 
-//Simulator shortcut to choose any pre created VM.
+// Simulator shortcut to choose any pre created VM.
 func (s *VCenterSimulator) ChooseSimulatorPreCreatedVM() (VirtualMachine, *simulator.VirtualMachine) {
 	machine := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	ref := machine.Reference()
@@ -102,7 +102,7 @@ func (s *VCenterSimulator) ChooseSimulatorPreCreatedVM() (VirtualMachine, *simul
 	return vm, machine
 }
 
-//Simulator shortcut to choose any pre created Datastore.
+// Simulator shortcut to choose any pre created Datastore.
 func (s *VCenterSimulator) ChooseSimulatorPreCreatedDatastore() (Datastore, *simulator.Datastore) {
 	ds := simulator.Map.Any("Datastore").(*simulator.Datastore)
 	ref := ds.Reference()
@@ -110,7 +110,7 @@ func (s *VCenterSimulator) ChooseSimulatorPreCreatedDatastore() (Datastore, *sim
 	return datastore, ds
 }
 
-//Simulator shortcut to choose any pre created Host.
+// Simulator shortcut to choose any pre created Host.
 func (s *VCenterSimulator) ChooseSimulatorPreCreatedHost() (*Host, *simulator.HostSystem) {
 	h := simulator.Map.Any("HostSystem").(*simulator.HostSystem)
 	ref := h.Reference()

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -25,27 +25,31 @@ import (
 //
 // In JSON:
 // ```json
-//   "network_adapters": [
-//     {
-//       "network": "VM Network",
-//       "network_card": "vmxnet3"
-//     },
-//     {
-//       "network": "OtherNetwork",
-//       "network_card": "vmxnet3"
-//     }
-//   ],
+//
+//	"network_adapters": [
+//	  {
+//	    "network": "VM Network",
+//	    "network_card": "vmxnet3"
+//	  },
+//	  {
+//	    "network": "OtherNetwork",
+//	    "network_card": "vmxnet3"
+//	  }
+//	],
+//
 // ```
 // In HCL2:
 // ```hcl
-//   network_adapters {
-//       network = "VM Network"
-//       network_card = "vmxnet3"
-//   }
-//   network_adapters {
-//       network = "OtherNetwork"
-//       network_card = "vmxnet3"
-//   }
+//
+//	network_adapters {
+//	    network = "VM Network"
+//	    network_card = "vmxnet3"
+//	}
+//	network_adapters {
+//	    network = "OtherNetwork"
+//	    network_card = "vmxnet3"
+//	}
+//
 // ```
 type NIC struct {
 	// Set the network in which the VM will be connected to. If no network is

--- a/docs-partials/builder/vsphere/common/DiskConfig.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig.mdx
@@ -6,71 +6,79 @@ Example that will create a 15GB and a 20GB disk on the VM. The second disk will 
 
 In JSON:
 ```json
-  "storage": [
-    {
-      "disk_size": 15000
-    },
-    {
-      "disk_size": 20000,
-      "disk_thin_provisioned": true
-    }
-  ],
+
+	"storage": [
+	  {
+	    "disk_size": 15000
+	  },
+	  {
+	    "disk_size": 20000,
+	    "disk_thin_provisioned": true
+	  }
+	],
+
 ```
 In HCL2:
 ```hcl
-  storage {
-      disk_size = 15000
-  }
-  storage {
-      disk_size = 20000
-      disk_thin_provisioned = true
-  }
+
+	storage {
+	    disk_size = 15000
+	}
+	storage {
+	    disk_size = 20000
+	    disk_thin_provisioned = true
+	}
+
 ```
 
 Example that creates 2 pvscsi controllers and adds 2 disks to each one:
 
 In JSON:
 ```json
-  "disk_controller_type": ["pvscsi", "pvscsi"],
-  "storage": [
-    {
-      "disk_size": 15000,
-      "disk_controller_index": 0
-    },
-    {
-      "disk_size": 15000,
-      "disk_controller_index": 0
-    },
-    {
-      "disk_size": 15000,
-      "disk_controller_index": 1
-    },
-    {
-      "disk_size": 15000,
-      "disk_controller_index": 1
-    }
-  ],
+
+	"disk_controller_type": ["pvscsi", "pvscsi"],
+	"storage": [
+	  {
+	    "disk_size": 15000,
+	    "disk_controller_index": 0
+	  },
+	  {
+	    "disk_size": 15000,
+	    "disk_controller_index": 0
+	  },
+	  {
+	    "disk_size": 15000,
+	    "disk_controller_index": 1
+	  },
+	  {
+	    "disk_size": 15000,
+	    "disk_controller_index": 1
+	  }
+	],
+
 ```
 
 In HCL2:
 ```hcl
-  disk_controller_type = ["pvscsi", "pvscsi"]
-  storage {
-     disk_size = 15000,
-     disk_controller_index = 0
-  }
-  storage {
-     disk_size = 15000
-     disk_controller_index = 0
-  }
-  storage {
-     disk_size = 15000
-     disk_controller_index = 1
-  }
-  storage {
-     disk_size = 15000
-     disk_controller_index = 1
-  }
+
+	disk_controller_type = ["pvscsi", "pvscsi"]
+	storage {
+	   disk_size = 15000,
+	   disk_controller_index = 0
+	}
+	storage {
+	   disk_size = 15000
+	   disk_controller_index = 0
+	}
+	storage {
+	   disk_size = 15000
+	   disk_controller_index = 1
+	}
+	storage {
+	   disk_size = 15000
+	   disk_controller_index = 1
+	}
+
 ```
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/ExportConfig.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig.mdx
@@ -7,22 +7,28 @@ Example usage:
 In JSON:
 ```json
 ...
-  "vm_name": "example-ubuntu",
+
+	"vm_name": "example-ubuntu",
+
 ...
-  "export": {
-    "force": true,
-    "output_directory": "./output_vsphere"
-  },
+
+	"export": {
+	  "force": true,
+	  "output_directory": "./output_vsphere"
+	},
+
 ```
 In HCL2:
 ```hcl
-  # ...
-  vm_name = "example-ubuntu"
-  # ...
-  export {
-    force = true
-    output_directory = "./output_vsphere"
-  }
+
+	# ...
+	vm_name = "example-ubuntu"
+	# ...
+	export {
+	  force = true
+	  output_directory = "./output_vsphere"
+	}
+
 ```
 The above configuration would create the following files:
 

--- a/docs-partials/builder/vsphere/iso/NIC.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC.mdx
@@ -7,27 +7,31 @@ Example that creates two network adapters:
 
 In JSON:
 ```json
-  "network_adapters": [
-    {
-      "network": "VM Network",
-      "network_card": "vmxnet3"
-    },
-    {
-      "network": "OtherNetwork",
-      "network_card": "vmxnet3"
-    }
-  ],
+
+	"network_adapters": [
+	  {
+	    "network": "VM Network",
+	    "network_card": "vmxnet3"
+	  },
+	  {
+	    "network": "OtherNetwork",
+	    "network_card": "vmxnet3"
+	  }
+	],
+
 ```
 In HCL2:
 ```hcl
-  network_adapters {
-      network = "VM Network"
-      network_card = "vmxnet3"
-  }
-  network_adapters {
-      network = "OtherNetwork"
-      network_card = "vmxnet3"
-  }
+
+	network_adapters {
+	    network = "VM Network"
+	    network_card = "vmxnet3"
+	}
+	network_adapters {
+	    network = "OtherNetwork"
+	    network_card = "vmxnet3"
+	}
+
 ```
 
 <!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/packer-plugin-vsphere
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/go-cmp v0.5.9
@@ -16,7 +16,6 @@ require (
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
-	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/controller-runtime v0.14.6
 )
 
@@ -136,6 +135,7 @@ require (
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
+	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect


### PR DESCRIPTION
- github: remove test-plugin-example workflow
- go.mod: bump go version from 1.18 to 1.19
