### PR TITLE
feat: add support for resetting cd-rom

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -927,6 +927,8 @@ boot time.
 
 - `remove_cdrom` (bool) - Remove CD-ROM devices from template. Defaults to `false`.
 
+- `keep_one_cdrom` (bool) - Keep One Cdrom
+
 <!-- End of code generated from the comments of the RemoveCDRomConfig struct in builder/vsphere/common/step_remove_cdrom.go; -->
 
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -683,6 +683,8 @@ iso_paths = [
 
 - `remove_cdrom` (bool) - Remove CD-ROM devices from template. Defaults to `false`.
 
+- `keep_one_cdrom` (bool) - Keep One Cdrom
+
 <!-- End of code generated from the comments of the RemoveCDRomConfig struct in builder/vsphere/common/step_remove_cdrom.go; -->
 
 

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -74,6 +74,7 @@ type FlatConfig struct {
 	CdromType                       *string                                     `mapstructure:"cdrom_type" cty:"cdrom_type" hcl:"cdrom_type"`
 	ISOPaths                        []string                                    `mapstructure:"iso_paths" cty:"iso_paths" hcl:"iso_paths"`
 	RemoveCdrom                     *bool                                       `mapstructure:"remove_cdrom" cty:"remove_cdrom" hcl:"remove_cdrom"`
+	KeepOneCdrom                    *bool                                       `mapstructure:"keep_one_cdrom" cty:"keep_one_cdrom" hcl:"keep_one_cdrom"`
 	FloppyIMGPath                   *string                                     `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
 	FloppyFiles                     []string                                    `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories               []string                                    `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
@@ -222,6 +223,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cdrom_type":                     &hcldec.AttrSpec{Name: "cdrom_type", Type: cty.String, Required: false},
 		"iso_paths":                      &hcldec.AttrSpec{Name: "iso_paths", Type: cty.List(cty.String), Required: false},
 		"remove_cdrom":                   &hcldec.AttrSpec{Name: "remove_cdrom", Type: cty.Bool, Required: false},
+		"keep_one_cdrom":                 &hcldec.AttrSpec{Name: "keep_one_cdrom", Type: cty.Bool, Required: false},
 		"floppy_img_path":                &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":                   &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                    &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},

--- a/builder/vsphere/common/step_remove_cdrom.go
+++ b/builder/vsphere/common/step_remove_cdrom.go
@@ -16,7 +16,8 @@ import (
 
 type RemoveCDRomConfig struct {
 	// Remove CD-ROM devices from template. Defaults to `false`.
-	RemoveCdrom bool `mapstructure:"remove_cdrom"`
+	RemoveCdrom  bool `mapstructure:"remove_cdrom"`
+	KeepOneCdrom bool `mapstructure:"keep_one_cdrom"`
 }
 
 type StepRemoveCDRom struct {
@@ -39,6 +40,30 @@ func (s *StepRemoveCDRom) Run(_ context.Context, state multistep.StateBag) multi
 		err := vm.RemoveCdroms()
 		if err != nil {
 			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+	}
+
+	if s.Config.KeepOneCdrom == true {
+		if _, err := vm.FindSATAController(); err == driver.ErrNoSataController {
+			ui.Say("Adding SATA controller...")
+			if err := vm.AddSATAController(); err != nil {
+				state.Put("error", err)
+				return multistep.ActionHalt
+			}
+		}
+
+		ui.Say("Adding SATA CD-ROM drive...")
+		err2 := vm.AddCdrom("sata", "[] /usr/lib/vmware/isoimages/windows.iso")
+		if err2 != nil {
+			state.Put("error", err2)
+			return multistep.ActionHalt
+		}
+
+		ui.Say("Ejecting ISO on SATA CD-ROM drive...")
+		err3 := vm.EjectCdroms()
+		if err3 != nil {
+			state.Put("error", err3)
 			return multistep.ActionHalt
 		}
 	}

--- a/builder/vsphere/common/step_remove_cdrom.hcl2spec.go
+++ b/builder/vsphere/common/step_remove_cdrom.hcl2spec.go
@@ -10,7 +10,8 @@ import (
 // FlatRemoveCDRomConfig is an auto-generated flat version of RemoveCDRomConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatRemoveCDRomConfig struct {
-	RemoveCdrom *bool `mapstructure:"remove_cdrom" cty:"remove_cdrom" hcl:"remove_cdrom"`
+	RemoveCdrom  *bool `mapstructure:"remove_cdrom" cty:"remove_cdrom" hcl:"remove_cdrom"`
+	KeepOneCdrom *bool `mapstructure:"keep_one_cdrom" cty:"keep_one_cdrom" hcl:"keep_one_cdrom"`
 }
 
 // FlatMapstructure returns a new FlatRemoveCDRomConfig.
@@ -25,7 +26,8 @@ func (*RemoveCDRomConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hc
 // The decoded values from this spec will then be applied to a FlatRemoveCDRomConfig.
 func (*FlatRemoveCDRomConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"remove_cdrom": &hcldec.AttrSpec{Name: "remove_cdrom", Type: cty.Bool, Required: false},
+		"remove_cdrom":   &hcldec.AttrSpec{Name: "remove_cdrom", Type: cty.Bool, Required: false},
+		"keep_one_cdrom": &hcldec.AttrSpec{Name: "keep_one_cdrom", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -77,6 +77,7 @@ type FlatConfig struct {
 	CdromType                       *string                                     `mapstructure:"cdrom_type" cty:"cdrom_type" hcl:"cdrom_type"`
 	ISOPaths                        []string                                    `mapstructure:"iso_paths" cty:"iso_paths" hcl:"iso_paths"`
 	RemoveCdrom                     *bool                                       `mapstructure:"remove_cdrom" cty:"remove_cdrom" hcl:"remove_cdrom"`
+	KeepOneCdrom                    *bool                                       `mapstructure:"keep_one_cdrom" cty:"keep_one_cdrom" hcl:"keep_one_cdrom"`
 	FloppyIMGPath                   *string                                     `mapstructure:"floppy_img_path" cty:"floppy_img_path" hcl:"floppy_img_path"`
 	FloppyFiles                     []string                                    `mapstructure:"floppy_files" cty:"floppy_files" hcl:"floppy_files"`
 	FloppyDirectories               []string                                    `mapstructure:"floppy_dirs" cty:"floppy_dirs" hcl:"floppy_dirs"`
@@ -227,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cdrom_type":                     &hcldec.AttrSpec{Name: "cdrom_type", Type: cty.String, Required: false},
 		"iso_paths":                      &hcldec.AttrSpec{Name: "iso_paths", Type: cty.List(cty.String), Required: false},
 		"remove_cdrom":                   &hcldec.AttrSpec{Name: "remove_cdrom", Type: cty.Bool, Required: false},
+		"keep_one_cdrom":                 &hcldec.AttrSpec{Name: "keep_one_cdrom", Type: cty.Bool, Required: false},
 		"floppy_img_path":                &hcldec.AttrSpec{Name: "floppy_img_path", Type: cty.String, Required: false},
 		"floppy_files":                   &hcldec.AttrSpec{Name: "floppy_files", Type: cty.List(cty.String), Required: false},
 		"floppy_dirs":                    &hcldec.AttrSpec{Name: "floppy_dirs", Type: cty.List(cty.String), Required: false},

--- a/docs-partials/builder/vsphere/common/RemoveCDRomConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/RemoveCDRomConfig-not-required.mdx
@@ -2,4 +2,6 @@
 
 - `remove_cdrom` (bool) - Remove CD-ROM devices from template. Defaults to `false`.
 
+- `keep_one_cdrom` (bool) - Keep One Cdrom
+
 <!-- End of code generated from the comments of the RemoveCDRomConfig struct in builder/vsphere/common/step_remove_cdrom.go; -->


### PR DESCRIPTION
I added a parameter named _**keep_one_cdrom**_ as boolean to permit the add of 1 SATA controller with 1 SATA CD-ROM drive after all drives are deleted.

Modifications are included in the step_remove_cdrom.go file:
```
if s.Config.KeepOneCdrom == true {
		if _, err := vm.FindSATAController(); err == driver.ErrNoSataController {
			ui.Say("Adding SATA controller...")
			if err := vm.AddSATAController(); err != nil {
				state.Put("error", err)
				return multistep.ActionHalt
			}
		}

		ui.Say("Adding SATA CD-ROM drive...")
		err2 := vm.AddCdrom("sata", "[] /usr/lib/vmware/isoimages/windows.iso")
		if err2 != nil {
			state.Put("error", err2)
			return multistep.ActionHalt
		}

		ui.Say("Ejecting ISO on SATA CD-ROM drive...")
		err3 := vm.EjectCdroms()
		if err3 != nil {
			state.Put("error", err3)
			return multistep.ActionHalt
		}
	}
```



Closes #24 

