### PR TITLE
chore(post-processor): update `vsphere`

### DIFF
--- a/.web-docs/components/post-processor/vsphere/README.md
+++ b/.web-docs/components/post-processor/vsphere/README.md
@@ -1,84 +1,94 @@
 Type: `vsphere`
 Artifact BuilderId: `packer.post-processor.vsphere`
 
-The Packer vSphere post-processor takes an artifact and uploads it to a vSphere endpoint.
-The artifact must have a vmx/ova/ovf image.
+This post-processor uploads an artifact to a vSphere endpoint.
+
+The artifact must be a VMX, OVA, or OVF file.
 
 ## Configuration
 
-There are many configuration options available for the post-processor. They are
-segmented below into two categories: required and optional parameters. Within
-each category, the available configuration keys are alphabetized.
+The following configuration options are available for the post-processor.
 
 Required:
 
-- `cluster` (string) - The vSphere cluster or ESXi host to upload the VM. This can be
-  either the name of the vSphere cluster or the FQDN/IP address of an ESXi host.
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `datacenter` (string) - The name of the datacenter within the vSphere environemnt
-   to add the VM.
+- `cluster` (string) - Specifies the vSphere cluster or ESXi host to upload the virtual machine.
+  This can be either the name of the vSphere cluster or the fully qualified domain name (FQDN)
+  or IP address of the ESXi host.
 
-- `datastore` (string) - The name of the datastore to place the VM. This is
-  _not required_ if `resource_pool` is specified.
+- `datacenter` (string) - Specifies the name of the vSphere datacenter object to place the virtual machine.
+  This is _not required_ if `resource_pool` is specified.
 
-- `host` (string) - The vSphere endpoint that will be contacted to perform
-  the VM upload.
+- `datastore` (string) - Specifies the name of the vSphere datastore to place the virtual machine.
 
-- `password` (string) - The password to use to authenticate to the endpoint.
+- `host` (string) - Specifies the fully qualified domain name or IP address of the vCenter Server or ESXi host.
 
-- `username` (string) - The username to use to authenticate to the endpoint.
+- `password` (string) - Specifies the password to use to authenticate to the vSphere endpoint.
 
-- `vm_name` (string) - The name of the VM after upload.
+- `username` (string) - Specifies the username to use to authenticate to the vSphere endpoint.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->
+
 
 Optional:
 
-- `esxi_host` (string) - Target ESXi host. Used to assign specific ESXi
-  host to upload the resulting VM, when a vCenter Server is used as
-  `host`. Can be either an FQDN (e.g., "esxi-01.example.com", requires proper DNS
-  setup and/or correct DNS search domain setting) or an IPv4 address.
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `disk_mode` (string) - Target disk format. See `ovftool` manual for
-  available options. Default: `thick`.
+- `disk_mode` (string) - Specifies the disk format of the target virtual machine. One of `thin`, `thick`,
 
-- `insecure` (boolean) - Whether or not the connection can be done
-  over an insecure connection. Default: `false`
+- `esxi_host` (string) - Specifies the fully qualified domain name or IP address of the ESXi host to upload the
+  virtual machine. This is _not required_ if `host` is a vCenter Server.
 
-- `keep_input_artifact` (boolean) - When `true`, preserve the local VM files,
-  even after importing them to the vSphere endpoint. Default: `false`.
+- `insecure` (bool) - Specifies whether to skip the verification of the server certificate. Defaults to `false`.
 
-- `resource_pool` (string) - The resource pool in which to upload the VM.
+- `options` ([]string) - Specifies custom options to add in `ovftool`.
+  Use `ovftool --help` to list all the options available.
 
-- `vm_folder` (string) - The folder within the datastore to place the VM.
+- `overwrite` (bool) - Specifies whether to overwrite the existing files.
+  If `true`, forces existing files to to be overwritten. Defaults to `false`.
 
-- `vm_network` (string) - The name of the network in which to place the VM.
+- `resource_pool` (string) - Specifies the name of the resource pool to place the virtual machine.
 
