### PR TITLE
chore(post-processor): update `vsphere-template`

### DIFF
--- a/.web-docs/components/post-processor/vsphere-template/README.md
+++ b/.web-docs/components/post-processor/vsphere-template/README.md
@@ -1,64 +1,61 @@
 Type: `vsphere-template`
 Artifact BuilderId: `packer.post-processor.vsphere`
 
-The Packer vSphere Template post-processor takes an artifact from the
-`vmware-iso` builder, built on ESXi (i.e. remote) or an artifact from the
-[vSphere](/packer/integrations/hashicorp/vsphere/latest/components/post-processor/vsphere) post-processor, marks the VM as a
-template, and places it in the path of your choice.
+This post-processor uses an artifact from the `vmware-iso` builder with an ESXi host or an artifact
+from the [vSphere](/packer/integrations/hashicorp/vsphere/latest/components/post-processor/vsphere) post-processor. It then marks
+the virtual machine as a template and moves it to your specified path.
 
 ## Configuration
 
-There are many configuration options available for the post-processor. They are
-provided below in two categories: required and optional parameters.
+The following configuration options are available for the post-processor.
 
 Required:
 
-- `host` (string) - The vSphere endpoint that contains the VM built by the
-  `vmware-iso` builder.
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `password` (string) - Password to use to authenticate to the vSphere
-  endpoint.
+- `host` (string) - Specifies the fully qualified domain name or IP address of the vSphere endpoint.
 
-- `username` (string) - The username to use to authenticate to the vSphere
-  endpoint.
+- `username` (string) - Specifies the username to use to authenticate to the vSphere endpoint.
+
+- `password` (string) - Specifies the password to use to authenticate to the vSphere endpoint.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; -->
+
 
 Optional:
 
-- `datacenter` (string) - If you have more than one, you will need to specify
-  which one the ESXi host used.
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `folder` (string) - Target path where the template will be created.
+- `insecure` (bool) - Specifies whether to skip the verification of the server certificate. Defaults to `false`.
 
-- `insecure` (boolean) - If `true`, skips the verification of the server
-  certificate. Default is `false`.
+- `datacenter` (string) - Specifies the name of the datacenter to use.
+  Required when the vCenter Server instance endpoint has more than one datacenter.
 
-- `keep_input_artifact` (boolean) - Unlike most post-processors, this option
-  has no effect for `vsphere-template`. This is because in order for a template
-  to work, you can't delete the vm that you generate the template from. The
-  vSphere Template post-processor will therefore always preserve the original
-  VM.
+- `folder` (string) - Specifies the name of the virtual machine folder path where the template will be created.
 
-- `snapshot_enable` (boolean) - Create a snapshot before marking as a
-  template. Default is `false`.
+- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.\
 
-- `snapshot_name` (string) - Name for the snapshot. Required when
-  `snapshot_enable` is `true`.
+- `snapshot_name` (string) - Specifies the name of the snapshot. Required when `snapshot_enable` is `true`.
 
-- `snapshot_description` (string) - Description for the snapshot. Required
-  when `snapshot_enable` is `true`.
+- `snapshot_description` (string) - Specifies a description for the snapshot. Required when `snapshot_enable` is `true`.
 
-- `reregister_vm` (boolean) - Use the method of unregister VM and reregister
-  as a template, rather than using the `markAsTemplate` method.
+- `reregister_vm` (boolean) - Specifies to keep the virtual machine registered after marking as a template.
 
-  NOTE: If you are getting permission denied errors when trying to mark as a
-  template, but it works fine in the vSphere UI, try setting this to `false`.
-  Default is `true`.
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; -->
 
-## Example
+
+- `keep_input_artifact` (boolean) - This option is not applicable to `vsphere-template`. For a
+  template to function, the original virtual machine from which it was generated cannot be deleted.
+  Therefore, the vSphere Template post-processor always preserves the original virtual machine.
+
+  ~> **Note**: If you are getting permission denied errors when trying to mark as a template, but it
+  works in the vSphere UI, set this to `false`. Default is `true`.
+
+## Example Usage
 
 An example is shown below, showing only the post-processor configuration:
 
-**HCL2**
+In HCL2:
 
 ```hcl
 source "null" "example" {
@@ -76,15 +73,14 @@ build {
           insecure            = false
           username            = "administrator@vsphere.local"
           password            = "VMw@re1!"
-          datacenter          = "dc-01"   
+          datacenter          = "dc-01"
           folder              = "/templates/os/distro"
       }
     }
 }
 ```
 
