### PR TITLE
feat: add support for precision clock device

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -749,6 +749,8 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 
 - `vTPM` (bool) - Add virtual TPM device for virtual machine. Defaults to `false`.
 
+- `precision_clock` (string) - Add a precision clock device for virtual machine. Defaults to `none`.
+
 <!-- End of code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; -->
 
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -406,6 +406,8 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 
 - `vTPM` (bool) - Add virtual TPM device for virtual machine. Defaults to `false`.
 
+- `precision_clock` (string) - Add a precision clock device for virtual machine. Defaults to `none`.
+
 <!-- End of code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; -->
 
 

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -66,6 +66,7 @@ type FlatConfig struct {
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
 	ForceBIOSSetup                  *bool                                       `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
 	VTPMEnabled                     *bool                                       `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
+	VirtualPrecisionClock           *string                                     `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
@@ -215,6 +216,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"force_bios_setup":               &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 		"vTPM":                           &hcldec.AttrSpec{Name: "vTPM", Type: cty.Bool, Required: false},
+		"precision_clock":                &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},

--- a/builder/vsphere/common/step_hardware.go
+++ b/builder/vsphere/common/step_hardware.go
@@ -52,6 +52,8 @@ type HardwareConfig struct {
 	ForceBIOSSetup bool `mapstructure:"force_bios_setup"`
 	// Add virtual TPM device for virtual machine. Defaults to `false`.
 	VTPMEnabled bool `mapstructure:"vTPM"`
+	// Add a precision clock device for virtual machine. Defaults to `none`.
+	VirtualPrecisionClock string `mapstructure:"precision_clock"`
 }
 
 func (c *HardwareConfig) Prepare() []error {
@@ -69,6 +71,10 @@ func (c *HardwareConfig) Prepare() []error {
 		errs = append(errs, fmt.Errorf("'vTPM' could be enabled only when 'firmware' set to 'efi' or 'efi-secure'"))
 	}
 
+	if c.VirtualPrecisionClock != "" && c.VirtualPrecisionClock != "ptp" && c.VirtualPrecisionClock != "ntp" && c.VirtualPrecisionClock != "none" {
+		errs = append(errs, fmt.Errorf("'precision_clock' must be '', 'ptp', 'ntp', or 'none'"))
+	}
+
 	return errs
 }
 
@@ -84,22 +90,23 @@ func (s *StepConfigureHardware) Run(_ context.Context, state multistep.StateBag)
 		ui.Say("Customizing hardware...")
 
 		err := vm.Configure(&driver.HardwareConfig{
-			CPUs:                s.Config.CPUs,
-			CpuCores:            s.Config.CpuCores,
-			CPUReservation:      s.Config.CPUReservation,
-			CPULimit:            s.Config.CPULimit,
-			RAM:                 s.Config.RAM,
-			RAMReservation:      s.Config.RAMReservation,
-			RAMReserveAll:       s.Config.RAMReserveAll,
-			NestedHV:            s.Config.NestedHV,
-			CpuHotAddEnabled:    s.Config.CpuHotAddEnabled,
-			MemoryHotAddEnabled: s.Config.MemoryHotAddEnabled,
-			VideoRAM:            s.Config.VideoRAM,
-			Displays:            s.Config.Displays,
-			VGPUProfile:         s.Config.VGPUProfile,
-			Firmware:            s.Config.Firmware,
-			ForceBIOSSetup:      s.Config.ForceBIOSSetup,
-			VTPMEnabled:         s.Config.VTPMEnabled,
+			CPUs:                  s.Config.CPUs,
+			CpuCores:              s.Config.CpuCores,
+			CPUReservation:        s.Config.CPUReservation,
+			CPULimit:              s.Config.CPULimit,
+			RAM:                   s.Config.RAM,
+			RAMReservation:        s.Config.RAMReservation,
+			RAMReserveAll:         s.Config.RAMReserveAll,
+			NestedHV:              s.Config.NestedHV,
+			CpuHotAddEnabled:      s.Config.CpuHotAddEnabled,
+			MemoryHotAddEnabled:   s.Config.MemoryHotAddEnabled,
+			VideoRAM:              s.Config.VideoRAM,
+			Displays:              s.Config.Displays,
+			VGPUProfile:           s.Config.VGPUProfile,
+			Firmware:              s.Config.Firmware,
+			ForceBIOSSetup:        s.Config.ForceBIOSSetup,
+			VTPMEnabled:           s.Config.VTPMEnabled,
+			VirtualPrecisionClock: s.Config.VirtualPrecisionClock,
 		})
 		if err != nil {
 			state.Put("error", err)

--- a/builder/vsphere/common/step_hardware.hcl2spec.go
+++ b/builder/vsphere/common/step_hardware.hcl2spec.go
@@ -10,22 +10,23 @@ import (
 // FlatHardwareConfig is an auto-generated flat version of HardwareConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatHardwareConfig struct {
-	CPUs                *int32  `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
-	CpuCores            *int32  `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
-	CPUReservation      *int64  `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
-	CPULimit            *int64  `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
-	CpuHotAddEnabled    *bool   `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`
-	RAM                 *int64  `mapstructure:"RAM" cty:"RAM" hcl:"RAM"`
-	RAMReservation      *int64  `mapstructure:"RAM_reservation" cty:"RAM_reservation" hcl:"RAM_reservation"`
-	RAMReserveAll       *bool   `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
-	MemoryHotAddEnabled *bool   `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
-	VideoRAM            *int64  `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
-	Displays            *int32  `mapstructure:"displays" cty:"displays" hcl:"displays"`
-	VGPUProfile         *string `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
-	NestedHV            *bool   `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
-	Firmware            *string `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
-	ForceBIOSSetup      *bool   `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
-	VTPMEnabled         *bool   `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
+	CPUs                  *int32  `mapstructure:"CPUs" cty:"CPUs" hcl:"CPUs"`
+	CpuCores              *int32  `mapstructure:"cpu_cores" cty:"cpu_cores" hcl:"cpu_cores"`
+	CPUReservation        *int64  `mapstructure:"CPU_reservation" cty:"CPU_reservation" hcl:"CPU_reservation"`
+	CPULimit              *int64  `mapstructure:"CPU_limit" cty:"CPU_limit" hcl:"CPU_limit"`
+	CpuHotAddEnabled      *bool   `mapstructure:"CPU_hot_plug" cty:"CPU_hot_plug" hcl:"CPU_hot_plug"`
+	RAM                   *int64  `mapstructure:"RAM" cty:"RAM" hcl:"RAM"`
+	RAMReservation        *int64  `mapstructure:"RAM_reservation" cty:"RAM_reservation" hcl:"RAM_reservation"`
+	RAMReserveAll         *bool   `mapstructure:"RAM_reserve_all" cty:"RAM_reserve_all" hcl:"RAM_reserve_all"`
+	MemoryHotAddEnabled   *bool   `mapstructure:"RAM_hot_plug" cty:"RAM_hot_plug" hcl:"RAM_hot_plug"`
+	VideoRAM              *int64  `mapstructure:"video_ram" cty:"video_ram" hcl:"video_ram"`
+	Displays              *int32  `mapstructure:"displays" cty:"displays" hcl:"displays"`
+	VGPUProfile           *string `mapstructure:"vgpu_profile" cty:"vgpu_profile" hcl:"vgpu_profile"`
+	NestedHV              *bool   `mapstructure:"NestedHV" cty:"NestedHV" hcl:"NestedHV"`
+	Firmware              *string `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
+	ForceBIOSSetup        *bool   `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
+	VTPMEnabled           *bool   `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
+	VirtualPrecisionClock *string `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 }
 
 // FlatMapstructure returns a new FlatHardwareConfig.
@@ -56,6 +57,7 @@ func (*FlatHardwareConfig) HCL2Spec() map[string]hcldec.Spec {
 		"firmware":         &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"force_bios_setup": &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 		"vTPM":             &hcldec.AttrSpec{Name: "vTPM", Type: cty.Bool, Required: false},
+		"precision_clock":  &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_hardware_test.go
+++ b/builder/vsphere/common/step_hardware_test.go
@@ -97,6 +97,21 @@ func TestHardwareConfig_Prepare(t *testing.T) {
 			fail:           true,
 			expectedErrMsg: "'vTPM' could be enabled only when 'firmware' set to 'efi' or 'efi-secure'",
 		},
+		{
+			name: "Validate 'precision_clock'",
+			config: &HardwareConfig{
+				VirtualPrecisionClock: "ntp",
+			},
+			fail: false,
+		},
+		{
+			name: "Validate 'precision_clock' and invalid option",
+			config: &HardwareConfig{
+				VirtualPrecisionClock: "invalid",
+			},
+			fail:           true,
+			expectedErrMsg: "'precision_clock' must be '', 'ptp', 'ntp', or 'none'",
+		},
 	}
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -93,22 +93,23 @@ type CloneConfig struct {
 }
 
 type HardwareConfig struct {
-	CPUs                int32
-	CpuCores            int32
-	CPUReservation      int64
-	CPULimit            int64
-	RAM                 int64
-	RAMReservation      int64
-	RAMReserveAll       bool
-	NestedHV            bool
-	CpuHotAddEnabled    bool
-	MemoryHotAddEnabled bool
-	VideoRAM            int64
-	Displays            int32
-	VGPUProfile         string
-	Firmware            string
-	ForceBIOSSetup      bool
-	VTPMEnabled         bool
+	CPUs                  int32
+	CpuCores              int32
+	CPUReservation        int64
+	CPULimit              int64
+	RAM                   int64
+	RAMReservation        int64
+	RAMReserveAll         bool
+	NestedHV              bool
+	CpuHotAddEnabled      bool
+	MemoryHotAddEnabled   bool
+	VideoRAM              int64
+	Displays              int32
+	VGPUProfile           string
+	Firmware              string
+	ForceBIOSSetup        bool
+	VTPMEnabled           bool
+	VirtualPrecisionClock string
 }
 
 type NIC struct {
@@ -656,6 +657,20 @@ func (vm *VirtualMachineDriver) Configure(config *HardwareConfig) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	if config.VirtualPrecisionClock != "" && config.VirtualPrecisionClock != "none" {
+		device := &types.VirtualPrecisionClock{
+			VirtualDevice: types.VirtualDevice{
+				Backing: &types.VirtualPrecisionClockSystemClockBackingInfo{
+					Protocol: config.VirtualPrecisionClock,
+				},
+			},
+		}
+		err = vm.addDevice(device)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -42,17 +42,18 @@ func TestVirtualMachineDriver_Configure(t *testing.T) {
 
 	// Happy test
 	hardwareConfig := &HardwareConfig{
-		CPUs:           1,
-		CpuCores:       1,
-		CPUReservation: 2500,
-		CPULimit:       1,
-		RAM:            1024,
-		RAMReserveAll:  true,
-		VideoRAM:       512,
-		VGPUProfile:    "grid_m10-8q",
-		Firmware:       "efi-secure",
-		ForceBIOSSetup: true,
-		VTPMEnabled:    true,
+		CPUs:                  1,
+		CpuCores:              1,
+		CPUReservation:        2500,
+		CPULimit:              1,
+		RAM:                   1024,
+		RAMReserveAll:         true,
+		VideoRAM:              512,
+		VGPUProfile:           "grid_m10-8q",
+		Firmware:              "efi-secure",
+		ForceBIOSSetup:        true,
+		VTPMEnabled:           true,
+		VirtualPrecisionClock: "ntp",
 	}
 	if err = vm.Configure(hardwareConfig); err != nil {
 		t.Fatalf("should not fail: %s", err.Error())

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -64,6 +64,7 @@ type FlatConfig struct {
 	Firmware                        *string                                     `mapstructure:"firmware" cty:"firmware" hcl:"firmware"`
 	ForceBIOSSetup                  *bool                                       `mapstructure:"force_bios_setup" cty:"force_bios_setup" hcl:"force_bios_setup"`
 	VTPMEnabled                     *bool                                       `mapstructure:"vTPM" cty:"vTPM" hcl:"vTPM"`
+	VirtualPrecisionClock           *string                                     `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
@@ -215,6 +216,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"firmware":                       &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"force_bios_setup":               &hcldec.AttrSpec{Name: "force_bios_setup", Type: cty.Bool, Required: false},
 		"vTPM":                           &hcldec.AttrSpec{Name: "vTPM", Type: cty.Bool, Required: false},
+		"precision_clock":                &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/HardwareConfig-not-required.mdx
@@ -36,4 +36,6 @@
 
 - `vTPM` (bool) - Add virtual TPM device for virtual machine. Defaults to `false`.
 
+- `precision_clock` (string) - Add a precision clock device for virtual machine. Defaults to `none`.
+
 <!-- End of code generated from the comments of the HardwareConfig struct in builder/vsphere/common/step_hardware.go; -->


### PR DESCRIPTION
These changes allow you to define a VirtualPrecisionClock device.

### Reference

Closes #354

### Tests

From @tenthirtyam 

```console
packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ go get

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 took 3.0s 
➜ go mod tidy

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ go fmt builder/vsphere/driver/vm.go 

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ go fmt builder/vsphere/driver/vm_test.go 

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ go fmt builder/vsphere/common/step_hardware.go 

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ go fmt builder/vsphere/common/step_hardware_test.go 

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ make generate
2024/02/26 14:26:48 Copying "docs" to ".docs/"
2024/02/26 14:26:48 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 took 41.1s 
➜ make build

packer-plugin-vsphere on  pr/367 [⇕$!] via 🐹 v1.22.0 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        8.858s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       4.369s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       15.168s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  6.187s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   20.340s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       12.214s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      14.876s
```