### PR TITLE
fix: update vsphere-supervisor test to skip output from retry (follow-up)

### DIFF
--- a/builder/vsphere/supervisor/utils_test.go
+++ b/builder/vsphere/supervisor/utils_test.go
@@ -71,7 +71,7 @@ func readLine(t *testing.T, writer *bytes.Buffer) string {
 
 	// Skip "continue checking" line as it can be printed from the retry.
 	if strings.Contains(actual, "continue checking") {
-		readLine(t, writer)
+		return readLine(t, writer)
 	}
 
 	return strings.TrimSpace(actual)


### PR DESCRIPTION
This is a follow-up change to https://github.com/hashicorp/packer-plugin-vsphere/pull/321 which appears still failing the [CI test](https://github.com/hashicorp/packer-plugin-vsphere/actions/runs/6813905834/job/18529542723). 

To verify, I manually updated the test code to ensure the timing issue occurs:

```console
--- a/builder/vsphere/supervisor/step_watch_source_test.go
+++ b/builder/vsphere/supervisor/step_watch_source_test.go
@@ -116,6 +116,8 @@ func TestWatchSource_Run(t *testing.T) {
        vmObj.Status.VmIp = testVMIP
        _ = kubeClient.Update(ctx, vmObj, opt)

+       time.Sleep(time.Second)
+
        vmServiceObj.Status.LoadBalancer.Ingress[0].IP = testIngressIP
        _ = kubeClient.Update(ctx, vmServiceObj, opt)
```

Running the above test against upstream/main:

```console
$ go test -count=1 -run ^TestWatchSource_Run$ github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor
2023/11/09 10:38:35 ui: Waiting for the source VM to be powered-on and accessible...
2023/11/09 10:38:36 ui: Source VM is NOT powered-on yet, continue watching...
2023/11/09 10:38:36 ui: Source VM is powered-on, waiting for an IP to be assigned...
2023/11/09 10:38:36 ui: Successfully obtained the source VM IP: 1.2.3.4
2023/11/09 10:38:36 ui: Getting source VM ingress IP from the VMService object
2023/11/09 10:38:36 ui: VMService object's ingress IP is empty, continue checking...
2023/11/09 10:38:36 Retryable error: VMService object's ingress IP is empty, continue checking...
2023/11/09 10:38:41 ui: Successfully retrieved the source VM ingress IP: 5.6.7.8
2023/11/09 10:38:41 ui: Source VM is now ready in Supervisor cluster
--- FAIL: TestWatchSource_Run (6.00s)
    utils_test.go:61: Expected output "Successfully retrieved the source VM ingress IP: 5.6.7.8" but got "VMService object's ingress IP is empty, continue checking..."
FAIL
FAIL	github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor	6.748s
FAIL
```

Running the above test against this PR:

```console
$ go test -count=1 -run ^TestWatchSource_Run$ github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor
ok  	github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor	6.587s
```
