### PR TITLE
docs: update clone/iso config

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -30,22 +30,25 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the Config struct in builder/vsphere/clone/config.go; DO NOT EDIT MANUALLY -->
 
-- `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
-  for linked clones. Defaults to `false`.
+- `create_snapshot` (bool) - Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+  Defaults to `false`.
 
-- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+- `snapshot_name` (string) - Specifies the name of the snapshot when `create_snapshot` is `true`.
   Defaults to `Created By Packer`.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `convert_to_template` (bool) - Specifies to convert the cloned virtual machine to a template after the build is complete.
+  Defaults to `false`.
+  If set to `true`, the virtual machine can not be imported to a content library.
 
-- `export` (\*common.ExportConfig) - Configuration for exporting VM to an ovf file.
-  The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+- `export` (\*common.ExportConfig) - Specifies the configuration for exporting the virtual machine to an OVF.
+  The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 
-- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing a VM template or OVF template to a Content Library.
-  The template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-  The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Specifies the configuration for importing a VM template or OVF template to a content library.
+  The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+  If set, `convert_to_template` must be set to `false`.
 
-- `customize` (\*CustomizeConfig) - Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).
+- `customize` (\*CustomizeConfig) - Specifies the customization options for the virtual machine.
+  Refer to the [customization options](#customization) section for more information.
 
 <!-- End of code generated from the comments of the Config struct in builder/vsphere/clone/config.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -33,20 +33,22 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the Config struct in builder/vsphere/iso/config.go; DO NOT EDIT MANUALLY -->
 
-- `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
-  for linked clones. Defaults to `false`.
+- `create_snapshot` (bool) - Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+  Defaults to `false`.
 
-- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+- `snapshot_name` (string) - Specifies the name of the snapshot when `create_snapshot` is `true`.
   Defaults to `Created By Packer`.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `convert_to_template` (bool) - Specifies to convert the cloned virtual machine to a template after the build is complete.
+  Defaults to `false`.
+  If set to `true`, the virtual machine can not be imported to a content library.
 