-- `overwrite` (boolean) - If `true`, force the system to overwrite the
-  existing files instead create new ones. Default: `false`
+- `vm_folder` (string) - Specifies the name of the virtual machine folder path where the virtual machine will be
+  placed.
 
-- `hardware_version` (string) - This option sets the maximum virtual hardware version
-  for the deployed VM. It does not upgrade the virtual hardware version of the source VM.
-  Instead, it limits the virtual hardware version of the deployed VM to the specified
-  version. If the source VM's hardware version is higher than the specified version,
-  the deployed VM's hardware version will be downgraded to the specified version.
-  If the source VM's hardware version is lower than or equal to the specified version,
-  the deployed VM's hardware version will be the same as the source VM's.
-  This option is useful when deploying to a vSphere / ESXi host whose version is different
-  than the one used to create the artifact.
+- `vm_name` (string) - Specifies the name of the virtual machine to be created on the vSphere endpoint.
+
+- `vm_network` (string) - Specifies the name of the network in which to place the virtual machine.
+
+- `hardware_version` (string) - Specifies the maximum virtual hardware version for the deployed virtual machine.
   
-  See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information
-  on the virtual hardware versions supported for each vSphere / ESXi version.
+  It does not upgrade the virtual hardware version of the source VM. Instead, it limits the
+  virtual hardware version of the deployed virtual machine  to the specified version.
+  If the source virtual machine's hardware version is higher than the specified version, the
+  deployed virtual machine's hardware version will be downgraded to the specified version.
+  
+  If the source virtual machine's hardware version is lower than or equal to the specified
+  version, the deployed virtual machine's hardware version will be the same as the source
+  virtual machine's.
+  
+  This option is useful when deploying to vCenter Server instance ot an ESXi host whose
+  version is different than the one used to create the artifact.
+  
+  See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information on the
+  virtual hardware versions supported.
 
-- `options` (array of strings) - Custom options to add in `ovftool`. See
-  `ovftool --help` to list all the options
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->
 
-# Example
 
-The following is an example of the vSphere post-processor being used in
-conjunction with the null builder to upload a vmx to a vSphere cluster.
+- `keep_input_artifact` (boolean) - Specifies to preserve the local virtual machines files, even
+  after importing them to the vSphere endpoint. Defaults to `false`.
 
-You can also use this post-processor with the vmx artifact from a build.
+# Example Usage
 
-**HCL2**
+The following is an example of the vSphere post-processor being used in conjunction with the `null`
+builder to upload a VMX to a vSphere cluster. You can also use this post-processor with the VMX
+artifact from a build.
+
+An example is shown below, showing only the post-processor configuration:
+
+In HCL2:
 
 ```hcl
 source "null" "example" {
@@ -96,7 +106,7 @@ build {
           host                = "vcenter.example.com"
           username            = "administrator@vsphere.local"
           password            = "VMw@re1!"
-          datacenter          = "dc-01"   
+          datacenter          = "dc-01"
           cluster             = "cluster-01"
           datastore           = "datastore-01"
           vm_network          = "VM Network"
@@ -106,7 +116,7 @@ build {
 }
 ```
 
-**JSON**
+In JSON:
 
 ```json
 {
@@ -135,33 +145,34 @@ build {
 }
 ```
 
-
 # Privileges
 
-The post-processor uses `ovftool` and therefore needs the same privileges
-as `ovftool`. Rather than giving full administrator access, you can create a role
-to give the post-processor the permissions necessary to run. Below is an example
-role. Please note that this is a user-supplied list so there may be a few
-extraneous permissions that are not strictly required.
+The post-processor uses `ovftool` and tneeds several privileges to be able to run `ovftool`.
 
-For vSphere the role needs the following privileges:
+Rather than giving full administrator access, you can create a role to give the post-processor the
+privileges necessary to run.
 
