### PR TITLE
🚧 feat: add support for reusing a vm

### DIFF
--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -39,7 +39,8 @@ type CDRomConfig struct {
 }
 
 type StepAddCDRom struct {
-	Config *CDRomConfig
+	Config  *CDRomConfig
+	ReuseVM bool
 }
 
 func (c *CDRomConfig) Prepare(k *ReattachCDRomConfig) []error {
@@ -63,7 +64,8 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(driver.VirtualMachine)
 
-	if s.Config.CdromType == "sata" {
+	// when ReuseVM is set we are not supposed to add new hw
+	if !s.ReuseVM && s.Config.CdromType == "sata" {
 		if _, err := vm.FindSATAController(); err == driver.ErrNoSataController {
 			ui.Say("Adding SATA controller...")
 			if err := vm.AddSATAController(); err != nil {
@@ -85,14 +87,37 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	ui.Say("Mounting ISO images...")
 	// Limitation in govmomi: can't batch-create cdroms and then mount ISO files,
 	// that results in wrong UnitNumber. So do that one-by-one.
-	for _, path := range s.Config.ISOPaths {
-		if path == "" {
-			state.Put("error", fmt.Errorf("invalid path: empty string"))
+	if s.ReuseVM {
+		cdroms, err := vm.GetCdroms(len(s.Config.ISOPaths))
+		if err != nil {
+			state.Put("error", fmt.Errorf("error fetching cdroms: %v", err))
 			return multistep.ActionHalt
 		}
-		if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
-			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
-			return multistep.ActionHalt
+		for i := 0; i < len(s.Config.ISOPaths); i++ {
+			path := s.Config.ISOPaths[i]
+			if path == "" {
+				state.Put("error", fmt.Errorf("invalid path: empty string"))
+				return multistep.ActionHalt
+			}
+			if err := vm.MountCdrom(path, cdroms[i]); err != nil {
+				state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
+				return multistep.ActionHalt
+			}
+			if err := vm.EditDevice(cdroms[i]); err != nil {
+				state.Put("error", fmt.Errorf("error commiting mount to cdrom: %v", err))
+				return multistep.ActionHalt
+			}
+		}
+	} else {
+		for _, path := range s.Config.ISOPaths {
+			if path == "" {
+				state.Put("error", fmt.Errorf("invalid path: empty string"))
+				return multistep.ActionHalt
+			}
+			if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
+				state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
+				return multistep.ActionHalt
+			}
 		}
 	}
 

--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -96,10 +96,75 @@ func TestStepAddCDRom_Run(t *testing.T) {
 				FindSATAControllerCalled: true,
 				AddCdromCalledTimes:      3,
 				AddCdromTypes:            []string{"sata", "sata", "sata"},
-				AddCdromPaths:            []string{"iso/path", "remote/path", "cd/path"},
+				MountCdromCalledTimes:    3,
+				MountCdromPaths:          []string{"iso/path", "remote/path", "cd/path"},
 			},
 			fail:       false,
 			errMessage: "",
+		},
+		{
+			name:  "3 mounts being added to a pre-existing VM with same CDroms amount",
+			state: cdAndIsoRemotePathStateBag(),
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths:  []string{"iso/path"},
+				},
+				ReuseVM: true,
+			},
+			vmMock: &driver.VirtualMachineMock{
+				AddCdromTypes: []string{"sata", "sata", "sata"},
+			},
+			expectedAction: multistep.ActionContinue,
+			expectedVmMock: &driver.VirtualMachineMock{
+				AddCdromTypes:         []string{"sata", "sata", "sata"},
+				MountCdromCalledTimes: 3,
+				MountCdromPaths:       []string{"iso/path", "remote/path", "cd/path"},
+			},
+			fail:       false,
+			errMessage: "",
+		},
+		{
+			name:  "3 mounts being added to a pre-existing VM with larger CDroms amount",
+			state: cdAndIsoRemotePathStateBag(),
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths:  []string{"iso/path"},
+				},
+				ReuseVM: true,
+			},
+			vmMock: &driver.VirtualMachineMock{
+				AddCdromTypes: []string{"sata", "sata", "sata", "sata"},
+			},
+			expectedAction: multistep.ActionContinue,
+			expectedVmMock: &driver.VirtualMachineMock{
+				AddCdromTypes:         []string{"sata", "sata", "sata", "sata"},
+				MountCdromCalledTimes: 3,
+				MountCdromPaths:       []string{"iso/path", "remote/path", "cd/path"},
+			},
+			fail:       false,
+			errMessage: "",
+		},
+		{
+			name:  "3 mounts being added to a pre-existing VM with lesser CDroms amount",
+			state: basicStateBag(nil),
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths:  []string{"iso/path", "remote/path", "cd/path"},
+				},
+				ReuseVM: true,
+			},
+			vmMock: &driver.VirtualMachineMock{
+				AddCdromTypes: []string{"sata"},
+			},
+			expectedAction: multistep.ActionHalt,
+			expectedVmMock: &driver.VirtualMachineMock{
+				AddCdromTypes: []string{"sata"},
+			},
+			fail:       true,
+			errMessage: "error fetching cdroms: Not enough cdroms: VM has 1, expected 3",
 		},
 		{
 			name:  "Add SATA Controller",
@@ -153,9 +218,10 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			vmMock:         new(driver.VirtualMachineMock),
 			expectedAction: multistep.ActionContinue,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalledTimes: 1,
-				AddCdromTypes:       []string{"ide"},
-				AddCdromPaths:       []string{"iso/path"},
+				AddCdromCalledTimes:   1,
+				AddCdromTypes:         []string{"ide"},
+				MountCdromCalledTimes: 1,
+				MountCdromPaths:       []string{"iso/path"},
 			},
 			fail:       false,
 			errMessage: "",
