### PR TITLE
chore: correct typos and markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,21 @@
 Please refer to [releases](https://github.com/hashicorp/packer-plugin-vsphere/releases) for the latest CHANGELOG information.
 
 ---
+
 ## 1.0.2 (October 18, 2021)
 
-### NOTES:
+### NOTES
+
 Support for the HCP Packer registry is currently in beta and requires
 Packer v1.7.7 [GH-115] [GH-120]
 
-### FEATURES:
+### FEATURES
+
 * Add HCP Packer registry image metadata to all artifacts. [GH-115]
     [GH-120]
 
-## IMPROVEMENTS:
+## IMPROVEMENTS
+
 * Add `floppy_content` parameter, which is similar to `http_content` and
     `cd_content`, but for floppy. [GH-117]
 * Add skip_import parameter in content_library_destination configuration.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ The plugin includes two builders which are able to create images, depending on y
 
     Learn more: [VMware Product Lifecycle Matrix][vmware-product-lifecycle-matrix]
 
-    > **Note**
-    >
-    > This plugin requires API write access and is therefore not supported for use with a free VMware vSphere Hypervisor license.
-
-* [Go 1.18][golang-install]
+* [Go 1.19][golang-install]
 
     Required if building the plugin.
 
@@ -50,7 +46,7 @@ packer {
 
 #### Manual Installation
 
-You can download [pre-built binary releases][releases-vsphere-plugin] of the plugin on GitHub. Once you have downloaded the latest release archive for your target operating system and architecture, uncompress to retrieve the plugin binary file for your platform.
+You can download [pre-built binary releases][releases-vsphere-plugin] of the plugin on GitHub. Once you have downloaded the latest release archive for your target operating system and architecture, extract the release archive to retrieve the plugin binary file for your platform.
 
 To install the downloaded plugin, please follow the Packer documentation on [installing a plugin][docs-packer-plugin-install].
 

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -32,7 +32,7 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	warns, err := conf.Prepare(raw)
 	testConfigOk(t, warns, err)
 	if conf.ShutdownConfig.Timeout != 3*time.Minute {
-		t.Fatalf("shutdown_timeout sould be equal 3 minutes, got %v", conf.ShutdownConfig.Timeout)
+		t.Fatalf("shutdown_timeout should be equal 3 minutes, got %v", conf.ShutdownConfig.Timeout)
 	}
 }
 

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -127,14 +127,14 @@ func TestCreateConfig_Prepare(t *testing.T) {
 			errs := c.config.Prepare()
 			if c.fail {
 				if len(errs) == 0 {
-					t.Fatalf("Config preprare should fail")
+					t.Fatalf("Config prepare should fail")
 				}
 				if errs[0].Error() != c.expectedErrMsg {
 					t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
 				}
 			} else {
 				if len(errs) != 0 {
-					t.Fatalf("Config preprare should not fail: %s", errs[0])
+					t.Fatalf("Config prepare should not fail: %s", errs[0])
 				}
 			}
 		})

--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	errCustomizeOptionMutalExclusive    = fmt.Errorf("Only one of `linux_options`, `windows_options`, `windows_sysprep_file` can be set")
+	errCustomizeOptionMutualExclusive   = fmt.Errorf("only one of `linux_options`, `windows_options`, `windows_sysprep_file` can be set")
 	windowsSysprepFileDeprecatedMessage = "`windows_sysprep_file` is deprecated and will be removed in a future release. please use `windows_sysprep_text`."
 )
 
@@ -168,7 +168,7 @@ func (c *CustomizeConfig) Prepare() ([]string, []error) {
 	}
 
 	if options_number > 1 {
-		errs = append(errs, errCustomizeOptionMutalExclusive)
+		errs = append(errs, errCustomizeOptionMutualExclusive)
 	} else if options_number == 0 {
 		errs = append(errs, fmt.Errorf("One of `linux_options`, `windows_options`, `windows_sysprep_file` must be set"))
 	}

--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -22,7 +22,7 @@ func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
 	}
 
 	// Expected error message
-	expectedError := errCustomizeOptionMutalExclusive
+	expectedError := errCustomizeOptionMutualExclusive
 	_, errors := config.Prepare()
 
 	// Make sure we only received on error

