### PR TITLE
web-docs: place ISO before clone/supervisor

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -6,13 +6,13 @@ integration {
   identifier = "packer/hashicorp/vsphere"
   component {
     type = "builder"
-    name = "vSphere Clone"
-    slug = "vsphere-clone"
+    name = "vSphere ISO"
+    slug = "vsphere-iso"
   }
   component {
     type = "builder"
-    name = "vSphere ISO"
-    slug = "vsphere-iso"
+    name = "vSphere Clone"
+    slug = "vsphere-clone"
   }
   component {
     type = "builder"


### PR DESCRIPTION
Since ISO and clone are generally more used, and for consistency compared to the components paragraph, we reorganise the metadata/ToC for the components of the plugin.