### PR TITLE
chore: address `io/ioutil` depreciation

### DIFF
--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -8,8 +8,8 @@ package clone
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -193,7 +193,7 @@ func (s *StepCustomize) identitySettings() (types.BaseCustomizationIdentitySetti
 	}
 
 	if s.Config.WindowsSysPrepFile != "" {
-		sysPrep, err := ioutil.ReadFile(s.Config.WindowsSysPrepFile)
+		sysPrep, err := os.ReadFile(s.Config.WindowsSysPrepFile)
 		if err != nil {
 			return nil, fmt.Errorf("error on reading %s: %s", s.Config.WindowsSysPrepFile, err)
 		}

--- a/builder/vsphere/common/step_ssh_key_pair.go
+++ b/builder/vsphere/common/step_ssh_key_pair.go
@@ -6,7 +6,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -98,7 +97,7 @@ func (s *StepSshKeyPair) Run(ctx context.Context, state multistep.StateBag) mult
 	if s.Debug {
 		ui.Message(fmt.Sprintf("Saving communicator private key for debug purposes: %s", s.DebugKeyPath))
 		// Write the key out
-		if err := ioutil.WriteFile(s.DebugKeyPath, kp.PrivateKeyPemBlock, 0600); err != nil {
+		if err := os.WriteFile(s.DebugKeyPath, kp.PrivateKeyPemBlock, 0600); err != nil {
 			state.Put("error", fmt.Errorf("Error saving debug key: %s", err))
 			return multistep.ActionHalt
 		}

--- a/builder/vsphere/driver/datastore_acc_test.go
+++ b/builder/vsphere/driver/datastore_acc_test.go
@@ -5,7 +5,7 @@ package driver
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
@@ -32,7 +32,7 @@ func TestFileUpload(t *testing.T) {
 	hostName := "esxi-1.vsphere65.test"
 
 	fileName := fmt.Sprintf("test-%v", time.Now().Unix())
-	tmpFile, err := ioutil.TempFile("", fileName)
+	tmpFile, err := os.CreateTemp("", fileName)
 	if err != nil {
 		t.Fatalf("Error creating temp file")
 	}
@@ -68,7 +68,7 @@ func TestFileUploadDRS(t *testing.T) {
 	hostName := ""
 
 	fileName := fmt.Sprintf("test-%v", time.Now().Unix())
-	tmpFile, err := ioutil.TempFile("", fileName)
+	tmpFile, err := os.CreateTemp("", fileName)
 	if err != nil {
 		t.Fatalf("Error creating temp file")
 	}

--- a/builder/vsphere/iso/builder_acc_test.go
+++ b/builder/vsphere/iso/builder_acc_test.go
@@ -5,7 +5,6 @@ package iso
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -484,7 +483,7 @@ func checkNetworkCard(name string) error {
 }
 
 func TestAccISOBuilderAcc_createFloppy(t *testing.T) {
-	tmpFile, err := ioutil.TempFile("", "packer-vsphere-iso-test")
+	tmpFile, err := os.CreateTemp("", "packer-vsphere-iso-test")
 	if err != nil {
 		t.Fatalf("Error creating temp file: %v", err)
 	}

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -6,7 +6,7 @@ package iso
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"path"
 	"strings"
 	"testing"
@@ -312,7 +312,7 @@ func TestStepCreateVM_Cleanup(t *testing.T) {
 	errorBuffer := &strings.Builder{}
 	ui := &packersdk.BasicUi{
 		Reader:      strings.NewReader(""),
-		Writer:      ioutil.Discard,
+		Writer:      io.Discard,
 		ErrorWriter: errorBuffer,
 	}
 	state.Put("ui", ui)

--- a/builder/vsphere/supervisor/step_create_source.go
+++ b/builder/vsphere/supervisor/step_create_source.go
@@ -9,7 +9,7 @@ package supervisor
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -247,7 +247,7 @@ func (s *StepCreateSource) createVMMetadataSecret(ctx context.Context, logger *P
 func (s *StepCreateSource) getBootstrapStringData(ctx context.Context, logger *PackerLogger) (map[string]string, error) {
 	if s.Config.BootstrapDataFile != "" {
 		logger.Info("Loading bootstrap data from file: %s", s.Config.BootstrapDataFile)
-		content, err := ioutil.ReadFile(s.Config.BootstrapDataFile)
+		content, err := os.ReadFile(s.Config.BootstrapDataFile)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/vsphere/supervisor/step_create_source_test.go
+++ b/builder/vsphere/supervisor/step_create_source_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -249,7 +248,7 @@ func TestCreateSource_RunCustomBootstrap(t *testing.T) {
 	defer os.Remove(testDataFile.Name())
 	defer testDataFile.Close()
 	testBootstrapData := []byte("unattend: test-unattend-config")
-	if err := ioutil.WriteFile(testDataFile.Name(), testBootstrapData, 0666); err != nil {
+	if err := os.WriteFile(testDataFile.Name(), testBootstrapData, 0666); err != nil {
 		t.Fatalf("Failed to write content to temp file: %v", err)
 	}
 	step.Config.BootstrapDataFile = testDataFile.Name()


### PR DESCRIPTION
`io/ioutil` is deprecated as of Go 1.16:

- Updates `ioutil.Discard` to `io.Discard`.
- Updates `ioutil.TempFile` to `os.CreateTemp`.
- Updates `ioutil.ReadFile` to `os.ReadFile`.
- Updates `ioutil.WriteFile` to `os.WriteFile`.

```console
packer-plugin-vsphere on  chore/ioutil-depreciation [!] via 🐹 v1.21.6 took 29.6s 
✦ ➜ make build

packer-plugin-vsphere on  chore/ioutil-depreciation [!] via 🐹 v1.21.6 took 8.7s 
✦ ➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        3.255s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       9.730s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       8.574s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  7.139s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   15.838s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       9.135s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      11.109s
```