-    Datastore.AllocateSpace
-    Host.Config.AdvancedConfig
-    Host.Config.NetService
-    Host.Config.Network
-    Network.Assign
-    System.Anonymous
-    System.Read
-    System.View
-    VApp.Import
-    VirtualMachine.Config.AddNewDisk
-    VirtualMachine.Config.AdvancedConfig
-    VirtualMachine.Inventory.Delete
+Below is an example role that will work. Please note that this is a user-supplied list so there may
+be a few extraneous privileges that are not strictly required.
 
-And this role must be authorized on the:
+For vSphere, the role needs the following privileges:
 
-    Cluster of the host
-    The destination folder (not on Datastore, on the vSphere logical view)
-    The network to be assigned
-    The destination datastore.
+- `Datastore.AllocateSpace`
+- `Host.Config.AdvancedConfig`
+- `Host.Config.NetService`
+- `Host.Config.Network`
+- `Network.Assign`
+- `System.Anonymous`
+- `System.Read`
+- `System.View`
+- `VApp.Import`
+- `VirtualMachine.Config.AddNewDisk`
+- `VirtualMachine.Config.AdvancedConfig`
+- `VirtualMachine.Inventory.Delete`
+
+The role must be authorized on the:
+
+- Cluster of the host.
+- The destination folder.
+- The destination datastore.
+- The network to be assigned.

--- a/docs-partials/post-processor/vsphere/Config-not-required.mdx
+++ b/docs-partials/post-processor/vsphere/Config-not-required.mdx
@@ -1,35 +1,42 @@
 <!-- Code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `cluster` (string) - Cluster
+- `disk_mode` (string) - Specifies the disk format of the target virtual machine. One of `thin`, `thick`,
 
-- `datacenter` (string) - Datacenter
+- `esxi_host` (string) - Specifies the fully qualified domain name or IP address of the ESXi host to upload the
+  virtual machine. This is _not required_ if `host` is a vCenter Server.
 
-- `datastore` (string) - Datastore
+- `insecure` (bool) - Specifies whether to skip the verification of the server certificate. Defaults to `false`.
 
-- `disk_mode` (string) - Disk Mode
+- `options` ([]string) - Specifies custom options to add in `ovftool`.
+  Use `ovftool --help` to list all the options available.
 
-- `host` (string) - Host
+- `overwrite` (bool) - Specifies whether to overwrite the existing files.
+  If `true`, forces existing files to to be overwritten. Defaults to `false`.
 
-- `esxi_host` (string) - ES Xi Host
+- `resource_pool` (string) - Specifies the name of the resource pool to place the virtual machine.
 
-- `insecure` (bool) - Insecure
+- `vm_folder` (string) - Specifies the name of the virtual machine folder path where the virtual machine will be
+  placed.
 
-- `options` ([]string) - Options
+- `vm_name` (string) - Specifies the name of the virtual machine to be created on the vSphere endpoint.
 
-- `overwrite` (bool) - Overwrite
+- `vm_network` (string) - Specifies the name of the network in which to place the virtual machine.
 
-- `password` (string) - Password
-
-- `resource_pool` (string) - Resource Pool
-
-- `username` (string) - Username
-
-- `vm_folder` (string) - VM Folder
-
-- `vm_name` (string) - VM Name
-
-- `vm_network` (string) - VM Network
-
-- `hardware_version` (string) - Hardware Version
+- `hardware_version` (string) - Specifies the maximum virtual hardware version for the deployed virtual machine.
+  
+  It does not upgrade the virtual hardware version of the source VM. Instead, it limits the
+  virtual hardware version of the deployed virtual machine  to the specified version.
+  If the source virtual machine's hardware version is higher than the specified version, the
+  deployed virtual machine's hardware version will be downgraded to the specified version.
+  
+  If the source virtual machine's hardware version is lower than or equal to the specified
+  version, the deployed virtual machine's hardware version will be the same as the source
+  virtual machine's.
+  
+  This option is useful when deploying to vCenter Server instance ot an ESXi host whose
+  version is different than the one used to create the artifact.
+  
+  See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information on the
+  virtual hardware versions supported.
 
 <!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->