@@ -173,9 +239,10 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			},
 			expectedAction: multistep.ActionHalt,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalledTimes: 1,
-				AddCdromTypes:       []string{""},
-				AddCdromPaths:       []string{"iso/path"},
+				AddCdromCalledTimes:   1,
+				AddCdromTypes:         []string{""},
+				MountCdromCalledTimes: 1,
+				MountCdromPaths:       []string{"iso/path"},
 			},
 			fail:       true,
 			errMessage: fmt.Sprintf("error mounting an image 'iso/path': %v", fmt.Errorf("AddCdrom error")),
@@ -191,9 +258,10 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			},
 			expectedAction: multistep.ActionHalt,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalledTimes: 1,
-				AddCdromTypes:       []string{""},
-				AddCdromPaths:       []string{"remote/path"},
+				AddCdromCalledTimes:   1,
+				AddCdromTypes:         []string{""},
+				MountCdromCalledTimes: 1,
+				MountCdromPaths:       []string{"remote/path"},
 			},
 			fail:       true,
 			errMessage: fmt.Sprintf("error mounting an image 'remote/path': %v", fmt.Errorf("AddCdrom error")),

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -1180,11 +1180,11 @@ func (vm *VirtualMachineDriver) RemoveDevice(keepFiles bool, device ...types.Bas
 	return vm.vm.RemoveDevice(vm.driver.ctx, keepFiles, device...)
 }
 
