### PR TITLE
common: make sure to prepend remote iso path

### DIFF
--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -74,7 +74,9 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	if path, ok := state.GetOk("iso_remote_path"); ok {
-		s.Config.ISOPaths = append(s.Config.ISOPaths, path.(string))
+		// The order matters: docs say "iso_url" should go first, so make sure to
+		// prepend it.
+		s.Config.ISOPaths = append([]string{path.(string)}, s.Config.ISOPaths...)
 	}
 
 	// Add our custom CD, if it exists

--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -96,7 +96,7 @@ func TestStepAddCDRom_Run(t *testing.T) {
 				FindSATAControllerCalled: true,
 				AddCdromCalledTimes:      3,
 				AddCdromTypes:            []string{"sata", "sata", "sata"},
-				AddCdromPaths:            []string{"iso/path", "remote/path", "cd/path"},
+				AddCdromPaths:            []string{"remote/path", "iso/path", "cd/path"},
 			},
 			fail:       false,
 			errMessage: "",


### PR DESCRIPTION
This fixes regression introduced by the commit

     "common: deduplicate AddCdrom call by appending path to ISOPaths"

that was squashed into:

     "refactor: only add / remove minimul number of cdroms (#355)"

It explained that the order is not guaranteed and does not matter, however the documentation says:

> If the "iso_url" is defined in addition to the "iso_paths", the
> "iso_url" is added to the VM first. This keeps the "iso_url" first
> in the boot order by default allowing the boot iso being defined by
> the iso_url and the vmware tools iso added from the datastore.

So fix the regression.

Fixes: https://github.com/hashicorp/packer-plugin-vsphere/issues/386