### PR TITLE
docs: update `vsphere/clone/step_clone`

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -54,26 +54,29 @@ necessary for this build to succeed and can be found further down the page.
 
 <!-- Code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `template` (string) - Name of source virtual machine. Path is optional.
+- `template` (string) - Specifies the name of the source virtual machine to clone.
 
-- `disk_size` (int64) - The size of the disk in MiB.
+- `disk_size` (int64) - Specifies the size of the primary disk in MiB.
+  Cannot be used with `linked_clone`.
 
-- `linked_clone` (bool) - Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
+- `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
+  Cannot be used with `disk_size`.`
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
-  specified, `host` must be specified to allow Packer to look for the
-  available network. If the network is inside a network folder in vSphere inventory,
-  you need to provide the full path to the network.
+- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
+  provide 'host' to allow Packer to search for an available network. For networks placed
+  within a network folder vCenter Server, provider the object path to the network.
+  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
 
-- `mac_address` (string) - Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
+- `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
+  If set, the `network` must be also specified.
 
-- `notes` (string) - VM notes.
+- `notes` (string) - Specifies the annotations for the virtual machine.
 
-- `destroy` (bool) - If set to true, the virtual machine will be destroyed after the build completes.
+- `destroy` (bool) - Specifies whether to destroy the virtual machine after the build is complete.
 
-- `vapp` (vAppConfig) - Set the vApp Options on the virtual machine image.
-  See the [vApp Options Configuration](/packer/integrations/hashicorp/vmware/latest/components/builder/vsphere-clone#vapp-options-configuration)
-  section for more information.
+- `vapp` (vAppConfig) - Specifies the vApp Options for the virtual machine. For more information, refer to the
+  [vApp Options Configuration](/packer/integrations/hashicorp/vmware/latest/components/builder/vsphere-clone#vapp-options-configuration)
+  section.
 
 <!-- End of code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; -->
 
@@ -205,13 +208,16 @@ In HCL2:
 
 <!-- Code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `properties` (map[string]string) - Set values for the available vApp Properties to supply configuration parameters to a virtual machine cloned from
-  a template that came from an imported OVF or OVA file.
+- `properties` (map[string]string) - Specifies the values for the available vApp properties. These are used to supply
+  configuration parameters to a virtual machine. This machine is cloned from a template
+  that originated from an imported OVF or OVA file.
   
-  -> **Note:** The only supported usage path for vApp properties is for existing user-configurable keys.
-  These generally come from an existing template that was created from an imported OVF or OVA file.
+  -> **Note:** The only supported usage path for vApp properties is for existing
+  user-configurable keys. These generally come from an existing template that was
+  created from an imported OVF or OVA file.
+  
   You cannot set values for vApp properties on virtual machines created from scratch,
-  virtual machines lacking a vApp configuration, or on property keys that do not exist.
+  on virtual machines that lack a vApp configuration, or on property keys that do not exist.
 
 <!-- End of code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; -->
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -20,37 +20,43 @@ import (
 )
 
 type vAppConfig struct {
-	// Set values for the available vApp Properties to supply configuration parameters to a virtual machine cloned from
-	// a template that came from an imported OVF or OVA file.
+	// Specifies the values for the available vApp properties. These are used to supply
+	// configuration parameters to a virtual machine. This machine is cloned from a template
+	// that originated from an imported OVF or OVA file.
 	//
-	// -> **Note:** The only supported usage path for vApp properties is for existing user-configurable keys.
-	// These generally come from an existing template that was created from an imported OVF or OVA file.
+	// -> **Note:** The only supported usage path for vApp properties is for existing
+	// user-configurable keys. These generally come from an existing template that was
+	// created from an imported OVF or OVA file.
+	//
 	// You cannot set values for vApp properties on virtual machines created from scratch,
-	// virtual machines lacking a vApp configuration, or on property keys that do not exist.
+	// on virtual machines that lack a vApp configuration, or on property keys that do not exist.
 	Properties map[string]string `mapstructure:"properties"`
 }
 
 type CloneConfig struct {
-	// Name of source virtual machine. Path is optional.
+	// Specifies the name of the source virtual machine to clone.
 	Template string `mapstructure:"template"`
-	// The size of the disk in MiB.
+	// Specifies the size of the primary disk in MiB.
+	// Cannot be used with `linked_clone`.
 	DiskSize int64 `mapstructure:"disk_size"`
-	// Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
+	// Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
+	// Cannot be used with `disk_size`.`
 	LinkedClone bool `mapstructure:"linked_clone"`
-	// Set the network in which the VM will be connected to. If no network is
-	// specified, `host` must be specified to allow Packer to look for the
-	// available network. If the network is inside a network folder in vSphere inventory,
-	// you need to provide the full path to the network.
+	// Specifies the network to which the virtual machine will connect. If no network is specified,
+	// provide 'host' to allow Packer to search for an available network. For networks placed
+	// within a network folder vCenter Server, provider the object path to the network.
+	// For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
 	Network string `mapstructure:"network"`
