### PR TITLE
chore(deps): bump google.golang.org/protobuf from v1.31.0 to v1.33.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,7 +132,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/grpc v1.59.0 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -858,8 +858,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Summary

Bump google.golang.org/protobuf from v1.31.0 to v1.33.0

### Reference

Ref: https://github.com/hashicorp/packer-plugin-vsphere/security/dependabot/26

### Testing

```console
packer-plugin-vsphere on  chore(post-processor)/update-vsphere [$!] via 🐹 v1.22.1 
➜ go get -u google.golang.org/protobuf           
go: upgraded google.golang.org/protobuf v1.31.0 => v1.33.0


packer-plugin-vsphere on  main [$!] via 🐹 v1.22.1 
➜ go mod tidy


packer-plugin-vsphere on  main [$!] via 🐹 v1.22.1 
➜ make build


packer-plugin-vsphere on  main [$!] via 🐹 v1.22.1 took 17.1s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.752s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.370s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       6.017s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.177s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.940s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.480s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.024s
```