-
-**JSON**
+In JSON:
 
 ```json
 {
@@ -110,17 +106,13 @@ build {
 }
 ```
 
+## Using the vSphere Template with Local Builders
 
-## Using the vSphere Template with local builders
+Once the [vSphere](/packer/integrations/hashicorp/vsphere/latest/components/post-processor/vsphere) post-processor takes an artifact
+from the builder and uploads it to a vSphere endpoint, you may want the virtual machine to be marked
+as a template.
 
-Once the [vSphere](/packer/integrations/hashicorp/vsphere/latest/components/post-processor/vsphere) post-processor takes an
-artifact from the builder and uploads it to a vSphere endpoint, you may want
-the VM to be marked as a template. Packer can do this for you automatically
-using a sequence definition (a collection of post-processors that are treated
-as as single pipeline, see [Post-Processors](/packer/docs/templates/legacy_json_templates/post-processors)
-for more information):
-
-**HCL2**
+In HCL2:
 
 ```hcl
 build {
@@ -140,8 +132,7 @@ build {
 }
 ```
 
-
-**JSON**
+In JSON:
 
 ```json
 {
@@ -168,63 +159,57 @@ build {
     }
   ]
 }
-
-
 ```
 
-
-In the example above, the result of each builder is passed through the defined
-sequence of post-processors starting with the `vsphere` post-processor which
-will upload the artifact to a vSphere endpoint. The resulting artifact is then
-passed on to the `vsphere-template` post-processor which handles marking a VM
-as a template. In JSON, note that the `vsphere` and `vsphere-template`
+In the example above, the result of each builder is passed through the defined sequence of
+post-processors starting with the `vsphere` post-processor which will upload the artifact to a
+vSphere endpoint. The resulting artifact is then passed on to the `vsphere-template` post-processor
+which handles marking a VM as a template. In JSON, note that the `vsphere` and `vsphere-template`
 post-processors can be paired together in their own array.
 
 ## Permissions
 
-The vSphere post processor needs several privileges to be able to mark the
-vm as a template. Rather than giving full administrator access, you can create
-a role to give the post-processor the privileges necessary to run. Here is an
-example role that will work. Please note that this is a user-supplied list so
-there may be a few extraneous privilegess that are not strictly required.
+The post processor needs several privileges to be able to mark the virtual as a template.
+
+Rather than giving full administrator access, you can create a role to give the post-processor the
+privileges necessary to run.
+
+Below is an example role that will work. Please note that this is a user-supplied list so there may
+be a few extraneous privileges that are not strictly required.
 
 For vSphere, the role needs the following privileges:
 
-    `Datastore.AllocateSpace`
-    `Host.Config.AdvancedConfig`
-    `Host.Config.NetService`
-    `Host.Config.Network`
-    `Network.Assign`
-    `System.Anonymous`
-    `System.Read`
-    `System.View`
-    `VApp.Import`
-    `VirtualMachine.Config.AddNewDisk`
-    `VirtualMachine.Config.AdvancedConfig`
-    `VirtualMachine.Inventory.Delete`
+- `Datastore.AllocateSpace`
+- `Host.Config.AdvancedConfig`
+- `Host.Config.NetService`
+- `Host.Config.Network`
+- `Network.Assign`
+- `System.Anonymous`
+- `System.Read`
+- `System.View`
+- `VApp.Import`
+- `VirtualMachine.Config.AddNewDisk`
+- `VirtualMachine.Config.AdvancedConfig`
+- `VirtualMachine.Inventory.Delete`
 
-and either (if `reregister_vm` is `false`):
+  and either (if `reregister_vm` is `false`):
 
-    `VirtualMachine.Provisioning.MarkAsTemplate`
+  - `VirtualMachine.Provisioning.MarkAsTemplate`
 
-or (if `reregister_vm` is `true` or unset):
+  or (if `reregister_vm` is `true` or unset):
 
-    `VirtualMachine.Inventory.Register`
-    `VirtualMachine.Inventory.Unregister`
+  - `VirtualMachine.Inventory.Register`
+  - `VirtualMachine.Inventory.Unregister`
 
 The role must be authorized on the:
 
-    `Cluster of the host`
-    `The destination folder`
-    `The destination datastore`
-    `The network to be assigned`
+- Cluster of the host.
+- The destination folder.
+- The destination datastore.
+- The network to be assigned.
 
 # Troubleshooting
 
