### PR TITLE
docs: update `disk_size` from mb to mib

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -54,11 +54,11 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `template` (string) - Name of source VM. Path is optional.
+- `template` (string) - Name of source virtual machine. Path is optional.
 
-- `disk_size` (int64) - The size of the disk in MB.
+- `disk_size` (int64) - The size of the disk in MiB.
 
-- `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
+- `linked_clone` (bool) - Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
 
 - `network` (string) - Set the network in which the VM will be connected to. If no network is
   specified, `host` must be specified to allow Packer to look for the
@@ -69,11 +69,11 @@ necessary for this build to succeed and can be found further down the page.
 
 - `notes` (string) - VM notes.
 
-- `destroy` (bool) - If set to true, the VM will be destroyed after the builder completes
+- `destroy` (bool) - If set to true, the virtual machine will be destroyed after the build completes.
 
-- `vapp` (vAppConfig) - Set the vApp Options to a virtual machine.
+- `vapp` (vAppConfig) - Set the vApp Options on the virtual machine image.
   See the [vApp Options Configuration](/packer/integrations/hashicorp/vmware/latest/components/builder/vsphere-clone#vapp-options-configuration)
-  to know the available options and how to use it.
+  section for more information.
 
 <!-- End of code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; -->
 
@@ -183,7 +183,7 @@ In HCL2:
 
 <!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_size` (int64) - The size of the disk in MB.
+- `disk_size` (int64) - The size of the disk in MiB.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 
@@ -196,7 +196,7 @@ In HCL2:
 
 - `disk_eagerly_scrub` (bool) - Enable VMDK eager scrubbing for VM. Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0)
+- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0).
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -972,7 +972,7 @@ In HCL2:
 
 <!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_size` (int64) - The size of the disk in MB.
+- `disk_size` (int64) - The size of the disk in MiB.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 
@@ -985,7 +985,7 @@ In HCL2:
 
 - `disk_eagerly_scrub` (bool) - Enable VMDK eager scrubbing for VM. Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0)
+- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0).
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -31,11 +31,11 @@ type vAppConfig struct {
 }
 
 type CloneConfig struct {
-	// Name of source VM. Path is optional.
+	// Name of source virtual machine. Path is optional.
 	Template string `mapstructure:"template"`
-	// The size of the disk in MB.
+	// The size of the disk in MiB.
 	DiskSize int64 `mapstructure:"disk_size"`
-	// Create VM as a linked clone from latest snapshot. Defaults to `false`.
+	// Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
 	LinkedClone bool `mapstructure:"linked_clone"`
 	// Set the network in which the VM will be connected to. If no network is
 	// specified, `host` must be specified to allow Packer to look for the
@@ -46,11 +46,11 @@ type CloneConfig struct {
 	MacAddress string `mapstructure:"mac_address"`
 	// VM notes.
 	Notes string `mapstructure:"notes"`
-	// If set to true, the VM will be destroyed after the builder completes
+	// If set to true, the virtual machine will be destroyed after the build completes.
 	Destroy bool `mapstructure:"destroy"`
-	// Set the vApp Options to a virtual machine.
+	// Set the vApp Options on the virtual machine image.
 	// See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
-	// to know the available options and how to use it.
+	// section for more information.
 	VAppConfig    vAppConfig           `mapstructure:"vapp"`
 	StorageConfig common.StorageConfig `mapstructure:",squash"`
 }

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -91,13 +91,13 @@ import (
 //
 // ```
 type DiskConfig struct {
-	// The size of the disk in MB.
+	// The size of the disk in MiB.
 	DiskSize int64 `mapstructure:"disk_size" required:"true"`
 	// Enable VMDK thin provisioning for VM. Defaults to `false`.
 	DiskThinProvisioned bool `mapstructure:"disk_thin_provisioned"`
 	// Enable VMDK eager scrubbing for VM. Defaults to `false`.
 	DiskEagerlyScrub bool `mapstructure:"disk_eagerly_scrub"`
-	// The assigned disk controller. Defaults to the first one (0)
+	// The assigned disk controller. Defaults to the first one (0).
 	DiskControllerIndex int `mapstructure:"disk_controller_index"`
 }
 

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -1,10 +1,10 @@
 <!-- Code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `template` (string) - Name of source VM. Path is optional.
+- `template` (string) - Name of source virtual machine. Path is optional.
 
-- `disk_size` (int64) - The size of the disk in MB.
+- `disk_size` (int64) - The size of the disk in MiB.
 
-- `linked_clone` (bool) - Create VM as a linked clone from latest snapshot. Defaults to `false`.
+- `linked_clone` (bool) - Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
 
 - `network` (string) - Set the network in which the VM will be connected to. If no network is
   specified, `host` must be specified to allow Packer to look for the
@@ -15,10 +15,10 @@
 
 - `notes` (string) - VM notes.
 
-- `destroy` (bool) - If set to true, the VM will be destroyed after the builder completes
+- `destroy` (bool) - If set to true, the virtual machine will be destroyed after the build completes.
 
-- `vapp` (vAppConfig) - Set the vApp Options to a virtual machine.
+- `vapp` (vAppConfig) - Set the vApp Options on the virtual machine image.
   See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
-  to know the available options and how to use it.
+  section for more information.
 
 <!-- End of code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -4,6 +4,6 @@
 
 - `disk_eagerly_scrub` (bool) - Enable VMDK eager scrubbing for VM. Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0)
+- `disk_controller_index` (int) - The assigned disk controller. Defaults to the first one (0).
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-required.mdx
@@ -1,5 +1,5 @@
 <!-- Code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; DO NOT EDIT MANUALLY -->
 
-- `disk_size` (int64) - The size of the disk in MB.
+- `disk_size` (int64) - The size of the disk in MiB.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->


### PR DESCRIPTION
- Updates `disk_size` from MB to MiB.
- Minor text updates.

Closes #348 

```zsh
packer-plugin-vsphere on docs/mb-to-mib
➜ go fmt ./...         

packer-plugin-vsphere on docs/mb-to-mib
➜ make build

packer-plugin-vsphere on docs/mb-to-mib
➜ export PATH=$PATH:$(go env GOPATH)/bin

packer-plugin-vsphere on docs/mb-to-mib
➜ make generate
2023/12/19 15:34:42 Copying "docs" to ".docs/"
2023/12/19 15:34:42 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on docs/mb-to-mib took 34.4s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.846s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.342s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.729s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.702s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   5.014s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.506s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.030s
```