--- a/docs-partials/post-processor/vsphere/Config-required.mdx
+++ b/docs-partials/post-processor/vsphere/Config-required.mdx
@@ -1,0 +1,18 @@
+<!-- Code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; DO NOT EDIT MANUALLY -->
+
+- `cluster` (string) - Specifies the vSphere cluster or ESXi host to upload the virtual machine.
+  This can be either the name of the vSphere cluster or the fully qualified domain name (FQDN)
+  or IP address of the ESXi host.
+
+- `datacenter` (string) - Specifies the name of the vSphere datacenter object to place the virtual machine.
+  This is _not required_ if `resource_pool` is specified.
+
+- `datastore` (string) - Specifies the name of the vSphere datastore to place the virtual machine.
+
+- `host` (string) - Specifies the fully qualified domain name or IP address of the vCenter Server or ESXi host.
+
+- `password` (string) - Specifies the password to use to authenticate to the vSphere endpoint.
+
+- `username` (string) - Specifies the username to use to authenticate to the vSphere endpoint.
+
+<!-- End of code generated from the comments of the Config struct in post-processor/vsphere/post-processor.go; -->

--- a/docs/post-processors/vsphere.mdx
+++ b/docs/post-processors/vsphere.mdx
@@ -1,7 +1,6 @@
 ---
 description: >
-  The Packer vSphere post-processor takes an artifact and uploads it to a
-  vSphere endpoint.
+  This post-processor uploads an artifact to a vSphere endpoint.
 page_title: vSphere - Post-Processors
 sidebar_title: vSphere
 ---
@@ -11,84 +10,34 @@ sidebar_title: vSphere
 Type: `vsphere`
 Artifact BuilderId: `packer.post-processor.vsphere`
 
-The Packer vSphere post-processor takes an artifact and uploads it to a vSphere endpoint.
-The artifact must have a vmx/ova/ovf image.
+This post-processor uploads an artifact to a vSphere endpoint.
+
+The artifact must be a VMX, OVA, or OVF file.
 
 ## Configuration
 
-There are many configuration options available for the post-processor. They are
-segmented below into two categories: required and optional parameters. Within
-each category, the available configuration keys are alphabetized.
+The following configuration options are available for the post-processor.
 
 Required:
 
-- `cluster` (string) - The vSphere cluster or ESXi host to upload the VM. This can be
-  either the name of the vSphere cluster or the FQDN/IP address of an ESXi host.
-
-- `datacenter` (string) - The name of the datacenter within the vSphere environemnt
-   to add the VM.
-
-- `datastore` (string) - The name of the datastore to place the VM. This is
-  _not required_ if `resource_pool` is specified.
-
-- `host` (string) - The vSphere endpoint that will be contacted to perform
-  the VM upload.
-
-- `password` (string) - The password to use to authenticate to the endpoint.
-
-- `username` (string) - The username to use to authenticate to the endpoint.
-
-- `vm_name` (string) - The name of the VM after upload.
+@include 'post-processor/vsphere/Config-required.mdx'
 
 Optional:
 
-- `esxi_host` (string) - Target ESXi host. Used to assign specific ESXi
-  host to upload the resulting VM, when a vCenter Server is used as
-  `host`. Can be either an FQDN (e.g., "esxi-01.example.com", requires proper DNS
-  setup and/or correct DNS search domain setting) or an IPv4 address.
+@include 'post-processor/vsphere/Config-not-required.mdx'
 
-- `disk_mode` (string) - Target disk format. See `ovftool` manual for
-  available options. Default: `thick`.
+- `keep_input_artifact` (boolean) - Specifies to preserve the local virtual machines files, even
+  after importing them to the vSphere endpoint. Defaults to `false`.
 
-- `insecure` (boolean) - Whether or not the connection can be done
-  over an insecure connection. Default: `false`
+# Example Usage
 
