### PR TITLE
Update Jenkins template example for supervisor builder

### DIFF
--- a/builder/vsphere/examples/supervisor/jenkins-template.pkr.hcl
+++ b/builder/vsphere/examples/supervisor/jenkins-template.pkr.hcl
@@ -119,9 +119,14 @@ EOF
 
   provisioner "shell" {
     inline = [
-      # Install Jenkins and its dependencies.
-      "curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee /usr/share/keyrings/jenkins-keyring.asc > /dev/null",
-      "echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] https://pkg.jenkins.io/debian binary/ | sudo tee /etc/apt/sources.list.d/jenkins.list > /dev/null",
+      # Download Jenkins repository key and add it to the trusted keyrings.
+      "curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo gpg --dearmor -o /usr/share/keyrings/jenkins-keyring.gpg",
+      "echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.gpg] https://pkg.jenkins.io/debian binary/ | sudo tee /etc/apt/sources.list.d/jenkins.list",
+
+      # Download the new Kubernetes community-owned repository key and add it to the trusted keyrings (to get apt-get update working).
+      "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /usr/share/keyrings/kubernetes-apt-keyring.gpg",
+      "echo deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ / | sudo tee /etc/apt/sources.list.d/kubernetes.list",
+
       # Sometimes apt-get uses IPv6 and causes failure, force to use IPv4 address.
       "sudo apt-get -qq -o Acquire::ForceIPv4=true update",
       "sudo apt-get -qq -o Acquire::ForceIPv4=true install -f -y ca-certificates openjdk-11-jre-headless",


### PR DESCRIPTION
This PR adds the required steps in the supervisor builder Jenkins template file to get the `apt-get update` command working.

See https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/ for more details.

Verified internally using the updated Jenkins template:
```console
==> vsphere-supervisor.vm: Creating temporary RSA SSH key for instance...
    vsphere-supervisor.vm: Connecting to Supervisor cluster...
    vsphere-supervisor.vm: Successfully connected to Supervisor cluster
    ...
==> vsphere-supervisor.vm: Provisioning with shell script: /var/folders/nf/cndlm4ts2bd9jz3dd667jfb80000gr/T/packer-shell350374452
    vsphere-supervisor.vm: deb [signed-by=/usr/share/keyrings/jenkins-keyring.gpg] https://pkg.jenkins.io/debian binary/
    vsphere-supervisor.vm: deb [signed-by=/usr/share/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /
    vsphere-supervisor.vm: Preconfiguring packages ...
    ...
    vsphere-supervisor.vm: done.
    ...
    vsphere-supervisor.vm: [sample-job] $ /bin/sh -xe /tmp/jenkins7660215003182937504.sh
    vsphere-supervisor.vm: + echo Hello VM-Service from Jenkins
    vsphere-supervisor.vm: Hello VM-Service from Jenkins
    vsphere-supervisor.vm: Finished: SUCCESS
    vsphere-supervisor.vm: Completed sample-job #1 : SUCCESS
    vsphere-supervisor.vm: Skip cleaning up the source objects as specified in config
    vsphere-supervisor.vm: Build 'vsphere-supervisor' finished.
Build 'vsphere-supervisor.vm' finished after 9 minutes 31 seconds.
```