### PR TITLE
chore(tests): remove unnecessary `AddCdromCalled`

### DIFF
--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -94,7 +94,6 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			expectedAction: multistep.ActionContinue,
 			expectedVmMock: &driver.VirtualMachineMock{
 				FindSATAControllerCalled: true,
-				AddCdromCalled:           true,
 				AddCdromCalledTimes:      3,
 				AddCdromTypes:            []string{"sata", "sata", "sata"},
 				AddCdromPaths:            []string{"remote/path", "iso/path", "cd/path"},
@@ -154,7 +153,6 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			vmMock:         new(driver.VirtualMachineMock),
 			expectedAction: multistep.ActionContinue,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalled:      true,
 				AddCdromCalledTimes: 1,
 				AddCdromTypes:       []string{"ide"},
 				AddCdromPaths:       []string{"iso/path"},
@@ -175,7 +173,6 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			},
 			expectedAction: multistep.ActionHalt,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalled:      true,
 				AddCdromCalledTimes: 1,
 				AddCdromTypes:       []string{""},
 				AddCdromPaths:       []string{"iso/path"},
@@ -194,7 +191,6 @@ func TestStepAddCDRom_Run(t *testing.T) {
 			},
 			expectedAction: multistep.ActionHalt,
 			expectedVmMock: &driver.VirtualMachineMock{
-				AddCdromCalled:      true,
 				AddCdromCalledTimes: 1,
 				AddCdromTypes:       []string{""},
 				AddCdromPaths:       []string{"remote/path"},

--- a/builder/vsphere/common/step_reattach_cdrom_test.go
+++ b/builder/vsphere/common/step_reattach_cdrom_test.go
@@ -46,7 +46,6 @@ func TestStepReattachCDRom_Run(t *testing.T) {
 				RemoveCdromsCalled:       true,
 				ReattachCDRomsCalled:     true,
 				FindSATAControllerCalled: true,
-				AddCdromCalled:           true,
 				AddCdromCalledTimes:      8,
 				AddCdromTypes: []string{
 					"sata", "sata",

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -30,7 +30,6 @@ type VirtualMachineMock struct {
 	AddSATAControllerCalled bool
 	AddSATAControllerErr    error
 
-	AddCdromCalled      bool
 	AddCdromCalledTimes int
 	AddCdromErr         error
 	AddCdromTypes       []string
@@ -188,7 +187,6 @@ func (vm *VirtualMachineMock) GetDir() (string, error) {
 
 func (vm *VirtualMachineMock) AddCdrom(cdromType string, isoPath string) error {
 	vm.AddCdromCalledTimes++
-	vm.AddCdromCalled = true
 	vm.AddCdromTypes = append(vm.AddCdromTypes, cdromType)
 	vm.AddCdromPaths = append(vm.AddCdromPaths, isoPath)
 	return vm.AddCdromErr


### PR DESCRIPTION
There is an AddCdromCalledTimes which serves the same purpose