### PR TITLE
🚧 feat: add vapp properties

### DIFF
--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -312,6 +312,8 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 - `destroy` (bool) - Destroy the virtual machine after the build completes.
   Defaults to `false`.
 
+- `vapp` (vAppConfig) - Set the vApp properties for a virtual machine.
+
 <!-- End of code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; -->
 
 
@@ -668,8 +670,8 @@ boot time.
 
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-If no adapter is defined, network tasks (communicators, most provisioners)
-will not work, so it's advised to define one.
+Defines a Network Adapter
+If no adapter is defined, network tasks (communicators, most provisioners) won't work, so it's advised to define one.
 
 Example configuration with two network adapters:
 

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -132,18 +132,19 @@ type NIC struct {
 }
 
 type CreateConfig struct {
-	Annotation    string
-	Name          string
-	Folder        string
-	Cluster       string
-	Host          string
-	ResourcePool  string
-	Datastore     string
-	GuestOS       string // example: otherGuest
-	NICs          []NIC
-	USBController []string
-	Version       uint // example: 10
-	StorageConfig StorageConfig
+	Annotation     string
+	Name           string
+	Folder         string
+	Cluster        string
+	Host           string
+	ResourcePool   string
+	Datastore      string
+	GuestOS        string // example: otherGuest
+	NICs           []NIC
+	USBController  []string
+	Version        uint // example: 10
+	StorageConfig  StorageConfig
+	VAppProperties map[string]string
 }
 
 func (d *VCenterDriver) NewVM(ref *types.ManagedObjectReference) VirtualMachine {

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -41,6 +41,7 @@ type FlatConfig struct {
 	USBController                   []string                                    `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
 	Notes                           *string                                     `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	Destroy                         *bool                                       `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	VAppConfig                      *FlatvAppConfig                             `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 	VMName                          *string                                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	Folder                          *string                                     `mapstructure:"folder" cty:"folder" hcl:"folder"`
 	Cluster                         *string                                     `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
@@ -200,6 +201,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"usb_controller":                 &hcldec.AttrSpec{Name: "usb_controller", Type: cty.List(cty.String), Required: false},
 		"notes":                          &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"destroy":                        &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
+		"vapp":                           &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"folder":                         &hcldec.AttrSpec{Name: "folder", Type: cty.String, Required: false},
 		"cluster":                        &hcldec.AttrSpec{Name: "cluster", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/step_create.hcl2spec.go
+++ b/builder/vsphere/iso/step_create.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatCreateConfig struct {
 	USBController      []string                `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
 	Notes              *string                 `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	Destroy            *bool                   `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	VAppConfig         *FlatvAppConfig         `mapstructure:"vapp" cty:"vapp" hcl:"vapp"`
 }
 
 // FlatMapstructure returns a new FlatCreateConfig.
@@ -41,6 +42,7 @@ func (*FlatCreateConfig) HCL2Spec() map[string]hcldec.Spec {
 		"usb_controller":       &hcldec.AttrSpec{Name: "usb_controller", Type: cty.List(cty.String), Required: false},
 		"notes":                &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"destroy":              &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
+		"vapp":                 &hcldec.BlockSpec{TypeName: "vapp", Nested: hcldec.ObjectSpec((*FlatvAppConfig)(nil).HCL2Spec())},
 	}
 	return s
 }
