### PR TITLE
Update Supervisor test to skip output from retry

### DIFF
--- a/builder/vsphere/supervisor/step_watch_source.go
+++ b/builder/vsphere/supervisor/step_watch_source.go
@@ -197,10 +197,7 @@ func (s *StepWatchSource) getVMIngressIP(ctx context.Context, logger *PackerLogg
 			return 5 * time.Second
 		},
 		ShouldRetry: func(err error) bool {
-			if errors.Is(err, context.DeadlineExceeded) {
-				return false
-			}
-			return true
+			return !errors.Is(err, context.DeadlineExceeded)
 		},
 	}.Run(ctx, func(ctx context.Context) error {
 

--- a/builder/vsphere/supervisor/utils_test.go
+++ b/builder/vsphere/supervisor/utils_test.go
@@ -57,15 +57,24 @@ func newBasicTestState(writer *bytes.Buffer) *multistep.BasicStateBag {
 
 func checkOutputLines(t *testing.T, writer *bytes.Buffer, expectedLines []string) {
 	for _, expected := range expectedLines {
-		actual, err := writer.ReadString('\n')
-		actual = strings.TrimSpace(actual)
-		if err != nil {
-			t.Fatalf("Failed to read line from writer, err: %s", err.Error())
-		}
-		if actual != expected {
+		if actual := readLine(t, writer); actual != expected {
 			t.Fatalf("Expected output %q but got %q", expected, actual)
 		}
 	}
+}
+
+func readLine(t *testing.T, writer *bytes.Buffer) string {
+	actual, err := writer.ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read line from writer, err: %s", err.Error())
+	}
+
+	// Skip "continue checking" line as it can be printed from the retry.
+	if strings.Contains(actual, "continue checking") {
+		readLine(t, writer)
+	}
+
+	return strings.TrimSpace(actual)
 }
 
 func getTestKubeconfigFile(t *testing.T, namespace string) *os.File {


### PR DESCRIPTION
This PR updates the Supervisor test util function `checkOutputLines` to skip the current actual output if it contains "continue checking" line. This is to avoid failing the test in `step_watch_source.go` where the VM ingress IP may not be set immediately, causing `retry.Config` to output "continue checking" and retry.

Testing Done:
```console
$ go test -count=100 -run ^TestWatchSource_Run$ github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor 
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   100.849s
```