### PR TITLE
refactor: only add / remove minimul number of cdroms

### DIFF
--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -73,12 +73,8 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 		}
 	}
 
-	ui.Say("Mounting ISO images...")
 	if path, ok := state.GetOk("iso_remote_path"); ok {
-		if err := vm.AddCdrom(s.Config.CdromType, path.(string)); err != nil {
-			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
-			return multistep.ActionHalt
-		}
+		s.Config.ISOPaths = append(s.Config.ISOPaths, path.(string))
 	}
 
 	// Add our custom CD, if it exists
@@ -86,6 +82,7 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 		s.Config.ISOPaths = append(s.Config.ISOPaths, cd_path)
 	}
 
+	ui.Say("Mounting ISO images...")
 	for _, path := range s.Config.ISOPaths {
 		if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
 			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))

--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -83,7 +83,13 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	ui.Say("Mounting ISO images...")
+	// Limitation in govmomi: can't batch-create cdroms and then mount ISO files,
+	// that results in wrong UnitNumber. So do that one-by-one.
 	for _, path := range s.Config.ISOPaths {
+		if path == "" {
+			state.Put("error", fmt.Errorf("invalid path: empty string"))
+			return multistep.ActionHalt
+		}
 		if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
 			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
 			return multistep.ActionHalt

--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -86,14 +86,13 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 		s.Config.ISOPaths = append(s.Config.ISOPaths, cd_path)
 	}
 
-	if len(s.Config.ISOPaths) > 0 {
-		for _, path := range s.Config.ISOPaths {
-			if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
-				state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
-				return multistep.ActionHalt
-			}
+	for _, path := range s.Config.ISOPaths {
+		if err := vm.AddCdrom(s.Config.CdromType, path); err != nil {
+			state.Put("error", fmt.Errorf("error mounting an image '%v': %v", path, err))
+			return multistep.ActionHalt
 		}
 	}
+
 	return multistep.ActionContinue
 }
 

--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -96,7 +96,7 @@ func TestStepAddCDRom_Run(t *testing.T) {
 				FindSATAControllerCalled: true,
 				AddCdromCalledTimes:      3,
 				AddCdromTypes:            []string{"sata", "sata", "sata"},
-				AddCdromPaths:            []string{"remote/path", "iso/path", "cd/path"},
+				AddCdromPaths:            []string{"iso/path", "remote/path", "cd/path"},
 			},
 			fail:       false,
 			errMessage: "",

--- a/builder/vsphere/common/step_reattach_cdrom.go
+++ b/builder/vsphere/common/step_reattach_cdrom.go
@@ -54,11 +54,11 @@ func (s *StepReattachCDRom) Run(_ context.Context, state multistep.StateBag) mul
 		state.Put("error", fmt.Errorf("error removing cdrom prior to reattaching: %v", err))
 		return multistep.ActionHalt
 	}
