### PR TITLE
feat: upload max retries

### DIFF
--- a/.web-docs/components/post-processor/vsphere/README.md
+++ b/.web-docs/components/post-processor/vsphere/README.md
@@ -74,6 +74,9 @@ Optional:
   See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information on the
   virtual hardware versions supported.
 
+- `max_retries` (int) - Specifies the maximum number of times to retry the upload operation if it fails.
+  Defaults to `5`.
+
 <!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->
 
 

--- a/docs-partials/post-processor/vsphere/Config-not-required.mdx
+++ b/docs-partials/post-processor/vsphere/Config-not-required.mdx
@@ -39,4 +39,7 @@
   See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information on the
   virtual hardware versions supported.
 
+- `max_retries` (int) - Specifies the maximum number of times to retry the upload operation if it fails.
+  Defaults to `5`.
+
 <!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->

--- a/post-processor/vsphere/post-processor.hcl2spec.go
+++ b/post-processor/vsphere/post-processor.hcl2spec.go
@@ -34,6 +34,7 @@ type FlatConfig struct {
 	VMName              *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMNetwork           *string           `mapstructure:"vm_network" cty:"vm_network" hcl:"vm_network"`
 	HardwareVersion     *string           `mapstructure:"hardware_version" cty:"hardware_version" hcl:"hardware_version"`
+	MaxRetries          *int              `mapstructure:"max_retries" cty:"max_retries" hcl:"max_retries"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -72,6 +73,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                    &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_network":                 &hcldec.AttrSpec{Name: "vm_network", Type: cty.String, Required: false},
 		"hardware_version":           &hcldec.AttrSpec{Name: "hardware_version", Type: cty.String, Required: false},
+		"max_retries":                &hcldec.AttrSpec{Name: "max_retries", Type: cty.Number, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
### Summary

- Updates the `vsphere` post-processor to support `max_retries` for the upload to a vSphere endpoint. Defaults to 5.
- Sets and uses constants for `DefaultMaxRetries`, `DefaultDiskMode`, and `OvftoolWindows`.

### Reference

Closes #30