@@ -70,6 +72,29 @@ func (*FlatNIC) HCL2Spec() map[string]hcldec.Spec {
 		"network_card": &hcldec.AttrSpec{Name: "network_card", Type: cty.String, Required: false},
 		"mac_address":  &hcldec.AttrSpec{Name: "mac_address", Type: cty.String, Required: false},
 		"passthrough":  &hcldec.AttrSpec{Name: "passthrough", Type: cty.Bool, Required: false},
+	}
+	return s
+}
+
+// FlatvAppConfig is an auto-generated flat version of vAppConfig.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatvAppConfig struct {
+	Properties map[string]string `mapstructure:"properties" cty:"properties" hcl:"properties"`
+}
+
+// FlatMapstructure returns a new FlatvAppConfig.
+// FlatvAppConfig is an auto-generated flat version of vAppConfig.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*vAppConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatvAppConfig)
+}
+
+// HCL2Spec returns the hcl spec of a vAppConfig.
+// This spec is used by HCL to read the fields of vAppConfig.
+// The decoded values from this spec will then be applied to a FlatvAppConfig.
+func (*FlatvAppConfig) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"properties": &hcldec.AttrSpec{Name: "properties", Type: cty.Map(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -401,6 +401,7 @@ func driverCreateConfig(config *CreateConfig, location *common.LocationConfig) *
 	}
 
 	return &driver.CreateConfig{
+		VAppProperties: config.VAppConfig.Properties,
 		StorageConfig: driver.StorageConfig{
 			DiskControllerType: config.StorageConfig.DiskControllerType,
 			Storage:            disks,

--- a/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -39,4 +39,6 @@
 - `destroy` (bool) - Destroy the virtual machine after the build completes.
   Defaults to `false`.
 
+- `vapp` (vAppConfig) - Set the vApp properties for a virtual machine.
+
 <!-- End of code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-If no adapter is defined, network tasks (communicators, most provisioners)
-will not work, so it's advised to define one.
+Defines a Network Adapter
+If no adapter is defined, network tasks (communicators, most provisioners) won't work, so it's advised to define one.
 
 Example configuration with two network adapters:
 

--- a/docs-partials/builder/vsphere/iso/vAppConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/vAppConfig-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the vAppConfig struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
+
+- `properties` (map[string]string) - Set values for the available vApp Properties to supply configuration parameters to a virtual machine cloned from
+  a template that came from an imported OVF or OVA file.
+  
+  -> **Note:** The only supported usage path for vApp properties is for existing user-configurable keys.
+  These generally come from an existing template that was created from an imported OVF or OVA file.
+  You cannot set values for vApp properties on virtual machines created from scratch,
+  virtual machines lacking a vApp configuration, or on property keys that do not exist.
+
+<!-- End of code generated from the comments of the vAppConfig struct in builder/vsphere/iso/step_create.go; -->


### PR DESCRIPTION
This pull request introduces support for vApp properties in the vSphere ISO builder. The changes include updates to the configuration structures, documentation, and relevant functions to handle vApp properties.

Support for vApp Properties:

* Added `vAppConfig` struct to define vApp properties for virtual machines. (`builder/vsphere/iso/step_create.go`) [[1]](diffhunk://#diff-d5153ce3b0321af12537b31ee71ba82155dc1a8ee7ae028dfe9071dec0aa2fc9R22-R32) [[2]](diffhunk://#diff-d5153ce3b0321af12537b31ee71ba82155dc1a8ee7ae028dfe9071dec0aa2fc9R113-R114)
* Updated `CreateConfig` and `FlatCreateConfig` to include `VAppConfig` for setting vApp properties. (`builder/vsphere/driver/vm.go`) [[1]](diffhunk://#diff-f81447593c9b389c1718a91e14307807b280b36f7c76f64a150637d6faba312bR136) (`builder/vsphere/iso/config.hcl2spec.go`) [[2]](diffhunk://#diff-2fd27dfc0b7ffb82b2fce57af1eb5d95c320069e1625bef83964d01c76b57d63R44) (`builder/vsphere/iso/step_create.hcl2spec.go`) [[3]](diffhunk://#diff-9c410a3d0f75d5d0aff60096ee4a43737c4a3e896167785848f4d72250f89c93R22)
* Modified `HCL2Spec` functions to handle the new `vAppConfig` block. (`builder/vsphere/iso/config.hcl2spec.go`) [[1]](diffhunk://#diff-2fd27dfc0b7ffb82b2fce57af1eb5d95c320069e1625bef83964d01c76b57d63R197) (`builder/vsphere/iso/step_create.hcl2spec.go`) [[2]](diffhunk://#diff-9c410a3d0f75d5d0aff60096ee4a43737c4a3e896167785848f4d72250f89c93R45) [[3]](diffhunk://#diff-9c410a3d0f75d5d0aff60096ee4a43737c4a3e896167785848f4d72250f89c93R78-R100)
* Updated the `Run` method in `StepCreateVM` to pass `VAppProperties` to the `CreateVM` function. (`builder/vsphere/iso/step_create.go`)
* Added generated documentation for `vAppConfig` and updated existing documentation to include the new configuration option. (`.web-docs/components/builder/vsphere-iso/README.md`) [[1]](diffhunk://#diff-6752170ad5617582d4773e4abc3c9a943a0685112b0b5591bd80239ee6aa08deR835-R836) (`docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx`) [[2]](diffhunk://#diff-7b3e3cdc97cca456bbd4308cb3151abd36adba9d85a95752cbfdcffbf2d437bcR34-R35) (`docs-partials/builder/vsphere/iso/vAppConfig-not-required.mdx`) [[3]](diffhunk://#diff-ee5d72a4e2069d0853cb117c52df137480f4d6e8b32a486eea095ae513e20b4bR1-R11)