-	// If the CD-ROM device type is SATA, find the SATA controller.
+
+	// If the CD-ROM device type is SATA, make sure SATA controller is present.
 	if s.CDRomConfig.CdromType == "sata" {
 		if _, err := vm.FindSATAController(); err == driver.ErrNoSataController {
 			ui.Say("Adding SATA controller...")
-			// If a SATA controller is not found, add it.
 			if err := vm.AddSATAController(); err != nil {
 				state.Put("error", fmt.Errorf("error adding sata controller: %v", err))
 				return multistep.ActionHalt

--- a/builder/vsphere/common/step_reattach_cdrom_test.go
+++ b/builder/vsphere/common/step_reattach_cdrom_test.go
@@ -27,7 +27,7 @@ func TestStepReattachCDRom_Run(t *testing.T) {
 		errMessage     string
 	}{
 		{
-			name: "Successfully reattach CD-ROM device",
+			name: "Successfully attach 3 additional CD-ROM devices",
 			step: &StepReattachCDRom{
 				Config: &ReattachCDRomConfig{
 					ReattachCDRom: 4,
@@ -43,22 +43,67 @@ func TestStepReattachCDRom_Run(t *testing.T) {
 			},
 			expectedVmMock: &driver.VirtualMachineMock{
 				EjectCdromsCalled:        true,
-				RemoveCdromsCalled:       true,
 				ReattachCDRomsCalled:     true,
 				FindSATAControllerCalled: true,
-				AddCdromCalledTimes:      8,
+				AddCdromCalledTimes:      6,
 				AddCdromTypes: []string{
 					"sata", "sata",
 					"sata", "sata",
 					"sata", "sata",
-					"sata", "sata",
 				},
-				AddCdromPaths: []string{
-					"[datastore] /iso/linux.iso", "[datastore] /iso/linux.iso",
-					"[datastore] /iso/linux.iso", "[datastore] /iso/linux.iso",
-					"[datastore] /iso/linux.iso", "[datastore] /iso/linux.iso",
-					"[datastore] /iso/linux.iso", "[datastore] /iso/linux.iso",
+			},
+			fail: false,
+		},
+		{
+			name: "Successfully attach 2 fewer CD-ROM devices than initially added",
+			step: &StepReattachCDRom{
+				Config: &ReattachCDRomConfig{
+					ReattachCDRom: 2,
 				},
+				CDRomConfig: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths: []string{
+						"[datastore] /iso/linux1.iso",
+						"[datastore] /iso/linux2.iso",
+						"[datastore] /iso/linux3.iso",
+						"[datastore] /iso/linux4.iso",
+					},
+				},
+			},
+			expectedAction: multistep.ActionContinue,
+			vmMock: &driver.VirtualMachineMock{
+				ReattachCDRomsCalled: true,
+			},
+			expectedVmMock: &driver.VirtualMachineMock{
+				RemoveNCdromsCalled:  true,
+				EjectCdromsCalled:    true,
+				ReattachCDRomsCalled: true,
+				AddCdromCalledTimes:  0,
+			},
+			fail: false,
+		},
+		{
+			name: "Successfully attach the same number of CD-ROMs as initially added",
+			step: &StepReattachCDRom{
+				Config: &ReattachCDRomConfig{
+					ReattachCDRom: 2,
+				},
+				CDRomConfig: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths: []string{
+						"[datastore] /iso/linux1.iso",
+						"[datastore] /iso/linux2.iso",
+					},
+				},
+			},
+			expectedAction: multistep.ActionContinue,
+			vmMock: &driver.VirtualMachineMock{
+				ReattachCDRomsCalled: true,
+			},
+			expectedVmMock: &driver.VirtualMachineMock{
+				EjectCdromsCalled:    true,
+				ReattachCDRomsCalled: true,
+				AddCdromCalledTimes:  0,
 			},
 			fail: false,
 		},

--- a/builder/vsphere/driver/vm_cdrom.go
+++ b/builder/vsphere/driver/vm_cdrom.go
@@ -5,6 +5,7 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/vmware/govmomi/vim25/types"
 )
@@ -69,6 +70,30 @@ func (vm *VirtualMachineDriver) RemoveCdroms() error {
 	if err = vm.RemoveDevice(true, sata...); err != nil {
 		return err
 	}
+	return nil
+}
+
+// RemoveNCdroms removes up to n CD-ROMs from the image.
+// An error will occur If n is larger then the attached CD-ROM count.
+// n == 0 results in no CD-ROMs being removed.
+func (vm *VirtualMachineDriver) RemoveNCdroms(n int) error {
+	if n == 0 {
+		return nil
+	}
+	devices, err := vm.Devices()
+	if err != nil {
+		return err
+	}
+	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
+	if (n < 0) || (n > len(cdroms)) {
+		return fmt.Errorf("invalid number: n must be between 0 and %d", len(cdroms))
+	}
+
+	cdroms = cdroms[:n]
+	if err = vm.RemoveDevice(true, cdroms...); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -64,6 +64,9 @@ type VirtualMachineMock struct {
 	RemoveCdromsCalled bool
 	RemoveCdromsErr    error
 
+	RemoveNCdromsCalled bool
+	RemoveNCdromsErr    error
+
 	ReattachCDRomsCalled bool
 	ReattachCDRomsErr    error
 
@@ -185,10 +188,12 @@ func (vm *VirtualMachineMock) GetDir() (string, error) {
 	return vm.GetDirResponse, vm.GetDirErr
 }
 
-func (vm *VirtualMachineMock) AddCdrom(cdromType string, isoPath string) error {
+func (vm *VirtualMachineMock) AddCdrom(controllerType string, isoPath string) error {
 	vm.AddCdromCalledTimes++
-	vm.AddCdromTypes = append(vm.AddCdromTypes, cdromType)
-	vm.AddCdromPaths = append(vm.AddCdromPaths, isoPath)
+	vm.AddCdromTypes = append(vm.AddCdromTypes, controllerType)
+	if isoPath != "" {
+		vm.AddCdromPaths = append(vm.AddCdromPaths, isoPath)
+	}
 	return vm.AddCdromErr
 }
 
@@ -262,6 +267,11 @@ func (vm *VirtualMachineMock) CreateCdrom(c *types.VirtualController) (*types.Vi
 func (vm *VirtualMachineMock) RemoveCdroms() error {
 	vm.RemoveCdromsCalled = true
 	return vm.RemoveCdromsErr
+}
+
+func (vm *VirtualMachineMock) RemoveNCdroms(n_cdroms int) error {
+	vm.RemoveNCdromsCalled = true
+	return vm.RemoveNCdromsErr
 }
 
 func (vm *VirtualMachineMock) ReattachCDRoms() error {


### PR DESCRIPTION
In PR #344 a feature to reuse an existing VM is being added. As part of that feature I had to factor out from `AddCdrom` the logic of creating a CD-rom as opposed to just mounting an image. Recently merged feature `reattach_cdroms` turned out to be a new user of the older logic, which made rebasing #344 non-trivial.

In this PR I refactor the `reattach_cdroms` logic to avoid unnecessarily calling `EjectCdroms`, `RemoveCdroms` and `AddCdrom` by calculating amount of CDroms that we want to have added/removed, and only calling the mentioned functions for that amount *(see the last commit)*.

This is a useful change in itself, disregarding whether #344 exists, so I'm sending it separately from the other PR. And it should simplify rebasing #344 later.