-- `keep_input_artifact` (boolean) - When `true`, preserve the local VM files,
-  even after importing them to the vSphere endpoint. Default: `false`.
+The following is an example of the vSphere post-processor being used in conjunction with the `null`
+builder to upload a VMX to a vSphere cluster. You can also use this post-processor with the VMX
+artifact from a build.
 
-- `resource_pool` (string) - The resource pool in which to upload the VM.
+An example is shown below, showing only the post-processor configuration:
 
-- `vm_folder` (string) - The folder within the datastore to place the VM.
-
-- `vm_network` (string) - The name of the network in which to place the VM.
-
-- `overwrite` (boolean) - If `true`, force the system to overwrite the
-  existing files instead create new ones. Default: `false`
-
-- `hardware_version` (string) - This option sets the maximum virtual hardware version
-  for the deployed VM. It does not upgrade the virtual hardware version of the source VM.
-  Instead, it limits the virtual hardware version of the deployed VM to the specified
-  version. If the source VM's hardware version is higher than the specified version,
-  the deployed VM's hardware version will be downgraded to the specified version.
-  If the source VM's hardware version is lower than or equal to the specified version,
-  the deployed VM's hardware version will be the same as the source VM's.
-  This option is useful when deploying to a vSphere / ESXi host whose version is different
-  than the one used to create the artifact.
-  
-  See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information
-  on the virtual hardware versions supported for each vSphere / ESXi version.
-
-- `options` (array of strings) - Custom options to add in `ovftool`. See
-  `ovftool --help` to list all the options
-
-# Example
-
-The following is an example of the vSphere post-processor being used in
-conjunction with the null builder to upload a vmx to a vSphere cluster.
-
-You can also use this post-processor with the vmx artifact from a build.
-
-**HCL2**
+In HCL2:
 
 ```hcl
 source "null" "example" {
@@ -106,7 +55,7 @@ build {
           host                = "vcenter.example.com"
           username            = "administrator@vsphere.local"
           password            = "VMw@re1!"
-          datacenter          = "dc-01"   
+          datacenter          = "dc-01"
           cluster             = "cluster-01"
           datastore           = "datastore-01"
           vm_network          = "VM Network"
@@ -116,7 +65,7 @@ build {
 }
 ```
 
-**JSON**
+In JSON:
 
 ```json
 {
@@ -145,33 +94,34 @@ build {
 }
 ```
 
-
 # Privileges
 
-The post-processor uses `ovftool` and therefore needs the same privileges
-as `ovftool`. Rather than giving full administrator access, you can create a role
-to give the post-processor the permissions necessary to run. Below is an example
-role. Please note that this is a user-supplied list so there may be a few
-extraneous permissions that are not strictly required.
+The post-processor uses `ovftool` and tneeds several privileges to be able to run `ovftool`.
 
-For vSphere the role needs the following privileges:
+Rather than giving full administrator access, you can create a role to give the post-processor the
+privileges necessary to run.
 
-    Datastore.AllocateSpace
-    Host.Config.AdvancedConfig
-    Host.Config.NetService
-    Host.Config.Network
-    Network.Assign
-    System.Anonymous
-    System.Read
-    System.View
-    VApp.Import
-    VirtualMachine.Config.AddNewDisk
-    VirtualMachine.Config.AdvancedConfig
-    VirtualMachine.Inventory.Delete
+Below is an example role that will work. Please note that this is a user-supplied list so there may
+be a few extraneous privileges that are not strictly required.
 
-And this role must be authorized on the:
+For vSphere, the role needs the following privileges:
 
