### PR TITLE
fix: remove obsolete path check

### DIFF
--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/hcl/v2/hcldec"

--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -92,11 +92,6 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		}
 	}
 
-	if p.config.Folder != "" && !strings.HasPrefix(p.config.Folder, "/") {
-		errs = packersdk.MultiErrorAppend(
-			errs, fmt.Errorf("Folder must be bound to the root"))
-	}
-
 	sdk, err := url.Parse(fmt.Sprintf("https://%v/sdk", p.config.Host))
 	if err != nil {
 		errs = packersdk.MultiErrorAppend(


### PR DESCRIPTION
Apparently this check is obsolete (see https://github.com/hashicorp/packer/issues/6975, specifically "You're right, the folder bound to the root doesn't do any effect at code level, that was because the[ first implementation ](https://github.com/bennu/packer/blob/2ddc07d3b9a84f59e65a6cc0fafd68db158645f5/post-processor/vsphere-template/step_create_folder.go#L43)used to use that, sadly I forgot to remove it when I changed it.") and still has an open issue (https://github.com/hashicorp/packer-plugin-vsphere/issues/3).  With this check in place, any attempt to use the vsphere-template post-processor seems to fail with errors like:

```
Error: Failed preparing post-processor-block "vsphere-template" ""

  on ubuntu-2204.pkr.hcl line 303:
  (source code not available)

1 error(s) occurred:

* Folder must be bound to the root
```

This was tested against the latest version.

gist with DEBUG log output: https://gist.github.com/cyberops7/751cd2f23189579f487174c7580f594a

Test case: include the `vsphere-template` post-processor block:
```
post-processors {
    post-processor "vsphere-template"{
      host             = var.vcenter_server
      insecure         = var.vcenter_insecure_connection
      username         = var.vcenter_username
      password         = var.vcenter_password
      datacenter       = var.vcenter_datacenter
      folder           = var.vcenter_template_folder
    }
  }
```

Closes #3


