### PR TITLE
feat: add `windows_sysprep_text` field

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -286,7 +286,23 @@ The settings for customize are as follows:
 
 - `windows_sysprep_file` (string) - Provide a sysprep.xml file to allow control of the customization process independent of vSphere. This option is deprecated, please use windows_sysprep_text.
 
-- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere.
+- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere. This option is intended to be used with HCL templates.
+  
+  **Example usage:**
+  **In HCL2:**
+  ```hcl
+  customize {
+     windows_sysprep_text = file("<path-to-sysprep.xml>")
+  }
+  ````
+  ```hcl
+  customize {
+     windows_sysprep_text = templatefile("<path-to-sysprep.xml>", {
+        var1="example"
+        var2="example-2"
+     })
+  }
+  ```
 
 - `network_interface` (NetworkInterfaces) - Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
   To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.

--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -284,7 +284,9 @@ The settings for customize are as follows:
 
 - `windows_options` (\*WindowsOptions) - Settings to Windows guest OS customization.
 
-- `windows_sysprep_file` (string) - Supply your own sysprep.xml file to allow full control of the customization process out-of-band of vSphere.
+- `windows_sysprep_file` (string) - Provide a sysprep.xml file to allow control of the customization process independent of vSphere. This option is deprecated, please use windows_sysprep_text.
+
+- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere.
 
 - `network_interface` (NetworkInterfaces) - Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
   To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -73,7 +73,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
-	// warnings := make([]string, 0)
+	warnings := make([]string, 0)
 	errs := new(packersdk.MultiError)
 
 	errs = packersdk.MultiErrorAppend(errs, c.ConnectConfig.Prepare()...)
@@ -100,11 +100,17 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		errs = packersdk.MultiErrorAppend(errs, c.ContentLibraryDestinationConfig.Prepare(&c.LocationConfig)...)
 	}
 	if c.CustomizeConfig != nil {
-		errs = packersdk.MultiErrorAppend(errs, c.CustomizeConfig.Prepare()...)
+		customizeWarnings, customizeErrors := c.CustomizeConfig.Prepare()
+		errs = packersdk.MultiErrorAppend(errs, customizeErrors...)
+		warnings = append(warnings, customizeWarnings...)
 	}
 
 	if len(errs.Errors) > 0 {
 		return nil, errs
+	}
+
+	if len(warnings) > 0 {
+		return warnings, nil
 	}
 
 	return nil, nil

--- a/builder/vsphere/clone/step_customize.hcl2spec.go
+++ b/builder/vsphere/clone/step_customize.hcl2spec.go
@@ -13,6 +13,7 @@ type FlatCustomizeConfig struct {
 	LinuxOptions       *FlatLinuxOptions      `mapstructure:"linux_options" cty:"linux_options" hcl:"linux_options"`
 	WindowsOptions     *FlatWindowsOptions    `mapstructure:"windows_options" cty:"windows_options" hcl:"windows_options"`
 	WindowsSysPrepFile *string                `mapstructure:"windows_sysprep_file" cty:"windows_sysprep_file" hcl:"windows_sysprep_file"`
+	WindowsSysPrepText *string                `mapstructure:"windows_sysprep_text" cty:"windows_sysprep_text" hcl:"windows_sysprep_text"`
 	NetworkInterfaces  []FlatNetworkInterface `mapstructure:"network_interface" cty:"network_interface" hcl:"network_interface"`
 	Ipv4Gateway        *string                `mapstructure:"ipv4_gateway" cty:"ipv4_gateway" hcl:"ipv4_gateway"`
 	Ipv6Gateway        *string                `mapstructure:"ipv6_gateway" cty:"ipv6_gateway" hcl:"ipv6_gateway"`
@@ -35,6 +36,7 @@ func (*FlatCustomizeConfig) HCL2Spec() map[string]hcldec.Spec {
 		"linux_options":        &hcldec.BlockSpec{TypeName: "linux_options", Nested: hcldec.ObjectSpec((*FlatLinuxOptions)(nil).HCL2Spec())},
 		"windows_options":      &hcldec.BlockSpec{TypeName: "windows_options", Nested: hcldec.ObjectSpec((*FlatWindowsOptions)(nil).HCL2Spec())},
 		"windows_sysprep_file": &hcldec.AttrSpec{Name: "windows_sysprep_file", Type: cty.String, Required: false},
+		"windows_sysprep_text": &hcldec.AttrSpec{Name: "windows_sysprep_text", Type: cty.String, Required: false},
 		"network_interface":    &hcldec.BlockListSpec{TypeName: "network_interface", Nested: hcldec.ObjectSpec((*FlatNetworkInterface)(nil).HCL2Spec())},
 		"ipv4_gateway":         &hcldec.AttrSpec{Name: "ipv4_gateway", Type: cty.String, Required: false},
 		"ipv6_gateway":         &hcldec.AttrSpec{Name: "ipv6_gateway", Type: cty.String, Required: false},

--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package clone
+
+import (
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TestSysprepFieldsMutuallyExclusive validates an error message is thrown
+// when both windows_sysprep_text and windows_sysprep_file are included in the config
+func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
+	// Customize config with windows sysprep file and windows sysprep text set.
+	config := &CustomizeConfig{
+		WindowsSysPrepFile: "path-to-file",
+		WindowsSysPrepText: "text",
+		NetworkInterfaces: []NetworkInterface{
+			NetworkInterface{},
+		},
+	}
+
+	// Expected error message
+	expectedError := errCustomizeOptionMutalExclusive
+	_, errors := config.Prepare()
+
+	// Make sure we only received on error
+	expectedErrorLength := 1
+	if len(errors) != expectedErrorLength {
+		t.Fatalf("expected errors of length %d but got %d", expectedErrorLength, len(errors))
+	}
+
+	// Validate the error messages are what we expect.
+	if errors[0].Error() != expectedError.Error() {
+		t.Fatalf("expected error message %s, but got error message %s", expectedError, errors[0].Error())
+	}
+}
+
+// TestWindowsSysprepFilePrintsWarning tests a warning about
+// the field being deprecated is returned when windows_sysprep_file field is set.
+func TestWindowsSysprepFilePrintsWarning(t *testing.T) {
+	// Customize config with windows sysprep file and windows sysprep text set.
+	config := &CustomizeConfig{
+		WindowsSysPrepFile: "path-to-file",
+		NetworkInterfaces: []NetworkInterface{
+			NetworkInterface{},
+		},
+	}
+
+	// Expected warning message
+	expectedWarning := windowsSysprepFileDeprecatedMessage
+	warnings, errors := config.Prepare()
+
+	// Fail if there were errors
+	if len(errors) > 0 {
+		t.Fatalf("there were errors when running prepare")
+	}
+
+	// Search warnings array for the warning message
+	found := false
+	for _, warning := range warnings {
+		if warning == expectedWarning {
+			found = true
+			break
+		}
+	}
+
+	// If we didn't find the expect warning message fail.
+	if found == false {
+		t.Fatalf("didn't find %s in warnings array", expectedWarning)
+	}
+
+}
+
+// TestWindowsSysprepTextSetsContent validates that when WindowSyrepText is set
+// that it sets the value for the vSphere customization spec.
+func TestWindowsSysprepTextSetsContent(t *testing.T) {
+	// Expected text
+	text := "xml customization spec"
+	config := &CustomizeConfig{
+		WindowsSysPrepText: text,
+		NetworkInterfaces: []NetworkInterface{
+			NetworkInterface{},
+		},
+	}
+
+	// Create a step customize object with the given config
+	stepCustomize := &StepCustomize{Config: config}
+
+	// Get the identity settings for the customize step
+	baseCustomizationSettings, err := stepCustomize.identitySettings()
+	if err != nil {
+		t.Fatalf("identity settings had unexpected errors. %v", err)
+	}
+
+	// Cast the result to the vsphere govmomi type
+	sysprepText, ok := baseCustomizationSettings.(*types.CustomizationSysprepText)
+	if !ok {
+		t.Fatalf("identity settings did not return CustomizationSysprepText type")
+	}
+
+	// Make sure the sysprep text value is equal to what was passed in via the config.
+	if sysprepText.Value != text {
+		t.Fatalf("expected the customization spec to contain %s but was %s", text, sysprepText.Value)
+	}
+}

--- a/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
@@ -6,7 +6,23 @@
 
 - `windows_sysprep_file` (string) - Provide a sysprep.xml file to allow control of the customization process independent of vSphere. This option is deprecated, please use windows_sysprep_text.
 
-- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere.
+- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere. This option is intended to be used with HCL templates.
+  
+  **Example usage:**
+  **In HCL2:**
+  ```hcl
+  customize {
+     windows_sysprep_text = file("<path-to-sysprep.xml>")
+  }
+  ````
+  ```hcl
+  customize {
+     windows_sysprep_text = templatefile("<path-to-sysprep.xml>", {
+        var1="example"
+        var2="example-2"
+     })
+  }
+  ```
 
 - `network_interface` (NetworkInterfaces) - Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
   To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.

--- a/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CustomizeConfig-not-required.mdx
@@ -4,7 +4,9 @@
 
 - `windows_options` (\*WindowsOptions) - Settings to Windows guest OS customization.
 
-- `windows_sysprep_file` (string) - Supply your own sysprep.xml file to allow full control of the customization process out-of-band of vSphere.
+- `windows_sysprep_file` (string) - Provide a sysprep.xml file to allow control of the customization process independent of vSphere. This option is deprecated, please use windows_sysprep_text.
+
+- `windows_sysprep_text` (string) - Provide the text for the sysprep.xml content to allow control of the customization process independent of vSphere.
 
 - `network_interface` (NetworkInterfaces) - Configure network interfaces on a per-interface basis that should matched up to the network adapters present in the VM.
   To use DHCP, declare an empty network_interface for each adapter being configured. This field is required.


### PR DESCRIPTION
Closes #357 

Allows users to submit a custom Windows Sysprep file as text instead of as a file. #357 discusses why this PR is useful. windows_sysprep_file will be marked as deprecated in favor of windows_sysprep_text. 

Note: I have tested this on my own Packer builds and it works fine. I noticed that there are not any tests around customization, but I am happy to write some if necessary.