-    Cluster of the host
-    The destination folder (not on Datastore, on the vSphere logical view)
-    The network to be assigned
-    The destination datastore.
+- `Datastore.AllocateSpace`
+- `Host.Config.AdvancedConfig`
+- `Host.Config.NetService`
+- `Host.Config.Network`
+- `Network.Assign`
+- `System.Anonymous`
+- `System.Read`
+- `System.View`
+- `VApp.Import`
+- `VirtualMachine.Config.AddNewDisk`
+- `VirtualMachine.Config.AdvancedConfig`
+- `VirtualMachine.Inventory.Delete`
+
+The role must be authorized on the:
+
+- Cluster of the host.
+- The destination folder.
+- The destination datastore.
+- The network to be assigned.

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -1,6 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
+//go:generate packer-sdc struct-markdown
 //go:generate packer-sdc mapstructure-to-hcl2 -type Config
 
 package vsphere
@@ -39,23 +40,60 @@ var (
 
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
-
-	Cluster         string   `mapstructure:"cluster"`
-	Datacenter      string   `mapstructure:"datacenter"`
-	Datastore       string   `mapstructure:"datastore"`
-	DiskMode        string   `mapstructure:"disk_mode"`
-	Host            string   `mapstructure:"host"`
-	ESXiHost        string   `mapstructure:"esxi_host"`
-	Insecure        bool     `mapstructure:"insecure"`
-	Options         []string `mapstructure:"options"`
-	Overwrite       bool     `mapstructure:"overwrite"`
-	Password        string   `mapstructure:"password"`
-	ResourcePool    string   `mapstructure:"resource_pool"`
-	Username        string   `mapstructure:"username"`
-	VMFolder        string   `mapstructure:"vm_folder"`
-	VMName          string   `mapstructure:"vm_name"`
-	VMNetwork       string   `mapstructure:"vm_network"`
-	HardwareVersion string   `mapstructure:"hardware_version"`
+	// Specifies the vSphere cluster or ESXi host to upload the virtual machine.
+	// This can be either the name of the vSphere cluster or the fully qualified domain name (FQDN)
+	// or IP address of the ESXi host.
+	Cluster string `mapstructure:"cluster" required:"true"`
+	// Specifies the name of the vSphere datacenter object to place the virtual machine.
+	// This is _not required_ if `resource_pool` is specified.
+	Datacenter string `mapstructure:"datacenter" required:"true"`
+	// Specifies the name of the vSphere datastore to place the virtual machine.
+	Datastore string `mapstructure:"datastore"  required:"true"`
+	// Specifies the disk format of the target virtual machine. One of `thin`, `thick`,
+	DiskMode string `mapstructure:"disk_mode"`
+	// Specifies the fully qualified domain name or IP address of the vCenter Server or ESXi host.
+	Host string `mapstructure:"host" required:"true"`
+	// Specifies the fully qualified domain name or IP address of the ESXi host to upload the
+	// virtual machine. This is _not required_ if `host` is a vCenter Server.
+	ESXiHost string `mapstructure:"esxi_host"`
+	// Specifies whether to skip the verification of the server certificate. Defaults to `false`.
+	Insecure bool `mapstructure:"insecure"`
+	// Specifies custom options to add in `ovftool`.
+	// Use `ovftool --help` to list all the options available.
+	Options []string `mapstructure:"options"`
+	// Specifies whether to overwrite the existing files.
+	// If `true`, forces existing files to to be overwritten. Defaults to `false`.
+	Overwrite bool `mapstructure:"overwrite"`
+	// Specifies the password to use to authenticate to the vSphere endpoint.
+	Password string `mapstructure:"password" required:"true"`
+	// Specifies the name of the resource pool to place the virtual machine.
+	ResourcePool string `mapstructure:"resource_pool"`
+	// Specifies the username to use to authenticate to the vSphere endpoint.
+	Username string `mapstructure:"username" required:"true"`
+	// Specifies the name of the virtual machine folder path where the virtual machine will be
+	// placed.
+	VMFolder string `mapstructure:"vm_folder"`
+	// Specifies the name of the virtual machine to be created on the vSphere endpoint.
+	VMName string `mapstructure:"vm_name"`
+	// Specifies the name of the network in which to place the virtual machine.
+	VMNetwork string `mapstructure:"vm_network"`
+	// Specifies the maximum virtual hardware version for the deployed virtual machine.
+	//
+	// It does not upgrade the virtual hardware version of the source VM. Instead, it limits the
+	// virtual hardware version of the deployed virtual machine  to the specified version.
+	// If the source virtual machine's hardware version is higher than the specified version, the
+	// deployed virtual machine's hardware version will be downgraded to the specified version.
+	//
+	// If the source virtual machine's hardware version is lower than or equal to the specified
+	// version, the deployed virtual machine's hardware version will be the same as the source
+	// virtual machine's.
+	//
+	// This option is useful when deploying to vCenter Server instance ot an ESXi host whose
+	// version is different than the one used to create the artifact.
+	//
+	// See [VMware KB 1003746](https://kb.vmware.com/s/article/1003746) for more information on the
+	// virtual hardware versions supported.
+	HardwareVersion string `mapstructure:"hardware_version"`
 
 	ctx interpolate.Context
 }

