### PR TITLE
fix: set mac address to lowercase

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -65,7 +65,7 @@ necessary for this build to succeed and can be found further down the page.
   available network. If the network is inside a network folder in vSphere inventory,
   you need to provide the full path to the network.
 
-- `mac_address` (string) - Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+- `mac_address` (string) - Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
 
 - `notes` (string) - VM notes.
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -41,7 +42,7 @@ type CloneConfig struct {
 	// available network. If the network is inside a network folder in vSphere inventory,
 	// you need to provide the full path to the network.
 	Network string `mapstructure:"network"`
-	// Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+	// Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
 	MacAddress string `mapstructure:"mac_address"`
 	// VM notes.
 	Notes string `mapstructure:"notes"`
@@ -117,7 +118,7 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		Datastore:       s.Location.Datastore,
 		LinkedClone:     s.Config.LinkedClone,
 		Network:         s.Config.Network,
-		MacAddress:      s.Config.MacAddress,
+		MacAddress:      strings.ToLower(s.Config.MacAddress),
 		Annotation:      s.Config.Notes,
 		VAppProperties:  s.Config.VAppConfig.Properties,
 		PrimaryDiskSize: s.Config.DiskSize,

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -247,7 +248,7 @@ func driverCreateConfig(config *CloneConfig, location *common.LocationConfig) *d
 		Datastore:       location.Datastore,
 		LinkedClone:     config.LinkedClone,
 		Network:         config.Network,
-		MacAddress:      config.MacAddress,
+		MacAddress:      strings.ToLower(config.MacAddress),
 		VAppProperties:  config.VAppConfig.Properties,
 		PrimaryDiskSize: config.DiskSize,
 	}

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -213,7 +213,7 @@ func TestVirtualMachineDriver_CloneWithMacAddress(t *testing.T) {
 	network := adapter.GetVirtualEthernetCard()
 	oldMacAddress := network.MacAddress
 
-	newMacAddress := "D4:B4:D4:96:70:26"
+	newMacAddress := "d4:b4:d4:96:70:26"
 	config := &CloneConfig{
 		Name:       "mock name",
 		Host:       "DC0_H0",

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -153,7 +154,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		networkCards = append(networkCards, driver.NIC{
 			Network:     nic.Network,
 			NetworkCard: nic.NetworkCard,
-			MacAddress:  nic.MacAddress,
+			MacAddress:  strings.ToLower(nic.MacAddress),
 			Passthrough: nic.Passthrough,
 		})
 	}

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -385,7 +385,7 @@ func driverCreateConfig(config *CreateConfig, location *common.LocationConfig) *
 		networkCards = append(networkCards, driver.NIC{
 			Network:     nic.Network,
 			NetworkCard: nic.NetworkCard,
-			MacAddress:  nic.MacAddress,
+			MacAddress:  strings.ToLower(nic.MacAddress),
 			Passthrough: nic.Passthrough,
 		})
 	}

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -11,7 +11,7 @@
   available network. If the network is inside a network folder in vSphere inventory,
   you need to provide the full path to the network.
 
-- `mac_address` (string) - Sets a custom Mac Address to the network adapter. If set, the [network](#network) must be also specified.
+- `mac_address` (string) - Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
 
 - `notes` (string) - VM notes.
 


### PR DESCRIPTION
### Summary

- Sets the MAC address to lowercase.
- Update "Mac address" to "MAC address".

### Reference

Ref: [VMware KB 82139](https://kb.vmware.com/s/article/82139)
Closes #324