-Some users have reported that vSphere templates created from local vSphere builds
-get their boot order reset to cdrom only instead of the original boot order
-defined by the template. If this issue affects you, the solution is to set
-`"bios.hddOrder": "scsi0:0"` in your builder's `vmx_data`.
-
-Packer doesn't automatically do this for you because it causes strange upload
-behavior in certain versions of `ovftool`.
+Some users have reported that vSphere templates created from local vSphere builds get their boot
+order reset to CD-ROM only instead of the original boot order defined by the template. If this issue
+affects you, the solution is to set `"bios.hddOrder": "scsi0:0"` in your builder's `vmx_data`.

--- a/docs-partials/post-processor/vsphere-template/Config-not-required.mdx
+++ b/docs-partials/post-processor/vsphere-template/Config-not-required.mdx
@@ -1,0 +1,18 @@
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `insecure` (bool) - Specifies whether to skip the verification of the server certificate. Defaults to `false`.
+
+- `datacenter` (string) - Specifies the name of the datacenter to use.
+  Required when the vCenter Server instance endpoint has more than one datacenter.
+
+- `folder` (string) - Specifies the name of the virtual machine folder path where the template will be created.
+
+- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.\
+
+- `snapshot_name` (string) - Specifies the name of the snapshot. Required when `snapshot_enable` is `true`.
+
+- `snapshot_description` (string) - Specifies a description for the snapshot. Required when `snapshot_enable` is `true`.
+
+- `reregister_vm` (boolean) - Specifies to keep the virtual machine registered after marking as a template.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; -->

--- a/docs-partials/post-processor/vsphere-template/Config-required.mdx
+++ b/docs-partials/post-processor/vsphere-template/Config-required.mdx
@@ -1,0 +1,9 @@
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `host` (string) - Specifies the fully qualified domain name or IP address of the vSphere endpoint.
+
+- `username` (string) - Specifies the username to use to authenticate to the vSphere endpoint.
+
+- `password` (string) - Specifies the password to use to authenticate to the vSphere endpoint.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere-template/post-processor.go; -->

--- a/docs-partials/post-processor/vsphere/Config-not-required.mdx
+++ b/docs-partials/post-processor/vsphere/Config-not-required.mdx
@@ -1,0 +1,35 @@
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `cluster` (string) - Cluster
+
+- `datacenter` (string) - Datacenter
+
+- `datastore` (string) - Datastore
+
+- `disk_mode` (string) - Disk Mode
+
+- `host` (string) - Host
+
+- `esxi_host` (string) - ES Xi Host
+
+- `insecure` (bool) - Insecure
+
+- `options` ([]string) - Options
+
+- `overwrite` (bool) - Overwrite
+
+- `password` (string) - Password
+
+- `resource_pool` (string) - Resource Pool
+
+- `username` (string) - Username
+
+- `vm_folder` (string) - VM Folder
+
+- `vm_name` (string) - VM Name
+
+- `vm_network` (string) - VM Network
+
+- `hardware_version` (string) - Hardware Version
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->

--- a/docs/post-processors/vsphere-template.mdx
+++ b/docs/post-processors/vsphere-template.mdx
@@ -1,9 +1,8 @@
 ---
 description: >
-  The Packer vSphere Template post-processor takes an artifact from the
-  VMware-iso builder, built on and ESXi host (i.e. remote) or an artifact from the
-  [vSphere](/packer/plugins/post-processors/vsphere/vsphere) post-processor, marks the VM as a
-  template, and leaves it in the path of your choice.
+  This post-processor uses an artifact from the `vmware-iso` builder with an ESXi host or an
+  artifact from the vSphere post-processor. It then marks the virtual machine as a template and
+  moves it to your specified path.
 page_title: vSphere Template - Post-Processors
 sidebar_title: vSphere Template
 ---
@@ -13,64 +12,34 @@ sidebar_title: vSphere Template
 Type: `vsphere-template`
 Artifact BuilderId: `packer.post-processor.vsphere`
 
-The Packer vSphere Template post-processor takes an artifact from the
-`vmware-iso` builder, built on ESXi (i.e. remote) or an artifact from the
-[vSphere](/packer/plugins/post-processors/vsphere/vsphere) post-processor, marks the VM as a
-template, and places it in the path of your choice.
+This post-processor uses an artifact from the `vmware-iso` builder with an ESXi host or an artifact
+from the [vSphere](/packer/plugins/post-processors/vsphere/vsphere) post-processor. It then marks
+the virtual machine as a template and moves it to your specified path.
 
 ## Configuration
 