--- a/post-processor/vsphere/post-processor.hcl2spec.go
+++ b/post-processor/vsphere/post-processor.hcl2spec.go
@@ -18,18 +18,18 @@ type FlatConfig struct {
 	PackerOnError       *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars      map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	Cluster             *string           `mapstructure:"cluster" cty:"cluster" hcl:"cluster"`
-	Datacenter          *string           `mapstructure:"datacenter" cty:"datacenter" hcl:"datacenter"`
-	Datastore           *string           `mapstructure:"datastore" cty:"datastore" hcl:"datastore"`
+	Cluster             *string           `mapstructure:"cluster" required:"true" cty:"cluster" hcl:"cluster"`
+	Datacenter          *string           `mapstructure:"datacenter" required:"true" cty:"datacenter" hcl:"datacenter"`
+	Datastore           *string           `mapstructure:"datastore" required:"true" cty:"datastore" hcl:"datastore"`
 	DiskMode            *string           `mapstructure:"disk_mode" cty:"disk_mode" hcl:"disk_mode"`
-	Host                *string           `mapstructure:"host" cty:"host" hcl:"host"`
+	Host                *string           `mapstructure:"host" required:"true" cty:"host" hcl:"host"`
 	ESXiHost            *string           `mapstructure:"esxi_host" cty:"esxi_host" hcl:"esxi_host"`
 	Insecure            *bool             `mapstructure:"insecure" cty:"insecure" hcl:"insecure"`
 	Options             []string          `mapstructure:"options" cty:"options" hcl:"options"`
 	Overwrite           *bool             `mapstructure:"overwrite" cty:"overwrite" hcl:"overwrite"`
-	Password            *string           `mapstructure:"password" cty:"password" hcl:"password"`
+	Password            *string           `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	ResourcePool        *string           `mapstructure:"resource_pool" cty:"resource_pool" hcl:"resource_pool"`
-	Username            *string           `mapstructure:"username" cty:"username" hcl:"username"`
+	Username            *string           `mapstructure:"username" required:"true" cty:"username" hcl:"username"`
 	VMFolder            *string           `mapstructure:"vm_folder" cty:"vm_folder" hcl:"vm_folder"`
 	VMName              *string           `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	VMNetwork           *string           `mapstructure:"vm_network" cty:"vm_network" hcl:"vm_network"`


### PR DESCRIPTION
### Summary

- Updates and simplifies code comments.
- Updates post-processor to generate documentation from structs.
- Generates the updated post-processor documentation.

### Testing

```console
packer-plugin-vsphere on chore(post-processor)/update-vsphere
➜ make generate
2024/03/18 11:09:48 Copying "docs" to ".docs/"
2024/03/18 11:09:48 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on chore(post-processor)/update-vsphere
➜ make dev  

packer-plugin-vsphere on chore(post-processor)/update-vsphere 
➜ make build

packer-plugin-vsphere on chore(post-processor)/update-vsphere
➜ make test

?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.545s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.664s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.196s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.046s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.909s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.471s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      1.986s
```