### PR TITLE
fix: remove vtpm req for vbs

### DIFF
--- a/builder/vsphere/common/step_add_flag.go
+++ b/builder/vsphere/common/step_add_flag.go
@@ -19,7 +19,6 @@ import (
 type FlagConfig struct {
 	// Enable Virtualization Based Security option for virtual machine. Defaults to `false`.
 	// Requires `vvtd_enabled` and `NestedHV` to be set to `true`.
-	// Requires `vTPM` to be set to `true`.
 	// Requires `firmware` to be set to `efi-secure`.
 	VbsEnabled bool `mapstructure:"vbs_enabled"`
 	// Enable IO/MMU option for virtual machine. Defaults to `false`.
@@ -40,10 +39,6 @@ func (c *FlagConfig) Prepare(h *HardwareConfig) []error {
 
 		if !h.NestedHV {
 			errs = append(errs, fmt.Errorf("`nestedhv` must be set to `true` when `vbs_enabled` is set to `true`"))
-		}
-
-		if !h.VTPMEnabled {
-			errs = append(errs, fmt.Errorf("`vtpm` must be set to `true` when `vbs_enabled` is set to `true`"))
 		}
 
 		if h.Firmware != "efi-secure" {

--- a/builder/vsphere/common/step_add_flag_test.go
+++ b/builder/vsphere/common/step_add_flag_test.go
@@ -35,9 +35,8 @@ func TestFlagConfig_Prepare(t *testing.T) {
 				VbsEnabled: true,
 			},
 			hardwareConfig: &HardwareConfig{
-				Firmware:    "efi-secure",
-				NestedHV:    true,
-				VTPMEnabled: true,
+				Firmware: "efi-secure",
+				NestedHV: true,
 			},
 			fail:           true,
 			expectedErrMsg: "`vvtd_enabled` must be set to `true` when `vbs_enabled` is set to `true`",
@@ -49,24 +48,10 @@ func TestFlagConfig_Prepare(t *testing.T) {
 				VvtdEnabled: true,
 			},
 			hardwareConfig: &HardwareConfig{
-				Firmware:    "efi-secure",
-				VTPMEnabled: true,
-			},
-			fail:           true,
-			expectedErrMsg: "`nestedhv` must be set to `true` when `vbs_enabled` is set to `true`",
-		},
-		{
-			name: "VbsEnabled but VTPMEnabled not set",
-			config: &FlagConfig{
-				VbsEnabled:  true,
-				VvtdEnabled: true,
-			},
-			hardwareConfig: &HardwareConfig{
-				NestedHV: true,
 				Firmware: "efi-secure",
 			},
 			fail:           true,
-			expectedErrMsg: "`vtpm` must be set to `true` when `vbs_enabled` is set to `true`",
+			expectedErrMsg: "`nestedhv` must be set to `true` when `vbs_enabled` is set to `true`",
 		},
 		{
 			name: "VbsEnabled but Firmware not set to efi-secure",
@@ -75,9 +60,8 @@ func TestFlagConfig_Prepare(t *testing.T) {
 				VvtdEnabled: true,
 			},
 			hardwareConfig: &HardwareConfig{
-				NestedHV:    true,
-				VTPMEnabled: true,
-				Firmware:    "efi",
+				NestedHV: true,
+				Firmware: "efi",
 			},
 			fail:           true,
 			expectedErrMsg: "`firmware` must be set to `efi-secure` when `vbs_enabled` is set to `true`",
@@ -89,9 +73,8 @@ func TestFlagConfig_Prepare(t *testing.T) {
 				VvtdEnabled: true,
 			},
 			hardwareConfig: &HardwareConfig{
-				NestedHV:    true,
-				VTPMEnabled: true,
-				Firmware:    "efi-secure",
+				NestedHV: true,
+				Firmware: "efi-secure",
 			},
 			fail:           false,
 			expectedErrMsg: "",

--- a/docs-partials/builder/vsphere/common/FlagConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/FlagConfig-not-required.mdx
@@ -2,7 +2,6 @@
 
 - `vbs_enabled` (bool) - Enable Virtualization Based Security option for virtual machine. Defaults to `false`.
   Requires `vvtd_enabled` and `NestedHV` to be set to `true`.
-  Requires `vTPM` to be set to `true`.
   Requires `firmware` to be set to `efi-secure`.
 
 - `vvtd_enabled` (bool) - Enable IO/MMU option for virtual machine. Defaults to `false`.


### PR DESCRIPTION
### Description

- `vtpm` does **not** need to be set to `true` when `vbs_enabled` is set to `true`.

### Summary

Closes #339 