-There are many configuration options available for the post-processor. They are
-provided below in two categories: required and optional parameters.
+The following configuration options are available for the post-processor.
 
 Required:
 
-- `host` (string) - The vSphere endpoint that contains the VM built by the
-  `vmware-iso` builder.
-
-- `password` (string) - Password to use to authenticate to the vSphere
-  endpoint.
-
-- `username` (string) - The username to use to authenticate to the vSphere
-  endpoint.
+@include 'post-processor/vsphere-template/Config-required.mdx'
 
 Optional:
 
-- `datacenter` (string) - If you have more than one, you will need to specify
-  which one the ESXi host used.
+@include 'post-processor/vsphere-template/Config-not-required.mdx'
 
-- `folder` (string) - Target path where the template will be created.
+- `keep_input_artifact` (boolean) - This option is not applicable to `vsphere-template`. For a
+  template to function, the original virtual machine from which it was generated cannot be deleted.
+  Therefore, the vSphere Template post-processor always preserves the original virtual machine.
 
-- `insecure` (boolean) - If `true`, skips the verification of the server
-  certificate. Default is `false`.
+  ~> **Note**: If you are getting permission denied errors when trying to mark as a template, but it
+  works in the vSphere UI, set this to `false`. Default is `true`.
 
-- `keep_input_artifact` (boolean) - Unlike most post-processors, this option
-  has no effect for `vsphere-template`. This is because in order for a template
-  to work, you can't delete the vm that you generate the template from. The
-  vSphere Template post-processor will therefore always preserve the original
-  VM.
-
-- `snapshot_enable` (boolean) - Create a snapshot before marking as a
-  template. Default is `false`.
-
-- `snapshot_name` (string) - Name for the snapshot. Required when
-  `snapshot_enable` is `true`.
-
-- `snapshot_description` (string) - Description for the snapshot. Required
-  when `snapshot_enable` is `true`.
-
-- `reregister_vm` (boolean) - Use the method of unregister VM and reregister
-  as a template, rather than using the `markAsTemplate` method.
-
-  NOTE: If you are getting permission denied errors when trying to mark as a
-  template, but it works fine in the vSphere UI, try setting this to `false`.
-  Default is `true`.
-
-## Example
+## Example Usage
 
 An example is shown below, showing only the post-processor configuration:
 
-**HCL2**
+In HCL2:
 
 ```hcl
 source "null" "example" {
@@ -88,15 +57,14 @@ build {
           insecure            = false
           username            = "administrator@vsphere.local"
           password            = "VMw@re1!"
-          datacenter          = "dc-01"   
+          datacenter          = "dc-01"
           folder              = "/templates/os/distro"
       }
     }
 }
 ```
 
-
-**JSON**
+In JSON:
 
 ```json
 {
@@ -122,17 +90,13 @@ build {
 }
 ```
 
+## Using the vSphere Template with Local Builders
 
-## Using the vSphere Template with local builders
+Once the [vSphere](/packer/plugins/post-processors/vsphere/vsphere) post-processor takes an artifact
+from the builder and uploads it to a vSphere endpoint, you may want the virtual machine to be marked
+as a template.
 
-Once the [vSphere](/packer/plugins/post-processors/vsphere/vsphere) post-processor takes an
-artifact from the builder and uploads it to a vSphere endpoint, you may want
-the VM to be marked as a template. Packer can do this for you automatically
-using a sequence definition (a collection of post-processors that are treated
-as as single pipeline, see [Post-Processors](/packer/docs/templates/legacy_json_templates/post-processors)
-for more information):
-
-**HCL2**
+In HCL2:
 
 ```hcl
 build {
@@ -152,8 +116,7 @@ build {
 }
 ```
 
-
-**JSON**
+In JSON:
 
 ```json
 {
@@ -180,63 +143,57 @@ build {
     }
   ]
 }
-
-
 ```
 
-
-In the example above, the result of each builder is passed through the defined
-sequence of post-processors starting with the `vsphere` post-processor which
-will upload the artifact to a vSphere endpoint. The resulting artifact is then
-passed on to the `vsphere-template` post-processor which handles marking a VM
-as a template. In JSON, note that the `vsphere` and `vsphere-template`
+In the example above, the result of each builder is passed through the defined sequence of
+post-processors starting with the `vsphere` post-processor which will upload the artifact to a
+vSphere endpoint. The resulting artifact is then passed on to the `vsphere-template` post-processor
+which handles marking a VM as a template. In JSON, note that the `vsphere` and `vsphere-template`
 post-processors can be paired together in their own array.
 
 ## Permissions
 
