### PR TITLE
fix: ipv6 rfc2732

### DIFF
--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -169,6 +170,12 @@ loop:
 	} else {
 		log.Printf("VM IP is still the same: %s", prevIp)
 		if time.Now().After(stopTime) {
+			if strings.Contains(ip, ":") {
+				// To use a literal IPv6 address in a URL the literal address should be enclosed in
+				// "[" and "]" characters. Refer to https://www.ietf.org/rfc/rfc2732.
+				// Example: ssh example@[2010:836B:4179::836B:4179]
+				ip = "[" + ip + "]"
+			}
 			log.Printf("VM IP seems stable enough: %s", ip)
 			return ip, nil
 		}


### PR DESCRIPTION
**Summary**

To use a literal IPv6 address in a URL, the literal address must be enclosed in "`[`" and "`]`" characters.

```
ssh example@[2010:836B:4179::836B:4179]
```

### Reference

Refer to https://www.ietf.org/rfc/rfc2732.

Closes: #333
