### PR TITLE
fix: 224

### DIFF
--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -29,7 +29,7 @@ func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepM
 	remoteFolder := "Discovered virtual machine"
 	//if post-processor config folder is not null, use the folder as remoteFolder
 	if p.config.Folder != "" {
-	    remoteFolder = p.config.Folder
+	    remoteFolder := p.config.Folder
 	}
 	vmname := artifact.Id()
 

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -29,7 +29,7 @@ func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepM
 	remoteFolder := "Discovered virtual machine"
 	//if post-processor config folder is not null, use the folder as remoteFolder
 	if p.config.Folder != "" {
-	    remoteFolder = p.config.Folder
+		remoteFolder = p.config.Folder
 	}
 	vmname := artifact.Id()
 

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -27,6 +27,10 @@ type stepMarkAsTemplate struct {
 
 func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepMarkAsTemplate {
 	remoteFolder := "Discovered virtual machine"
+	//if post-processor config folder is not null, use the folder as remoteFolder
+	if p.config.Folder != "" {
+	    remoteFolder = p.config.Folder
+	}
 	vmname := artifact.Id()
 
 	if artifact.BuilderId() == vsphere.BuilderId {

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -29,7 +29,7 @@ func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepM
 	remoteFolder := "Discovered virtual machine"
 	//if post-processor config folder is not null, use the folder as remoteFolder
 	if p.config.Folder != "" {
-	    remoteFolder := p.config.Folder
+	    remoteFolder = p.config.Folder
 	}
 	vmname := artifact.Id()
 


### PR DESCRIPTION
Use the folder defined in the post-processor packer config as a remoteFolder when marking the VM as a template.
```hcl
post-processors {
      post-processor "vsphere-template"{
          host              = "vcenter.example.com"
          insecure        = false
          username       = "admin@vsphere.local"
          password       = "testpwd"
          datacenter     = "dc-01"   
          folder              = "/templates/"
      }
}
```


This PR resolves open issue #224

Closes #224