-The vSphere post processor needs several privileges to be able to mark the
-vm as a template. Rather than giving full administrator access, you can create
-a role to give the post-processor the privileges necessary to run. Here is an
-example role that will work. Please note that this is a user-supplied list so
-there may be a few extraneous privilegess that are not strictly required.
+The post processor needs several privileges to be able to mark the virtual as a template.
+
+Rather than giving full administrator access, you can create a role to give the post-processor the
+privileges necessary to run.
+
+Below is an example role that will work. Please note that this is a user-supplied list so there may
+be a few extraneous privileges that are not strictly required.
 
 For vSphere, the role needs the following privileges:
 
-    `Datastore.AllocateSpace`
-    `Host.Config.AdvancedConfig`
-    `Host.Config.NetService`
-    `Host.Config.Network`
-    `Network.Assign`
-    `System.Anonymous`
-    `System.Read`
-    `System.View`
-    `VApp.Import`
-    `VirtualMachine.Config.AddNewDisk`
-    `VirtualMachine.Config.AdvancedConfig`
-    `VirtualMachine.Inventory.Delete`
+- `Datastore.AllocateSpace`
+- `Host.Config.AdvancedConfig`
+- `Host.Config.NetService`
+- `Host.Config.Network`
+- `Network.Assign`
+- `System.Anonymous`
+- `System.Read`
+- `System.View`
+- `VApp.Import`
+- `VirtualMachine.Config.AddNewDisk`
+- `VirtualMachine.Config.AdvancedConfig`
+- `VirtualMachine.Inventory.Delete`
 
-and either (if `reregister_vm` is `false`):
+  and either (if `reregister_vm` is `false`):
 
-    `VirtualMachine.Provisioning.MarkAsTemplate`
+  - `VirtualMachine.Provisioning.MarkAsTemplate`
 
-or (if `reregister_vm` is `true` or unset):
+  or (if `reregister_vm` is `true` or unset):
 
-    `VirtualMachine.Inventory.Register`
-    `VirtualMachine.Inventory.Unregister`
+  - `VirtualMachine.Inventory.Register`
+  - `VirtualMachine.Inventory.Unregister`
 
 The role must be authorized on the:
 
-    `Cluster of the host`
-    `The destination folder`
-    `The destination datastore`
-    `The network to be assigned`
+- Cluster of the host.
+- The destination folder.
+- The destination datastore.
+- The network to be assigned.
 
 # Troubleshooting
 