-- `export` (\*common.ExportConfig) - Configuration for exporting VM to an ovf file.
-  The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+- `export` (\*common.ExportConfig) - Specifies the configuration for exporting the virtual machine to an OVF.
+  The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 
-- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing the VM template to a Content Library.
-  The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-  The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Specifies the configuration for importing a VM template or OVF template to a content library.
+  The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+  If set, `convert_to_template` must be set to `false`.
 
 <!-- End of code generated from the comments of the Config struct in builder/vsphere/iso/config.go; -->
 

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -37,22 +37,25 @@ type Config struct {
 	Comm                       communicator.Config `mapstructure:",squash"`
 	common.ShutdownConfig      `mapstructure:",squash"`
 
-	// Create a snapshot when set to `true`, so the VM can be used as a base
-	// for linked clones. Defaults to `false`.
+	// Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+	// Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
-	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+	// Specifies the name of the snapshot when `create_snapshot` is `true`.
 	// Defaults to `Created By Packer`.
 	SnapshotName string `mapstructure:"snapshot_name"`
-	// Convert VM to a template. Defaults to `false`.
+	// Specifies to convert the cloned virtual machine to a template after the build is complete.
+	// Defaults to `false`.
+	// If set to `true`, the virtual machine can not be imported to a content library.
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
-	// Configuration for exporting VM to an ovf file.
-	// The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+	// Specifies the configuration for exporting the virtual machine to an OVF.
+	// The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 	Export *common.ExportConfig `mapstructure:"export"`
-	// Configuration for importing a VM template or OVF template to a Content Library.
-	// The template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-	// The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+	// Specifies the configuration for importing a VM template or OVF template to a content library.
+	// The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+	// If set, `convert_to_template` must be set to `false`.
 	ContentLibraryDestinationConfig *common.ContentLibraryDestinationConfig `mapstructure:"content_library_destination"`
-	// Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).
+	// Specifies the customization options for the virtual machine.
+	// Refer to the [customization options](#customization) section for more information.
 	CustomizeConfig *CustomizeConfig `mapstructure:"customize"`
 
 	ctx interpolate.Context

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -39,20 +39,22 @@ type Config struct {
 
 	common.ShutdownConfig `mapstructure:",squash"`
 
-	// Create a snapshot when set to `true`, so the VM can be used as a base
-	// for linked clones. Defaults to `false`.
+	// Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+	// Defaults to `false`.
 	CreateSnapshot bool `mapstructure:"create_snapshot"`
-	// When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+	// Specifies the name of the snapshot when `create_snapshot` is `true`.
 	// Defaults to `Created By Packer`.
 	SnapshotName string `mapstructure:"snapshot_name"`
-	// Convert VM to a template. Defaults to `false`.
+	// Specifies to convert the cloned virtual machine to a template after the build is complete.
+	// Defaults to `false`.
+	// If set to `true`, the virtual machine can not be imported to a content library.
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
-	// Configuration for exporting VM to an ovf file.
-	// The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+	// Specifies the configuration for exporting the virtual machine to an OVF.
+	// The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 	Export *common.ExportConfig `mapstructure:"export"`
-	// Configuration for importing the VM template to a Content Library.
-	// The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-	// The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+	// Specifies the configuration for importing a VM template or OVF template to a content library.
+	// The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+	// If set, `convert_to_template` must be set to `false`.
 	ContentLibraryDestinationConfig *common.ContentLibraryDestinationConfig `mapstructure:"content_library_destination"`
 
 	ctx interpolate.Context

--- a/docs-partials/builder/vsphere/clone/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/Config-not-required.mdx
@@ -1,20 +1,23 @@
 <!-- Code generated from the comments of the Config struct in builder/vsphere/clone/config.go; DO NOT EDIT MANUALLY -->
 
-- `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
-  for linked clones. Defaults to `false`.
+- `create_snapshot` (bool) - Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+  Defaults to `false`.
 
-- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+- `snapshot_name` (string) - Specifies the name of the snapshot when `create_snapshot` is `true`.
   Defaults to `Created By Packer`.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `convert_to_template` (bool) - Specifies to convert the cloned virtual machine to a template after the build is complete.
+  Defaults to `false`.
+  If set to `true`, the virtual machine can not be imported to a content library.
 
-- `export` (\*common.ExportConfig) - Configuration for exporting VM to an ovf file.
-  The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+- `export` (\*common.ExportConfig) - Specifies the configuration for exporting the virtual machine to an OVF.
+  The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 
-- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing a VM template or OVF template to a Content Library.
-  The template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-  The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Specifies the configuration for importing a VM template or OVF template to a content library.
+  The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+  If set, `convert_to_template` must be set to `false`.
 
-- `customize` (\*CustomizeConfig) - Customize the cloned VM to configure host, network, or licensing settings. See the [customization options](#customization).
+- `customize` (\*CustomizeConfig) - Specifies the customization options for the virtual machine.
+  Refer to the [customization options](#customization) section for more information.
 
 <!-- End of code generated from the comments of the Config struct in builder/vsphere/clone/config.go; -->

--- a/docs-partials/builder/vsphere/iso/Config-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/Config-not-required.mdx
@@ -1,18 +1,20 @@
 <!-- Code generated from the comments of the Config struct in builder/vsphere/iso/config.go; DO NOT EDIT MANUALLY -->
 
-- `create_snapshot` (bool) - Create a snapshot when set to `true`, so the VM can be used as a base
-  for linked clones. Defaults to `false`.
+- `create_snapshot` (bool) - Specifies to create a snapshot of the virtual machine to use as a base for linked clones.
+  Defaults to `false`.
 
-- `snapshot_name` (string) - When `create_snapshot` is `true`, `snapshot_name` determines the name of the snapshot.
+- `snapshot_name` (string) - Specifies the name of the snapshot when `create_snapshot` is `true`.
   Defaults to `Created By Packer`.
 
-- `convert_to_template` (bool) - Convert VM to a template. Defaults to `false`.
+- `convert_to_template` (bool) - Specifies to convert the cloned virtual machine to a template after the build is complete.
+  Defaults to `false`.
+  If set to `true`, the virtual machine can not be imported to a content library.
 
-- `export` (\*common.ExportConfig) - Configuration for exporting VM to an ovf file.
-  The VM will not be exported if no [Export Configuration](#export-configuration) is specified.
+- `export` (\*common.ExportConfig) - Specifies the configuration for exporting the virtual machine to an OVF.
+  The virtual machine is not exported if [export configuration](#export-configuration) is not specified.
 
-- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Configuration for importing the VM template to a Content Library.
-  The VM template will not be imported if no [Content Library Import Configuration](#content-library-import-configuration) is specified.
-  The import doesn't work if [convert_to_template](#convert_to_template) is set to true.
+- `content_library_destination` (\*common.ContentLibraryDestinationConfig) - Specifies the configuration for importing a VM template or OVF template to a content library.
+  The template will not be imported if no [content library import configuration](#content-library-import-configuration) is specified.
+  If set, `convert_to_template` must be set to `false`.
 
 <!-- End of code generated from the comments of the Config struct in builder/vsphere/iso/config.go; -->


### PR DESCRIPTION
### Summary

Updates config documentation for `vsphere-clone` and `vsphere-iso`.

Testing

```console

packer-plugin-vsphere on  docs/update-clone-iso-config via 🐹 v1.22.0 
➜ make build

packer-plugin-vsphere on  docs/update-clone-iso-config via 🐹 v1.22.0 took 3.4s 
➜ make generate
2024/03/04 21:59:25 Copying "docs" to ".docs/"
2024/03/04 21:59:25 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on  docs/update-clone-iso-config via 🐹 v1.22.0 took 11.6s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.435s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.698s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.587s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  1.783s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   3.911s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.293s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.155s
```