### PR TITLE
chore: Remove support for deprecated `images` configuration attribute in favor of `image_files` attribute in the export config block

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1183,7 +1183,7 @@ cloud-init 21.3 and later for more information.
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-You may optionally export an ovf from vSphere to the instance running Packer.
+You can export an image in Open Virtualization Format (OVF) to the Packer host.
 
 Example usage:
 
@@ -1197,7 +1197,7 @@ In JSON:
 
 	"export": {
 	  "force": true,
-	  "output_directory": "./output_vsphere"
+	  "output_directory": "./output-artifacts"
 	},
 
 ```
@@ -1209,16 +1209,16 @@ In HCL2:
 	# ...
 	export {
 	  force = true
-	  output_directory = "./output_vsphere"
+	  output_directory = "./output-artifacts"
 	}
 
 ```
 The above configuration would create the following files:
 
 ```text
-./output_vsphere/example-ubuntu-disk-0.vmdk
-./output_vsphere/example-ubuntu.mf
-./output_vsphere/example-ubuntu.ovf
+./output-artifacts/example-ubuntu-disk-0.vmdk
+./output-artifacts/example-ubuntu.mf
+./output-artifacts/example-ubuntu.ovf
 ```
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
@@ -1228,23 +1228,25 @@ The above configuration would create the following files:
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-- `name` (string) - Name of the ovf. defaults to the name of the VM
+- `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
+  The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Overwrite ovf if it exists
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
+  If set to false, the export will fail if the files already exists.
 
-- `images` (bool) - Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+  For example, `.nvram` and `.log` files.
 
-- `image_files` (bool) - In exported files, include additional image files that are attached to the VM, such as nvram, iso, img.
+- `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
+  Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
-
-- `options` ([]string) - Advanced ovf export options. Options can include:
-  * mac - MAC address is exported for all ethernet devices
-  * uuid - UUID is exported for all virtual machines
-  * extraconfig - all extra configuration options are exported for a virtual machine
-  * nodevicesubtypes - resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported
+- `options` ([]string) - Advanced image export options. Options can include:
+  * mac - MAC address is exported for each Ethernet device.
+  * uuid - UUID is exported for the virtual machine.
+  * extraconfig - Extra configuration options are exported for the virtual machine.
+  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
-  For example, adding the following export config option would output the mac addresses for all Ethernet devices in the ovf file:
+  For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
   In JSON:
   ```json

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -994,7 +994,7 @@ In HCL2:
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-You may optionally export an ovf from vSphere to the instance running Packer.
+You can export an image in Open Virtualization Format (OVF) to the Packer host.
 
 Example usage:
 
@@ -1008,7 +1008,7 @@ In JSON:
 
 	"export": {
 	  "force": true,
-	  "output_directory": "./output_vsphere"
+	  "output_directory": "./output-artifacts"
 	},
 
 ```
@@ -1020,16 +1020,16 @@ In HCL2:
 	# ...
 	export {
 	  force = true
-	  output_directory = "./output_vsphere"
+	  output_directory = "./output-artifacts"
 	}
 
 ```
 The above configuration would create the following files:
 
 ```text
-./output_vsphere/example-ubuntu-disk-0.vmdk
-./output_vsphere/example-ubuntu.mf
-./output_vsphere/example-ubuntu.ovf
+./output-artifacts/example-ubuntu-disk-0.vmdk
+./output-artifacts/example-ubuntu.mf
+./output-artifacts/example-ubuntu.ovf
 ```
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
@@ -1039,23 +1039,25 @@ The above configuration would create the following files:
 
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-- `name` (string) - Name of the ovf. defaults to the name of the VM
+- `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
+  The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Overwrite ovf if it exists
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
+  If set to false, the export will fail if the files already exists.
 
-- `images` (bool) - Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+  For example, `.nvram` and `.log` files.
 