-Some users have reported that vSphere templates created from local vSphere builds
-get their boot order reset to cdrom only instead of the original boot order
-defined by the template. If this issue affects you, the solution is to set
-`"bios.hddOrder": "scsi0:0"` in your builder's `vmx_data`.
-
-Packer doesn't automatically do this for you because it causes strange upload
-behavior in certain versions of `ovftool`.
+Some users have reported that vSphere templates created from local vSphere builds get their boot
+order reset to CD-ROM only instead of the original boot order defined by the template. If this issue
+affects you, the solution is to set `"bios.hddOrder": "scsi0:0"` in your builder's `vmx_data`.

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -18,10 +18,10 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Host                *string           `mapstructure:"host" cty:"host" hcl:"host"`
+	Host                *string           `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
+	Username            *string           `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
+	Password            *string           `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Insecure            *bool             `mapstructure:"insecure" cty:"insecure" hcl:"insecure"`
-	Username            *string           `mapstructure:"username" cty:"username" hcl:"username"`
-	Password            *string           `mapstructure:"password" cty:"password" hcl:"password"`
 	Datacenter          *string           `mapstructure:"datacenter" cty:"datacenter" hcl:"datacenter"`
 	Folder              *string           `mapstructure:"folder" cty:"folder" hcl:"folder"`
 	SnapshotEnable      *bool             `mapstructure:"snapshot_enable" cty:"snapshot_enable" hcl:"snapshot_enable"`
@@ -51,9 +51,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_user_variables":      &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables": &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
 		"host":                       &hcldec.AttrSpec{Name: "host", Type: cty.String, Required: false},
-		"insecure":                   &hcldec.AttrSpec{Name: "insecure", Type: cty.Bool, Required: false},
 		"username":                   &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":                   &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
+		"insecure":                   &hcldec.AttrSpec{Name: "insecure", Type: cty.Bool, Required: false},
 		"datacenter":                 &hcldec.AttrSpec{Name: "datacenter", Type: cty.String, Required: false},
 		"folder":                     &hcldec.AttrSpec{Name: "folder", Type: cty.String, Required: false},
 		"snapshot_enable":            &hcldec.AttrSpec{Name: "snapshot_enable", Type: cty.Bool, Required: false},

--- a/post-processor/vsphere-template/post-processor_test.go
+++ b/post-processor/vsphere-template/post-processor_test.go
@@ -9,9 +9,9 @@ import (
 
 func getTestConfig() Config {
 	return Config{
-		Username: "me",
-		Password: "notpassword",
-		Host:     "myhost",
+		Username: "administrator@vsphere.local",
+		Password: "password",
+		Host:     "vcenter.example.com",
 	}
 }
 
@@ -22,7 +22,7 @@ func TestConfigure_Good(t *testing.T) {
 
 	err := p.Configure(config)
 	if err != nil {
-		t.Errorf("Error: %s", err)
+		t.Errorf("error: %s", err)
 	}
 }
 
@@ -33,10 +33,10 @@ func TestConfigure_ReRegisterVM(t *testing.T) {
 
 	err := p.Configure(config)
 	if err != nil {
-		t.Errorf("Error: %s", err)
+		t.Errorf("error: %s", err)
 	}
 
 	if p.config.ReregisterVM.False() {
-		t.Errorf("This should default to unset, not false.")
+		t.Errorf(("error: should be unset, not false"))
 	}
 }

--- a/post-processor/vsphere-template/step_choose_datacenter.go
+++ b/post-processor/vsphere-template/step_choose_datacenter.go
@@ -5,6 +5,7 @@ package vsphere_template
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -23,8 +24,10 @@ func (s *stepChooseDatacenter) Run(ctx context.Context, state multistep.StateBag
 
 	ui.Message("Choosing datacenter...")
 
+	// Find the datacenter or use the default one if not specified.
 	dc, err := finder.DatacenterOrDefault(context.Background(), s.Datacenter)
 	if err != nil {
+		err = fmt.Errorf("error finding datacenter %s: %s", s.Datacenter, err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/post-processor/vsphere-template/step_create_snapshot.go
+++ b/post-processor/vsphere-template/step_create_snapshot.go
@@ -22,6 +22,7 @@ type stepCreateSnapshot struct {
 }
 
 func NewStepCreateSnapshot(artifact packersdk.Artifact, p *PostProcessor) *stepCreateSnapshot {
+	// Set the default folder.
 	remoteFolder := "Discovered virtual machine"
 	vmname := artifact.Id()
 
@@ -49,10 +50,9 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 		return multistep.ActionContinue
 	}
 
-	ui.Message("Creating a Snapshot...")
+	ui.Message("Creating virtual machine snapshot...")
 
 	vm, err := findRuntimeVM(cli, dcPath, s.VMName, s.RemoteFolder)
-
 	if err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())
@@ -60,7 +60,6 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	task, err := vm.CreateSnapshot(context.Background(), s.SnapshotName, s.SnapshotDescription, false, false)
-
 	if err != nil {
 		state.Put("error", err)
 		ui.Error(err.Error())


### PR DESCRIPTION
### Summary

- Updates error messages to use a more well-formed structure.
- Updates and simplifies code comments.
- Updates post-processor to generate documentation from structs.
- Generates the updated post-processor documentation.

### Testing

```console
packer-plugin-vsphere on  chore(post-processor)/update-vsphere-template [$!?] via 🐹 v1.22.1 
➜ make dev


packer-plugin-vsphere on  chore(post-processor)/update-vsphere-template [$!?] via 🐹 v1.22.1 
➜ make generate
2024/03/14 14:01:06 Copying "docs" to ".docs/"
2024/03/14 14:01:06 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...


packer-plugin-vsphere on  chore(post-processor)/update-vsphere-template [$!?] via 🐹 v1.22.1 took 11.6s 
➜ make build


packer-plugin-vsphere on  chore(post-processor)/update-vsphere-template [$!?] via 🐹 v1.22.1 took 3.2s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.092s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.645s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       6.430s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  1.438s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.679s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.781s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.089s
```