### PR TITLE
chore(deps): bump `github.com/vmware/govmomi` from 0.29.0 to 0.33.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
       interval: "daily"
     allow:
       - dependency-name: "github.com/hashicorp/packer-plugin-sdk"
-
+      - dependency-name: "github.com/vmware/govmomi"

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -95,7 +95,7 @@ func (d *VCenterDriver) UpdateContentLibraryItem(item *library.Item, name string
 	item.Patch(&library.Item{
 		ID:          item.ID,
 		Name:        name,
-		Description: description,
+		Description: &description,
 	})
 	return lm.UpdateLibraryItem(d.ctx, item)
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -850,7 +850,7 @@ func (vm *VirtualMachineDriver) ImportOvfToContentLibrary(ovf vcenter.OVF) error
 	if err == nil {
 		// Updates existing library item
 		ovf.Target.LibraryItemID = item.ID
-		if ovf.Spec.Description != item.Description {
+		if item.Description != nil && ovf.Spec.Description != *item.Description {
 			err = vm.driver.UpdateContentLibraryItem(item, ovf.Spec.Name, ovf.Spec.Description)
 			if err != nil {
 				log.Printf("cannot update content library: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/hashicorp/packer-plugin-vsphere
 go 1.19
 
 require (
-	github.com/google/go-cmp v0.5.9
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/hcl/v2 v2.16.2
 	github.com/hashicorp/packer-plugin-sdk v0.5.1
 	github.com/pkg/errors v0.9.1
 	github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec5758f097
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1
-	github.com/vmware/govmomi v0.29.0
+	github.com/vmware/govmomi v0.33.1
 	github.com/zclconf/go-cty v1.12.1
 	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -574,8 +574,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
 github.com/ugorji/go/codec v1.2.6 h1:7kbGefxLoDBuYXOms4yD7223OpNMMPNPZxXk5TvFcyQ=
@@ -589,8 +589,8 @@ github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec57
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec5758f097/go.mod h1:S0HMBgdo3S/0a5hwq+Ya4XZI2aEDtGkSGeojU1cINOg=
 github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1 h1:krW4K3Vj8DkVqLMUOlW1OMLr1BY9Lg+PLZ7mAzlJz/A=
 github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1/go.mod h1:vauVboD3sQxP+pb28TnI9wfrj+0nH2zSEc9Q7AzWJ54=
-github.com/vmware/govmomi v0.29.0 h1:SHJQ7DUc4fltFZv16znJNGHR1/XhiDK5iKxm2OqwkuU=
-github.com/vmware/govmomi v0.29.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
+github.com/vmware/govmomi v0.33.1 h1:qS2VpEBd/WLbzLO5McI6h5o5zaKsrezUxRY5r9jkW8A=
+github.com/vmware/govmomi v0.33.1/go.mod h1:QuzWGiEMA/FYlu5JXKjytiORQoxv2hTHdS2lWnIqKMM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
- Bumps `github.com/vmware/govmomi` from 0.29.0 to 0.33.1.
- Added `github.com/vmware/govmomi` to dependabot dependency checks.
- Address changes needed in `vm.go` and `library.go` for the content library items and tested.

> **Notes**
>
>`github.com/vmware/govmomi 0.33.1`
>
> <details>
> <summary>Release Notes</summary>
> <p><em>Sourced from <a href="https://github.com/vmware/govmomi/releases">github.com/vmware/govmomi's releases</a>.</em></p>
> <blockquote>
> <h2>v0.33.0</h2>
> <p><!-- raw HTML omitted --><!-- raw HTML omitted --></p>
> <h2><a href="https://github.com/vmware/govmomi/compare/v0.32.0...v0.33.0">Release v0.33.0</a></h2>
> <blockquote>
> <p>Release Date: 2023-10-25</p>
> </blockquote>
> <h3>💫 <code>govc</code> (CLI)</h3>
> <ul>
> <li>[5264e839]	add cluster.change '-ha-admission-control-enabled' flag</li>
> <li>[3bcaf429]	add option to enable hidden properties in import.{spec,ova} (<a href="https://redirect.github.com/vmware/govmomi/issues/3111">#3111</a>)</li>
> </ul>
> <h3>💫 <code>vcsim</code> (Simulator)</h3>
> <ul>
> <li>[db0ba920]	Handle prepare guest operations when svm is nil</li>
> <li>[0754d758]	fix ModifyListView to return unresolved references</li>
> <li>[7f3a0708]	Remove extra devices in OVF Deploy w/ ConfigSpec</li>
> </ul>
> <h3>🧹 Chore</h3>
> <ul>
> <li>[f3c1fca9]	Update version.go for v0.33.0</li>
> <li>[675eebd2]	remove refs to deprecated io/ioutil</li>
> </ul>
> <h3>⚠️ BREAKING</h3>
> <p>fix ModifyListView to return unresolved references [0754d758]:
> api: view.ListView.{Add,Remove,Reset} methods now return unresolved references</p>
> <h3>📖 Commits</h3>
> <ul>
> <li>[f3c1fca9]	chore: Update version.go for v0.33.0</li>
> <li>[19726dc6]	Add functionality for checking whether the provided thumbprint is known to the soap client</li>
> <li>[5264e839]	govc: add cluster.change '-ha-admission-control-enabled' flag</li>
> <li>[db0ba920]	vcsim: Handle prepare guest operations when svm is nil</li>
> <li>[0434fd26]	vapi: add support for OperationID header</li>
> <li>[0754d758]	vcsim: fix ModifyListView to return unresolved references</li>
> <li>[5569c012]	build(deps): bump github.com/google/go-cmp from 0.5.9 to 0.6.0</li>
> <li>[babee198]	build(deps): bump chuhlomin/render-template from 1.7 to 1.8</li>
> <li>[7f3a0708]	vcsim: Remove extra devices in OVF Deploy w/ ConfigSpec</li>
> <li>[3bcaf429]	govc: add option to enable hidden properties in import.{spec,ova} (<a href="https://redirect.github.com/vmware/govmomi/issues/3111">#3111</a>)</li>
> <li>[675eebd2]	chore: remove refs to deprecated io/ioutil</li>
> </ul>
> </blockquote>
> </details>
> <details>
> <summary>Commits</summary>
> <ul>
> <li><a href="https://github.com/vmware/govmomi/commit/6de69ad0cd33a85545b15c7d201745f2fd807dd1"><code>6de69ad</code></a> Add additional PBM methods</li>
> <li><a href="https://github.com/vmware/govmomi/commit/f3c1fca929db8a8289c27533de1fdffaf72cfba3"><code>f3c1fca</code></a> chore: Update version.go for v0.33.0</li>
> <li><a href="https://github.com/vmware/govmomi/commit/fc117d63069edb062c3fba246554fdb15697ea75"><code>fc117d6</code></a> Merge pull request <a href="https://redirect.github.com/vmware/govmomi/issues/3265">#3265</a> from HakanSunay/topic/hhalil/thumbprint-check</li>
> <li><a href="https://github.com/vmware/govmomi/commit/19726dc640c78b7576551f69ff5241158e5406b1"><code>19726dc</code></a> Add functionality for checking whether the provided thumbprint is known to th...</li>
> <li><a href="https://github.com/vmware/govmomi/commit/244e3ac4bfc31edacd09f191e6a5411ad0c15064"><code>244e3ac</code></a> Merge pull request <a href="https://redirect.github.com/vmware/govmomi/issues/3261">#3261</a> from mayankbh/topic/bmayank/prepare-guest-op-fix</li>
> <li><a href="https://github.com/vmware/govmomi/commit/846db5af7c3c849d02cfd4a26761edef21d7489c"><code>846db5a</code></a> Merge pull request <a href="https://redirect.github.com/vmware/govmomi/issues/3262">#3262</a> from dougm/ha-admission-control</li>
> <li><a href="https://github.com/vmware/govmomi/commit/5264e839fb89f03e9ea98c3c3960a0e19fe8371c"><code>5264e83</code></a> govc: add cluster.change '-ha-admission-control-enabled' flag</li>
> <li><a href="https://github.com/vmware/govmomi/commit/db0ba9202af0b7a14b977df795c747c72dcf327a"><code>db0ba92</code></a> vcsim: Handle prepare guest operations when svm is nil</li>
> <li><a href="https://github.com/vmware/govmomi/commit/c4befe0bafa6d88a27e80183015e90968bb585c0"><code>c4befe0</code></a> Merge pull request <a href="https://redirect.github.com/vmware/govmomi/issues/3259">#3259</a> from dougm/vapi-operation-id</li>
> <li><a href="https://github.com/vmware/govmomi/commit/0434fd262e1470d6db205daa784eee3524dcd70e"><code>0434fd2</code></a> vapi: add support for OperationID header</li>
> <li>Additional commits viewable in <a href="https://github.com/vmware/govmomi/compare/v0.32.0...v0.33.1">compare view</a></li>
> </ul>
> </details>

