### PR TITLE
fix: `windows_options` nil and length check

### DIFF
--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -356,13 +356,12 @@ func (w *WindowsOptions) sysprep() *types.CustomizationSysprep {
 }
 
 func (w *WindowsOptions) guiRunOnce() *types.CustomizationGuiRunOnce {
-	obj := &types.CustomizationGuiRunOnce{
-		CommandList: *w.RunOnceCommandList,
-	}
-	if len(obj.CommandList) < 1 {
+	if w.RunOnceCommandList == nil || len(*w.RunOnceCommandList) < 1 {
 		return nil
 	}
-	return obj
+	return &types.CustomizationGuiRunOnce{
+		CommandList: *w.RunOnceCommandList,
+	}
 }
 
 func boolValue(p *bool, fallback bool) bool {


### PR DESCRIPTION
### Description

Return `nil` if `RunOnceCommandList` is `nil` or if it is an empty slice.

### Reference

Closes #269