-	// Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
+	// Specifies the network card MAC address. For example `00:50:56:00:00:00`.
+	// If set, the `network` must be also specified.
 	MacAddress string `mapstructure:"mac_address"`
-	// VM notes.
+	// Specifies the annotations for the virtual machine.
 	Notes string `mapstructure:"notes"`
-	// If set to true, the virtual machine will be destroyed after the build completes.
+	// Specifies whether to destroy the virtual machine after the build is complete.
 	Destroy bool `mapstructure:"destroy"`
-	// Set the vApp Options on the virtual machine image.
-	// See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
-	// section for more information.
+	// Specifies the vApp Options for the virtual machine. For more information, refer to the
+	// [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
+	// section.
 	VAppConfig    vAppConfig           `mapstructure:"vapp"`
 	StorageConfig common.StorageConfig `mapstructure:",squash"`
 }
@@ -92,10 +98,10 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionHalt
 	}
 
-	ui.Say("Cloning VM...")
+	ui.Say("Cloning virtual machine...")
 	template, err := d.FindVM(s.Config.Template)
 	if err != nil {
-		state.Put("error", fmt.Errorf("Error finding vm to clone: %s", err))
+		state.Put("error", fmt.Errorf("error finding virtual machine to clone: %s", err))
 		return multistep.ActionHalt
 	}
 

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -1,24 +1,27 @@
 <!-- Code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `template` (string) - Name of source virtual machine. Path is optional.
+- `template` (string) - Specifies the name of the source virtual machine to clone.
 
-- `disk_size` (int64) - The size of the disk in MiB.
+- `disk_size` (int64) - Specifies the size of the primary disk in MiB.
+  Cannot be used with `linked_clone`.
 
-- `linked_clone` (bool) - Create the virtual machine as a linked clone from latest snapshot. Defaults to `false`.
+- `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
+  Cannot be used with `disk_size`.`
 
-- `network` (string) - Set the network in which the VM will be connected to. If no network is
-  specified, `host` must be specified to allow Packer to look for the
-  available network. If the network is inside a network folder in vSphere inventory,
-  you need to provide the full path to the network.
+- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
+  provide 'host' to allow Packer to search for an available network. For networks placed
+  within a network folder vCenter Server, provider the object path to the network.
+  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
 
-- `mac_address` (string) - Sets a custom MAC address to the network adapter. If set, the [network](#network) must be also specified.
+- `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
+  If set, the `network` must be also specified.
 
-- `notes` (string) - VM notes.
+- `notes` (string) - Specifies the annotations for the virtual machine.
 
-- `destroy` (bool) - If set to true, the virtual machine will be destroyed after the build completes.
+- `destroy` (bool) - Specifies whether to destroy the virtual machine after the build is complete.
 
-- `vapp` (vAppConfig) - Set the vApp Options on the virtual machine image.
-  See the [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
-  section for more information.
+- `vapp` (vAppConfig) - Specifies the vApp Options for the virtual machine. For more information, refer to the
+  [vApp Options Configuration](/packer/plugins/builders/vmware/vsphere-clone#vapp-options-configuration)
+  section.
 
 <!-- End of code generated from the comments of the CloneConfig struct in builder/vsphere/clone/step_clone.go; -->

--- a/docs-partials/builder/vsphere/clone/vAppConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/vAppConfig-not-required.mdx
@@ -1,11 +1,14 @@
 <!-- Code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
-- `properties` (map[string]string) - Set values for the available vApp Properties to supply configuration parameters to a virtual machine cloned from
-  a template that came from an imported OVF or OVA file.
+- `properties` (map[string]string) - Specifies the values for the available vApp properties. These are used to supply
+  configuration parameters to a virtual machine. This machine is cloned from a template
+  that originated from an imported OVF or OVA file.
   
-  -> **Note:** The only supported usage path for vApp properties is for existing user-configurable keys.
-  These generally come from an existing template that was created from an imported OVF or OVA file.
+  -> **Note:** The only supported usage path for vApp properties is for existing
+  user-configurable keys. These generally come from an existing template that was
+  created from an imported OVF or OVA file.
+  
   You cannot set values for vApp properties on virtual machines created from scratch,
-  virtual machines lacking a vApp configuration, or on property keys that do not exist.
+  on virtual machines that lack a vApp configuration, or on property keys that do not exist.
 
 <!-- End of code generated from the comments of the vAppConfig struct in builder/vsphere/clone/step_clone.go; -->


### PR DESCRIPTION
### Summary

Updates descriptions for generated documentation.

### Testing

```console
packer-plugin-vsphere on  docs/update-step-clone via 🐹 v1.22.0 
➜ make build   


packer-plugin-vsphere on  docs/update-step-clone via 🐹 v1.22.0 took 4.2s 
➜ make generate
2024/03/04 22:16:49 Copying "docs" to ".docs/"
2024/03/04 22:16:49 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...


packer-plugin-vsphere on  docs/update-step-clone via 🐹 v1.22.0 took 11.5s 
➜ make test    
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.001s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.316s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       4.645s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.307s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.614s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.992s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.859s
```