-- `image_files` (bool) - In exported files, include additional image files that are attached to the VM, such as nvram, iso, img.
+- `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
+  Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
-
-- `options` ([]string) - Advanced ovf export options. Options can include:
-  * mac - MAC address is exported for all ethernet devices
-  * uuid - UUID is exported for all virtual machines
-  * extraconfig - all extra configuration options are exported for a virtual machine
-  * nodevicesubtypes - resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported
+- `options` ([]string) - Advanced image export options. Options can include:
+  * mac - MAC address is exported for each Ethernet device.
+  * uuid - UUID is exported for the virtual machine.
+  * extraconfig - Extra configuration options are exported for the virtual machine.
+  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
-  For example, adding the following export config option would output the mac addresses for all Ethernet devices in the ovf file:
+  For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
   In JSON:
   ```json

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -154,7 +154,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		steps = append(steps, &common.StepExport{
 			Name:       b.config.Export.Name,
 			Force:      b.config.Export.Force,
-			ImageFiles: b.config.Export.Images,
+			ImageFiles: b.config.Export.ImageFiles,
 			Manifest:   b.config.Export.Manifest,
 			OutputDir:  b.config.Export.OutputDir.OutputDir,
 			Options:    b.config.Export.Options,

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -14,7 +14,6 @@ import (
 type FlatExportConfig struct {
 	Name       *string      `mapstructure:"name" cty:"name" hcl:"name"`
 	Force      *bool        `mapstructure:"force" cty:"force" hcl:"force"`
-	Images     *bool        `mapstructure:"images" cty:"images" hcl:"images"`
 	ImageFiles *bool        `mapstructure:"image_files" cty:"image_files" hcl:"image_files"`
 	Manifest   *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
 	OutputDir  *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
@@ -36,7 +35,6 @@ func (*FlatExportConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"name":                 &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 		"force":                &hcldec.AttrSpec{Name: "force", Type: cty.Bool, Required: false},
-		"images":               &hcldec.AttrSpec{Name: "images", Type: cty.Bool, Required: false},
 		"image_files":          &hcldec.AttrSpec{Name: "image_files", Type: cty.Bool, Required: false},
 		"manifest":             &hcldec.AttrSpec{Name: "manifest", Type: cty.String, Required: false},
 		"output_directory":     &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -156,7 +156,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		steps = append(steps, &common.StepExport{
 			Name:       b.config.Export.Name,
 			Force:      b.config.Export.Force,
-			ImageFiles: b.config.Export.Images,
+			ImageFiles: b.config.Export.ImageFiles,
 			Manifest:   b.config.Export.Manifest,
 			OutputDir:  b.config.Export.OutputDir.OutputDir,
 			Options:    b.config.Export.Options,

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -1,22 +1,24 @@
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-- `name` (string) - Name of the ovf. defaults to the name of the VM
+- `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
+  The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Overwrite ovf if it exists
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
+  If set to false, the export will fail if the files already exists.
 
-- `images` (bool) - Deprecated: Images will be removed in a future release. Please see `image_files` for more details on this argument.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+  For example, `.nvram` and `.log` files.
 
-- `image_files` (bool) - In exported files, include additional image files that are attached to the VM, such as nvram, iso, img.
+- `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
+  Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `manifest` (string) - Generate manifest using sha1, sha256, sha512. Defaults to 'sha256'. Use 'none' for no manifest.
-
-- `options` ([]string) - Advanced ovf export options. Options can include:
-  * mac - MAC address is exported for all ethernet devices
-  * uuid - UUID is exported for all virtual machines
-  * extraconfig - all extra configuration options are exported for a virtual machine
-  * nodevicesubtypes - resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported
+- `options` ([]string) - Advanced image export options. Options can include:
+  * mac - MAC address is exported for each Ethernet device.
+  * uuid - UUID is exported for the virtual machine.
+  * extraconfig - Extra configuration options are exported for the virtual machine.
+  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
-  For example, adding the following export config option would output the mac addresses for all Ethernet devices in the ovf file:
+  For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
   In JSON:
   ```json

--- a/docs-partials/builder/vsphere/common/ExportConfig.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; DO NOT EDIT MANUALLY -->
 
-You may optionally export an ovf from vSphere to the instance running Packer.
+You can export an image in Open Virtualization Format (OVF) to the Packer host.
 
 Example usage:
 
@@ -14,7 +14,7 @@ In JSON:
 
 	"export": {
 	  "force": true,
-	  "output_directory": "./output_vsphere"
+	  "output_directory": "./output-artifacts"
 	},
 
 ```
@@ -26,16 +26,16 @@ In HCL2:
 	# ...
 	export {
 	  force = true
-	  output_directory = "./output_vsphere"
+	  output_directory = "./output-artifacts"
 	}
 
 ```
 The above configuration would create the following files:
 
 ```text
-./output_vsphere/example-ubuntu-disk-0.vmdk
-./output_vsphere/example-ubuntu.mf
-./output_vsphere/example-ubuntu.ovf
+./output-artifacts/example-ubuntu-disk-0.vmdk
+./output-artifacts/example-ubuntu.mf
+./output-artifacts/example-ubuntu.ovf
 ```
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->


### PR DESCRIPTION
### Summary

- Removes deprecated `images` option that was noted to be removed over 2 years ago.
- Updated export configuration descriptions.
- Simplified `manifest` validation.
- Updated to use `ui.Say` versus `ui.Message` for output consistency.
- Added code comments.
- Improved output and error messaging for output consistency.

### Tests

```bash
...
==> vsphere-iso.linux-photon: Executing shutdown command...
==> vsphere-iso.linux-photon: Deleting Floppy drives...
==> vsphere-iso.linux-photon: Eject CD-ROM drives...
==> vsphere-iso.linux-photon: Deleting CD-ROM drives...
==> vsphere-iso.linux-photon: Exporting to Open Virtualization Format (OVF)...
==> vsphere-iso.linux-photon: Downloading linux-photon-4.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Exporting linux-photon-4.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Writing OVF descriptor linux-photon-4.0-develop.ovf...
==> vsphere-iso.linux-photon: Creating SHA1 manifest linux-photon-4.0-develop.mf...
==> vsphere-iso.linux-photon: Completed export to Open Virtualization Format (OVF).
    vsphere-iso.linux-photon: Closing sessions ....
Build 'vsphere-iso.linux-photon' finished after 7 minutes 28 seconds.
...
```