--- a/builder/vsphere/common/hcp_metadata.go
+++ b/builder/vsphere/common/hcp_metadata.go
@@ -36,7 +36,7 @@ func GetVMMetadata(vm *driver.VirtualMachineDriver, state multistep.StateBag) ma
 		p := vm.NewResourcePool(info.ResourcePool)
 		poolPath, err := p.Path()
 		if err == nil && poolPath != "" {
-			labels["resurce_pool"] = poolPath
+			labels["resource_pool"] = poolPath
 		}
 	}
 

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -159,7 +159,7 @@ loop:
 
 	if prevIp == "" || prevIp != ip {
 		if prevIp == "" {
-			log.Printf("VM IP aquired: %s", ip)
+			log.Printf("VM IP acquired: %s", ip)
 		} else {
 			log.Printf("VM IP changed from %s to %s", prevIp, ip)
 		}

--- a/builder/vsphere/driver/disk_test.go
+++ b/builder/vsphere/driver/disk_test.go
@@ -29,7 +29,7 @@ func TestAddStorageDevices(t *testing.T) {
 	noExistingDevices := object.VirtualDeviceList{}
 	storageConfigSpec, err := config.AddStorageDevices(noExistingDevices)
 	if err != nil {
-		t.Fatalf("unexpected erro: %q", err.Error())
+		t.Fatalf("unexpected error: %q", err.Error())
 	}
 	if len(storageConfigSpec) != 3 {
 		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))
@@ -41,7 +41,7 @@ func TestAddStorageDevices(t *testing.T) {
 
 	storageConfigSpec, err = config.AddStorageDevices(existingDevices)
 	if err != nil {
-		t.Fatalf("unexpected erro: %q", err.Error())
+		t.Fatalf("unexpected error: %q", err.Error())
 	}
 	if len(storageConfigSpec) != 3 {
 		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -108,7 +108,7 @@ func (l *LibraryFilePath) Validate() error {
 	l.path = strings.TrimLeft(l.path, "/")
 	parts := strings.Split(l.path, "/")
 	if len(parts) != 3 {
-		return fmt.Errorf("Not a valid Content Library File path. The path must contain the nanmes for the library, item and file.")
+		return fmt.Errorf("invalid content library file path. path must contain the names for the library, item, and file.")
 	}
 	return nil
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -168,12 +168,12 @@ func (d *VCenterDriver) PreCleanVM(ui packersdk.Ui, vmPath string, force bool, v
 		// covert to a vm if it is a template so it can be deleted
 		isTemplate, err := vm.IsTemplate()
 		if err != nil {
-			return fmt.Errorf("error determing if the vm is a template%s: %v", vmPath, err)
+			return fmt.Errorf("error determining if the vm is a template%s: %v", vmPath, err)
 		} else if isTemplate {
 			ui.Say(fmt.Sprintf("%s is a template, attempting to convert it to a vm", vmPath))
 			err := vm.ConvertToVirtualMachine(vsphereCluster, vsphereHost, vsphereResourcePool)
 			if err != nil {
-				return fmt.Errorf("error convertng template back to virtual machine for cleanup %s: %v", vmPath, err)
+				return fmt.Errorf("error converting template back to virtual machine for cleanup %s: %v", vmPath, err)
 			}
 		}
 
@@ -316,7 +316,7 @@ func (vm *VirtualMachineDriver) FloppyDevices() (object.VirtualDeviceList, error
 func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) (VirtualMachine, error) {
 	folder, err := vm.driver.FindFolder(config.Folder)
 	if err != nil {
-		return nil, fmt.Errorf("Error finding filder: %s", err)
+		return nil, fmt.Errorf("Error finding folder: %s", err)
 	}
 
 	var relocateSpec types.VirtualMachineRelocateSpec
@@ -1062,7 +1062,7 @@ func findNetwork(network string, host string, d *VCenterDriver) (object.NetworkR
 		return object.NewNetwork(d.client.Client, i.Network[0]), nil
 	}
 
-	return nil, fmt.Errorf("Couldn't find network; 'host' and 'network' not specified. At least one of the two must be specified.")
+	return nil, fmt.Errorf("error finding network; 'host' and 'network' not specified. at least one of the two must be specified.")
 }
 
 func newVGPUProfile(vGPUProfile string) types.VirtualPCIPassthrough {

--- a/builder/vsphere/driver/vm_clone_acc_test.go
+++ b/builder/vsphere/driver/vm_clone_acc_test.go
@@ -43,7 +43,7 @@ func TestVMAcc_clone(t *testing.T) {
 				t.Fatalf("Cannot find template vm '%v': %v", templateName, err)
 			}
 
-			log.Printf("[DEBUG] Clonning VM")
+			log.Printf("[DEBUG] Cloning VM")
 			vm, err := template.Clone(context.TODO(), tc.config)
 			if err != nil {
 				t.Fatalf("Cannot clone vm '%v': %v", templateName, err)
@@ -170,7 +170,7 @@ func configureCheck(t *testing.T, vm VirtualMachine, _ *CloneConfig) {
 
 	memoryHotAdd := vmInfo.Config.MemoryHotAddEnabled
 	if *memoryHotAdd != hwConfig.MemoryHotAddEnabled {
-		t.Errorf("VM should have Memroy hot add set to %v, got %v", hwConfig.MemoryHotAddEnabled, memoryHotAdd)
+		t.Errorf("VM should have memory hot add set to %v, got %v", hwConfig.MemoryHotAddEnabled, memoryHotAdd)
 	}
 }
 
@@ -253,7 +253,7 @@ func startAndStopCheck(t *testing.T, vm VirtualMachine, config *CloneConfig) {
 	log.Printf("[DEBUG] Waiting max 1m0s for shutdown to complete")
 	err = vm.WaitForShutdown(context.TODO(), 1*time.Minute)
 	if err != nil {
-		t.Fatalf("Failed to wait for giest shutdown: %v", err)
+		t.Fatalf("Failed to wait for guest shutdown: %v", err)
 	}
 }
 

--- a/builder/vsphere/iso/builder_acc_test.go
+++ b/builder/vsphere/iso/builder_acc_test.go
@@ -473,7 +473,7 @@ func checkNetworkCard(name string) error {
 		return fmt.Errorf("Cannot find the network card")
 	}
 	if len(netCards) > 1 {
-		return fmt.Errorf("Found several network catds")
+		return fmt.Errorf("Found several network cards")
 	}
 	if _, ok := netCards[0].(*types.VirtualVmxnet3); !ok {
 		return fmt.Errorf("The network card type is not the expected one (vmxnet3)")

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -31,7 +31,7 @@ func TestCreateConfig_Prepare(t *testing.T) {
 		},
 	}
 	if errs := config.Prepare(); len(errs) != 0 {
-		t.Fatalf("Config preprare should not fail: %s", errs[0])
+		t.Fatalf("Config prepare should not fail: %s", errs[0])
 	}
 	if config.GuestOSType != "otherGuest" {
 		t.Fatalf("GuestOSType should default to 'otherGuest'")
@@ -185,14 +185,14 @@ func TestCreateConfig_Prepare(t *testing.T) {
 		errs := c.config.Prepare()
 		if c.fail {
 			if len(errs) == 0 {
-				t.Fatalf("Config preprare should fail")
+				t.Fatalf("Config prepare should fail")
 			}
 			if errs[0].Error() != c.expectedErrMsg {
 				t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
 			}
 		} else {
 			if len(errs) != 0 {
-				t.Fatalf("Config preprare should not fail: %s", errs[0])
+				t.Fatalf("Config prepare should not fail: %s", errs[0])
 			}
 		}
 	}

--- a/post-processor/vsphere/artifact_test.go
+++ b/post-processor/vsphere/artifact_test.go
@@ -20,6 +20,6 @@ func TestArtifact_ImplementsArtifact(t *testing.T) {
 func TestArtifact_Id(t *testing.T) {
 	artifact := NewArtifact("datastore", "vmfolder", "vmname", nil)
 	if artifact.Id() != "datastore::vmfolder::vmname" {
-		t.Fatalf("must return datastore, vmfolder and vmname splitted by :: as Id")
+		t.Fatalf("must return datastore, vmfolder, and vmname split by :: as id")
 	}
 }

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -61,7 +61,7 @@ func TestGenerateURI_Basic(t *testing.T) {
 	}
 	expected_uri := "vi://me:notpassword@myhost/mydc/host/mycluster"
 	if uri.String() != expected_uri {
-		t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
+		t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expected_uri)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 
 	cases := []escapeCases{
 		{`this has spaces`, `this%20has%20spaces`},
-		{`exclaimation_!`, `exclaimation_%21`},
+		{`exclamation_!`, `exclamation_%21`},
 		{`hash_#_dollar_$`, `hash_%23_dollar_$`},
 		{`ampersand_&awesome`, `ampersand_&awesome`},
 		{`single_quote_'_and_another_'`, `single_quote_%27_and_another_%27`},
@@ -100,7 +100,7 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 		expected_uri := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
 
 		if uri.String() != expected_uri {
-			t.Fatalf("URI did not match. Recieved: %s. Expected: %s", uri, expected_uri)
+			t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expected_uri)
 		}
 	}
 }
@@ -119,7 +119,7 @@ func TestGetEncodedPassword(t *testing.T) {
 		t.Fatalf("Password is set but test said it is not")
 	}
 	if encoded != expected {
-		t.Fatalf("Should have successfully gotten encoded password. Expected: %s; recieved: %s", expected, encoded)
+		t.Fatalf("Should have successfully gotten encoded password. Expected: %s; received: %s", expected, encoded)
 	}
 
 	// There is no password


### PR DESCRIPTION
### Summary

Technical Debt:

- Correct misspellings and grammar.
- Correct version of Go in `README.md` to match `go.mod`.
- Correct markdownlint issues in `CHANGELOG.md`.

### Testing

```sh
> make generate
2024/03/01 22:55:03 Copying "docs" to ".docs/"
2024/03/01 22:55:03 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

> make build   

> make test 
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.744s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.671s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.534s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  1.387s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.190s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.295s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      1.615s
``

