### PR TITLE
docs: update `vsphere/iso/step_create`

### DIFF
--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -788,22 +788,36 @@ boot time.
 
 <!-- Code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `vm_version` (uint) - Set VM hardware version. Defaults to the most current VM hardware
-  version supported by the vCenter Server version. See
-  [VMware KB article 1003746](https://kb.vmware.com/s/article/1003746) for
-  the full list of supported VM hardware versions.
+- `vm_version` (uint) - Specifies the virtual machine hardware version. Defaults to the most current virtual machine
+  hardware version supported by the ESXi host.
+  Refer to [VMware KB article 1003746](https://kb.vmware.com/s/article/1003746) for the list
+  of supported virtual machine hardware versions.
 
-- `guest_os_type` (string) - Set VM OS type. Defaults to `otherGuest`. See [
-  here](https://developer.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
-  for a full list of possible values.
+- `guest_os_type` (string) - Specifies the guest operating system identifier for the virtual machine.
+  If not specified, the setting defaults to `otherGuest`.
+  
+  To get a list of supported guest operating system identifiers for your ESXi host,
+  run the following PowerShell command using `VMware.PowerCLI`:
+  
+  ```powershell
+  Connect-VIServer -Server "vc.example.com" -User "administrator@vsphere" -Password "password"
+  $esxiHost = Get-VMHost -Name "esxi.example.com"
+  $environmentBrowser = Get-View -Id $esxiHost.ExtensionData.Parent.ExtensionData.ConfigManager.EnvironmentBrowser
+  $vmxVersion = ($environmentBrowser.QueryConfigOptionDescriptor() | Where-Object DefaultConfigOption).Key
+  $osDescriptor = $environmentBrowser.QueryConfigOption($vmxVersion, $null).GuestOSDescriptor
+  $osDescriptor | Select-Object Id, Fullname
+  ```
 
-- `network_adapters` ([]NIC) - Sets the network adapters, if no adapter is specified, every network related task is not applicable.
+- `network_adapters` ([]NIC) - Specifies the network adapters for the virtual machine.
+  If no network adapter is defined, all network-related operations will be skipped.
 
-- `usb_controller` ([]string) - Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
+- `usb_controller` ([]string) - Specifies the USB controllers for the virtual machine. Use `usb` for a USB 2.0 controller and
+  `xhci`` for a USB 3.0 controller.
+  -> **Note:** Maximum of one controller of each type.
 
-- `notes` (string) - VM notes.
+- `notes` (string) - Specifies the annotations for the virtual machine.
 
-- `destroy` (bool) - If set to true, the VM will be destroyed after the builder completes
+- `destroy` (bool) - Specifies whether to destroy the virtual machine after the build is complete.
 
 <!-- End of code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; -->
 
@@ -863,7 +877,7 @@ In HCL2:
 
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network_card` (string) - Set VM network card type. Example `vmxnet3`.
+- `network_card` (string) - Specifies the virtual machine network card type. For example `vmxnet3`.
 
 <!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->
 
@@ -872,14 +886,14 @@ In HCL2:
 
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
-  specified, `host` must be specified to allow Packer to look for the
-  available network. If the network is inside a network folder in vCenter,
-  you need to provide the full path to the network.
+- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
+  provide 'host' to allow Packer to search for an available network. For networks placed
+  within a network folder vCenter Server, provider the object path to the network.
+  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
 
-- `mac_address` (string) - Set network card MAC address
+- `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
 
-- `passthrough` (\*bool) - Enable DirectPath I/O passthrough
+- `passthrough` (\*bool) - Specifies whether to enable DirectPath I/O passthrough for the network device.
 
 <!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->
 

--- a/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/CreateConfig-not-required.mdx
@@ -1,20 +1,34 @@
 <!-- Code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `vm_version` (uint) - Set VM hardware version. Defaults to the most current VM hardware
-  version supported by the vCenter Server version. See
-  [VMware KB article 1003746](https://kb.vmware.com/s/article/1003746) for
-  the full list of supported VM hardware versions.
+- `vm_version` (uint) - Specifies the virtual machine hardware version. Defaults to the most current virtual machine
+  hardware version supported by the ESXi host.
+  Refer to [VMware KB article 1003746](https://kb.vmware.com/s/article/1003746) for the list
+  of supported virtual machine hardware versions.
 
-- `guest_os_type` (string) - Set VM OS type. Defaults to `otherGuest`. See [
-  here](https://developer.vmware.com/apis/358/vsphere/doc/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html)
-  for a full list of possible values.
+- `guest_os_type` (string) - Specifies the guest operating system identifier for the virtual machine.
+  If not specified, the setting defaults to `otherGuest`.
+  
+  To get a list of supported guest operating system identifiers for your ESXi host,
+  run the following PowerShell command using `VMware.PowerCLI`:
+  
+  ```powershell
+  Connect-VIServer -Server "vc.example.com" -User "administrator@vsphere" -Password "password"
+  $esxiHost = Get-VMHost -Name "esxi.example.com"
+  $environmentBrowser = Get-View -Id $esxiHost.ExtensionData.Parent.ExtensionData.ConfigManager.EnvironmentBrowser
+  $vmxVersion = ($environmentBrowser.QueryConfigOptionDescriptor() | Where-Object DefaultConfigOption).Key
+  $osDescriptor = $environmentBrowser.QueryConfigOption($vmxVersion, $null).GuestOSDescriptor
+  $osDescriptor | Select-Object Id, Fullname
+  ```
 
-- `network_adapters` ([]NIC) - Sets the network adapters, if no adapter is specified, every network related task is not applicable.
+- `network_adapters` ([]NIC) - Specifies the network adapters for the virtual machine.
+  If no network adapter is defined, all network-related operations will be skipped.
 
-- `usb_controller` ([]string) - Create USB controllers for the virtual machine. "usb" for a usb 2.0 controller. "xhci" for a usb 3.0 controller. There can only be at most one of each.
+- `usb_controller` ([]string) - Specifies the USB controllers for the virtual machine. Use `usb` for a USB 2.0 controller and
+  `xhci`` for a USB 3.0 controller.
+  -> **Note:** Maximum of one controller of each type.
 
-- `notes` (string) - VM notes.
+- `notes` (string) - Specifies the annotations for the virtual machine.
 
-- `destroy` (bool) - If set to true, the VM will be destroyed after the builder completes
+- `destroy` (bool) - Specifies whether to destroy the virtual machine after the build is complete.
 
 <!-- End of code generated from the comments of the CreateConfig struct in builder/vsphere/iso/step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
@@ -1,12 +1,12 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
-  specified, `host` must be specified to allow Packer to look for the
-  available network. If the network is inside a network folder in vCenter,
-  you need to provide the full path to the network.
+- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
+  provide 'host' to allow Packer to search for an available network. For networks placed
+  within a network folder vCenter Server, provider the object path to the network.
+  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
 
-- `mac_address` (string) - Set network card MAC address
+- `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
 
-- `passthrough` (\*bool) - Enable DirectPath I/O passthrough
+- `passthrough` (\*bool) - Specifies whether to enable DirectPath I/O passthrough for the network device.
 
 <!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->

--- a/docs-partials/builder/vsphere/iso/NIC-required.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC-required.mdx
@@ -1,5 +1,5 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network_card` (string) - Set VM network card type. Example `vmxnet3`.
+- `network_card` (string) - Specifies the virtual machine network card type. For example `vmxnet3`.
 
 <!-- End of code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; -->


### PR DESCRIPTION
### Summary

- Updates descriptions for generated documentation.
- Provides the PowerShell syntax using `VMware.PowerCLI`. By using this method, you can get the list of supported guest os identifiers based on the version of ESXI in your environment.

### Testing

```console
>make build
> make generate
2024/03/01 19:23:51 Copying "docs" to ".docs/"
2024/03/01 19:23:51 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...
```

### Documentation

`guest_os_type` (string) - Defines the guest operating system identifier for the virtual machine. If not specified, the setting defaults to `otherGuest`.

To get a list of supported guest operating system identifiers for your ESXi host run the following PowerShell command using `VMware.PowerCLI`:

```powershell
Connect-VIServer -Server "vc.example.com" -User "administrator@vsphere" -Password "password"
$esxiHost = Get-VMHost -Name "esxi.example.com"
$browser = Get-View -Id $esxiHost.ExtensionData.Parent.ExtensionData.ConfigManager.EnvironmentBrowser
$vmxVer = ($browser.QueryConfigOptionDescriptor() | Where-Object DefaultConfigOption).Key
$osDesc = $browser.QueryConfigOption($vmxVer, $null).GuestOSDescriptor
$osDesc | Select-Object Id, Fullname
```

### Explanation

By using this method, you can get the list based on the version of ESXI in your environment.

Example:

```powershell
Connect-VIServer -Server "vc.example.com" -User "administrator@vsphere" -Password "password"
$esxiHost = Get-VMHost -Name "esxi.example.com"
$browser = Get-View -Id $esxiHost.ExtensionData.Parent.ExtensionData.ConfigManager.EnvironmentBrowser
$vmxVer = ($browser.QueryConfigOptionDescriptor() | Where-Object DefaultConfigOption).Key
$osDesc = $browser.QueryConfigOption($vmxVer, $null).GuestOSDescriptor
$osDesc | Select-Object Id, Fullname

Id                         FullName
--                         --------
amazonlinux3_64Guest       Amazon Linux 3 (64-bit)
amazonlinux2_64Guest       Amazon Linux 2 (64-bit)
windows2019srvNext_64Guest Microsoft Windows Server 2022 (64-bit)
windows2019srv_64Guest     Microsoft Windows Server 2019 (64-bit)
windows9Server64Guest      Microsoft Windows Server 2016 (64-bit)
windows8Server64Guest      Microsoft Windows Server 2012 (64-bit)
windows7Server64Guest      Microsoft Windows Server 2008 R2 (64-bit)
winLonghorn64Guest         Microsoft Windows Server 2008 (64-bit)
winLonghornGuest           Microsoft Windows Server 2008 (32-bit)
winNetEnterprise64Guest    Microsoft Windows Server 2003 (64-bit)
winNetEnterpriseGuest      Microsoft Windows Server 2003 (32-bit)
winNetDatacenter64Guest    Microsoft Windows Server 2003 Datacenter (64-bit)
winNetDatacenterGuest      Microsoft Windows Server 2003 Datacenter (32-bit)
winNetStandard64Guest      Microsoft Windows Server 2003 Standard (64-bit)
winNetStandardGuest        Microsoft Windows Server 2003 Standard (32-bit)
winNetWebGuest             Microsoft Windows Server 2003 Web Edition (32-bit)
winNetBusinessGuest        Microsoft Small Business Server 2003
windows9_64Guest           Microsoft Windows 10 (64-bit)
windows9Guest              Microsoft Windows 10 (32-bit)
windows8_64Guest           Microsoft Windows 8.x (64-bit)
windows8Guest              Microsoft Windows 8.x (32-bit)
windows7_64Guest           Microsoft Windows 7 (64-bit)
windows7Guest              Microsoft Windows 7 (32-bit)
winVista64Guest            Microsoft Windows Vista (64-bit)
winVistaGuest              Microsoft Windows Vista (32-bit)
winXPPro64Guest            Microsoft Windows XP Professional (64-bit)
winXPProGuest              Microsoft Windows XP Professional (32-bit)
win2000AdvServGuest        Microsoft Windows 2000
win2000ServGuest           Microsoft Windows 2000 Server
win2000ProGuest            Microsoft Windows 2000 Professional
winNTGuest                 Microsoft Windows NT
win98Guest                 Microsoft Windows 98
win95Guest                 Microsoft Windows 95
win31Guest                 Microsoft Windows 3.1
dosGuest                   Microsoft MS-DOS
vmwarePhoton64Guest        VMware Photon OS (64-bit)
crxPod1Guest               VMware CRX Pod 1 (64-bit)
rhel9_64Guest              Red Hat Enterprise Linux 9 (64-bit)
rhel8_64Guest              Red Hat Enterprise Linux 8 (64-bit)
rhel7_64Guest              Red Hat Enterprise Linux 7 (64-bit)
rhel6_64Guest              Red Hat Enterprise Linux 6 (64-bit)
rhel6Guest                 Red Hat Enterprise Linux 6 (32-bit)
rhel5_64Guest              Red Hat Enterprise Linux 5 (64-bit)
rhel5Guest                 Red Hat Enterprise Linux 5 (32-bit)
rhel4_64Guest              Red Hat Enterprise Linux 4 (64-bit)
rhel4Guest                 Red Hat Enterprise Linux 4 (32-bit)
rhel3_64Guest              Red Hat Enterprise Linux 3 (64-bit)
rhel3Guest                 Red Hat Enterprise Linux 3 (32-bit)
rhel2Guest                 Red Hat Enterprise Linux 2.1
sles16_64Guest             SUSE Linux Enterprise 16 (64-bit)
sles15_64Guest             SUSE Linux Enterprise 15 (64-bit)
sles12_64Guest             SUSE Linux Enterprise 12 (64-bit)
sles11_64Guest             SUSE Linux Enterprise 11 (64-bit)
sles11Guest                SUSE Linux Enterprise 11 (32-bit)
sles10_64Guest             SUSE Linux Enterprise 10 (64-bit)
sles10Guest                SUSE Linux Enterprise 10 (32-bit)
sles64Guest                SUSE Linux Enterprise 8/9 (64-bit)
slesGuest                  SUSE Linux Enterprise 8/9 (32-bit)
centos9_64Guest            CentOS 9 (64-bit)
centos8_64Guest            CentOS 8 (64-bit)
centos7_64Guest            CentOS 7 (64-bit)
centos6_64Guest            CentOS 6 (64-bit)
centos6Guest               CentOS 6 (32-bit)
centos64Guest              CentOS 4/5 (64-bit)
centosGuest                CentOS 4/5 (32-bit)
debian11_64Guest           Debian GNU/Linux 11 (64-bit)
debian11Guest              Debian GNU/Linux 11 (32-bit)
debian10_64Guest           Debian GNU/Linux 10 (64-bit)
debian10Guest              Debian GNU/Linux 10 (32-bit)
debian9_64Guest            Debian GNU/Linux 9 (64-bit)
debian9Guest               Debian GNU/Linux 9 (32-bit)
debian8_64Guest            Debian GNU/Linux 8 (64-bit)
debian8Guest               Debian GNU/Linux 8 (32-bit)
debian7_64Guest            Debian GNU/Linux 7 (64-bit)
debian7Guest               Debian GNU/Linux 7 (32-bit)
debian6_64Guest            Debian GNU/Linux 6 (64-bit)
debian6Guest               Debian GNU/Linux 6 (32-bit)
debian5_64Guest            Debian GNU/Linux 5 (64-bit)
debian5Guest               Debian GNU/Linux 5 (32-bit)
debian4_64Guest            Debian GNU/Linux 4 (64-bit)
debian4Guest               Debian GNU/Linux 4 (32-bit)
opensuse64Guest            SUSE openSUSE (64-bit)
opensuseGuest              SUSE openSUSE (32-bit)
asianux8_64Guest           Asianux 8 (64-bit)
asianux7_64Guest           Asianux 7 (64-bit)
asianux4_64Guest           Asianux 4 (64-bit)
asianux4Guest              Asianux 4 (32-bit)
asianux3_64Guest           Asianux 3 (64-bit)
asianux3Guest              Asianux 3 (32-bit)
fedora64Guest              Red Hat Fedora (64-bit)
fedoraGuest                Red Hat Fedora (32-bit)
oesGuest                   Novell Open Enterprise Server
oracleLinux9_64Guest       Oracle Linux 9 (64-bit)
oracleLinux8_64Guest       Oracle Linux 8 (64-bit)
oracleLinux7_64Guest       Oracle Linux 7 (64-bit)
oracleLinux6_64Guest       Oracle Linux 6 (64-bit)
oracleLinux6Guest          Oracle Linux 6 (32-bit)
oracleLinux64Guest         Oracle Linux 4/5 (64-bit)
oracleLinuxGuest           Oracle Linux 4/5 (32-bit)
ubuntu64Guest              Ubuntu Linux (64-bit)
ubuntuGuest                Ubuntu Linux (32-bit)
coreos64Guest              CoreOS Linux (64-bit)
other5xLinux64Guest        Other 5.x or later Linux (64-bit)
other5xLinuxGuest          Other 5.x or later Linux (32-bit)
other4xLinux64Guest        Other 4.x Linux (64-bit)
other4xLinuxGuest          Other 4.x Linux (32-bit)
other3xLinux64Guest        Other 3.x Linux (64-bit)
other3xLinuxGuest          Other 3.x Linux (32-bit)
other26xLinux64Guest       Other 2.6.x Linux (64-bit)
other26xLinuxGuest         Other 2.6.x Linux (32-bit)
other24xLinux64Guest       Other 2.4.x Linux (64-bit)
other24xLinuxGuest         Other 2.4.x Linux (32-bit)
otherLinux64Guest          Other Linux (64-bit)
otherLinuxGuest            Other Linux (32-bit)
darwin21_64Guest           Apple macOS 12 (64-bit)
darwin20_64Guest           Apple macOS 11 (64-bit)
darwin19_64Guest           Apple macOS 10.15 (64-bit)
darwin18_64Guest           Apple macOS 10.14 (64-bit)
darwin17_64Guest           Apple macOS 10.13 (64-bit)
darwin16_64Guest           Apple macOS 10.12 (64-bit)
darwin15_64Guest           Apple Mac OS X 10.11 (64-bit)
darwin14_64Guest           Apple Mac OS X 10.10 (64-bit)
darwin13_64Guest           Apple Mac OS X 10.9 (64-bit)
darwin12_64Guest           Apple Mac OS X 10.8 (64-bit)
darwin11_64Guest           Apple Mac OS X 10.7 (64-bit)
darwin11Guest              Apple Mac OS X 10.7 (32-bit)
darwin10_64Guest           Apple Mac OS X 10.6 (64-bit)
darwin10Guest              Apple Mac OS X 10.6 (32-bit)
darwin64Guest              Apple Mac OS X 10.5 (64-bit)
darwinGuest                Apple Mac OS X 10.5 (32-bit)
freebsd13_64Guest          FreeBSD 13 or later versions (64-bit)
freebsd13Guest             FreeBSD 13 or later versions (32-bit)
freebsd12_64Guest          FreeBSD 12 (64-bit)
freebsd12Guest             FreeBSD 12 (32-bit)
freebsd11_64Guest          FreeBSD 11 (64-bit)
freebsd11Guest             FreeBSD 11 (32-bit)
freebsd64Guest             FreeBSD Pre-11 versions (64-bit)
freebsdGuest               FreeBSD Pre-11 versions (32-bit)
os2Guest                   IBM OS/2
netware6Guest              Novell NetWare 6.x
netware5Guest              Novell NetWare 5.1
solaris11_64Guest          Oracle Solaris 11 (64-bit)
solaris10_64Guest          Oracle Solaris 10 (64-bit)
solaris10Guest             Oracle Solaris 10 (32-bit)
solaris9Guest              Sun Microsystems Solaris 9
solaris8Guest              Sun Microsystems Solaris 8
openServer6Guest           SCO OpenServer 6
openServer5Guest           SCO OpenServer 5
unixWare7Guest             SCO UnixWare 7
eComStation2Guest          Serenity Systems eComStation 2
eComStationGuest           Serenity Systems eComStation 1
otherGuest64               Other (64-bit)
otherGuest                 Other (32-bit)
vmkernel65Guest            VMware ESXi 6.x
vmkernel7Guest             VMware ESXi 7.0 or later
vmkernel6Guest             VMware ESXi 6.0
vmkernel5Guest             VMware ESXi 5.x
```

### Reference

Closes #368 