-func (vm *VirtualMachineDriver) addDevice(device types.BaseVirtualDevice) error {
+func (vm *VirtualMachineDriver) commitDevToESXi(device types.BaseVirtualDevice, op types.VirtualDeviceConfigSpecOperation) error {
 	newDevices := object.VirtualDeviceList{device}
 	confSpec := types.VirtualMachineConfigSpec{}
 	var err error
-	confSpec.DeviceChange, err = newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	confSpec.DeviceChange, err = newDevices.ConfigSpec(op)
 	if err != nil {
 		return err
 	}
@@ -1196,6 +1196,10 @@ func (vm *VirtualMachineDriver) addDevice(device types.BaseVirtualDevice) error 
 
 	_, err = task.WaitForResult(vm.driver.ctx, nil)
 	return err
+}
+
+func (vm *VirtualMachineDriver) addDevice(device types.BaseVirtualDevice) error {
+	return vm.commitDevToESXi(device, types.VirtualDeviceConfigSpecOperationAdd)
 }
 
 func (vm *VirtualMachineDriver) AddConfigParams(params map[string]string, info *types.ToolsConfigInfo) error {

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -5,6 +5,7 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -30,10 +31,12 @@ type VirtualMachineMock struct {
 	AddSATAControllerCalled bool
 	AddSATAControllerErr    error
 
+	MountCdromCalledTimes int
+	MountCdromPaths       []string
+
 	AddCdromCalledTimes int
 	AddCdromErr         error
 	AddCdromTypes       []string
-	AddCdromPaths       []string
 
 	AddFlagCalled            bool
 	AddFlagCalledTimes       int
@@ -188,11 +191,28 @@ func (vm *VirtualMachineMock) GetDir() (string, error) {
 	return vm.GetDirResponse, vm.GetDirErr
 }
 
+func (vm *VirtualMachineMock) GetCdroms(n_cdroms int) (object.VirtualDeviceList, error) {
+	if n_cdroms > len(vm.AddCdromTypes) {
+		return nil, fmt.Errorf("Not enough cdroms: VM has %d, expected %d", len(vm.AddCdromTypes), n_cdroms)
+	}
+	return make(object.VirtualDeviceList, n_cdroms), nil
+}
+
+func (vm *VirtualMachineMock) MountCdrom(isoPath string, cdrom types.BaseVirtualDevice) error {
+	vm.MountCdromCalledTimes++
+	if isoPath != "" {
+		vm.MountCdromPaths = append(vm.MountCdromPaths, isoPath)
+	}
+	return nil
+}
+
 func (vm *VirtualMachineMock) AddCdrom(controllerType string, isoPath string) error {
 	vm.AddCdromCalledTimes++
 	vm.AddCdromTypes = append(vm.AddCdromTypes, controllerType)
 	if isoPath != "" {
-		vm.AddCdromPaths = append(vm.AddCdromPaths, isoPath)
+		if err := vm.MountCdrom(isoPath, nil); err != nil {
+			return err
+		}
 	}
 	return vm.AddCdromErr
 }
@@ -215,6 +235,10 @@ func (vm *VirtualMachineMock) RemoveDevice(keepFiles bool, device ...types.BaseV
 }
 
 func (vm *VirtualMachineMock) addDevice(device types.BaseVirtualDevice) error {
+	return nil
+}
+
+func (vm *VirtualMachineMock) EditDevice(device types.BaseVirtualDevice) error {
 	return nil
 }
 

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -79,7 +79,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			FlagConfig: b.config.FlagConfig,
 		},
 		&common.StepAddCDRom{
-			Config: &b.config.CDRomConfig,
+			Config:  &b.config.CDRomConfig,
+			ReuseVM: b.config.CreateConfig.ReuseVM,
 		},
 		&common.StepConfigParams{
 			Config: &b.config.ConfigParamsConfig,

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -41,6 +41,7 @@ type FlatConfig struct {
 	USBController                   []string                                    `mapstructure:"usb_controller" cty:"usb_controller" hcl:"usb_controller"`
 	Notes                           *string                                     `mapstructure:"notes" cty:"notes" hcl:"notes"`
 	Destroy                         *bool                                       `mapstructure:"destroy" cty:"destroy" hcl:"destroy"`
+	ReuseVM                         *bool                                       `mapstructure:"reuse_vm" cty:"reuse_vm" hcl:"reuse_vm"`
 	VMName                          *string                                     `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	Folder                          *string                                     `mapstructure:"folder" cty:"folder" hcl:"folder"`
 	Cluster                         *string                                     `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
@@ -193,6 +194,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"usb_controller":                 &hcldec.AttrSpec{Name: "usb_controller", Type: cty.List(cty.String), Required: false},
 		"notes":                          &hcldec.AttrSpec{Name: "notes", Type: cty.String, Required: false},
 		"destroy":                        &hcldec.AttrSpec{Name: "destroy", Type: cty.Bool, Required: false},
+		"reuse_vm":                       &hcldec.AttrSpec{Name: "reuse_vm", Type: cty.Bool, Required: false},
 		"vm_name":                        &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"folder":                         &hcldec.AttrSpec{Name: "folder", Type: cty.String, Required: false},
 		"cluster":                        &hcldec.AttrSpec{Name: "cluster", Type: cty.String, Required: false},


### PR DESCRIPTION
This PR resolves the problem where users could not install a system from ISO to a pre-created Virtual Machine.

This mostly ready and works, except the two TODO points below. I wanted to submit this at its current 90% ready state to get comments on whether the approach is okay, design, etc. I am barely familiar both with Packer, its plugin system, ESXi, and it's also my first ever experience with Go. So would be good to get feedback at this point to make sure I won't have to rewrite everything from scratch 😊

Closes #334

TODO:

* [x] Handle the case of `iso_paths` having more than one element. I presume the correct way of solving that for `reuseVM` case would be pre-building a list of all CD-roms, then asserting that amount of ISOs ≤ amount of CD-roms, then mounting ISO to each CD-rom in the list.
* [ ] Error out if HCL/JSON config has `reuse_vm = true` and also hardware configuration *(because we don't want to modify hw on a pre-created VM)*.
