### PR TITLE
feat: add support for export to ova

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1263,20 +1263,20 @@ The above configuration would create the following files:
 - `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
   The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
-  If set to false, the export will fail if the files already exists.
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to `false`.
+  If set to `false`, an error is returned if the file(s) already exists.
 
-- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to `false`.
   For example, `.nvram` and `.log` files.
 
 - `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
   Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `options` ([]string) - Advanced image export options. Options can include:
-  * mac - MAC address is exported for each Ethernet device.
-  * uuid - UUID is exported for the virtual machine.
-  * extraconfig - Extra configuration options are exported for the virtual machine.
-  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
+- `options` ([]string) - Advanced image export options. Available options can include:
+  - mac - MAC address is exported for each Ethernet device.
+  - uuid - UUID is exported for the virtual machine.
+  - extraconfig - Extra configuration options are exported for the virtual machine.
+  - nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
   For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
@@ -1294,6 +1294,18 @@ The above configuration would create the following files:
       options = ["mac"]
     }
   ```
+
+- `output_format` (string) - The output format for the exported virtual machine image. Defaults to `ovf`.
+  Available options include `ovf` and `ova`.
+  
+  When set to `ova`, the image is first exported using Open Virtualization
+  / Format (`.ovf`) and then converted to an Open Virtualization Archive
+  (`.ova`) using the VMware [Open Virtualization Format Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest)
+  (ovftool). The intermediate files are removed after the conversion.
+  
+  ~> **Note:** To use the `ova` format option, VMware ovftool must be
+  installed on the Packer host and accessible in either the system `PATH`
+  or the user's `PATH`.
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
 
@@ -1342,7 +1354,7 @@ The template is stored in a existing or newly created library item.
   For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
   exists it will be then updated with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+  ~> **Note:** It's not possible to update existing library items with a new VM template. If updating an existing library
   item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
 - `description` (string) - Description of the library item that will be created.

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1090,20 +1090,20 @@ The above configuration would create the following files:
 - `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
   The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
-  If set to false, the export will fail if the files already exists.
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to `false`.
+  If set to `false`, an error is returned if the file(s) already exists.
 
-- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to `false`.
   For example, `.nvram` and `.log` files.
 
 - `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
   Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `options` ([]string) - Advanced image export options. Options can include:
-  * mac - MAC address is exported for each Ethernet device.
-  * uuid - UUID is exported for the virtual machine.
-  * extraconfig - Extra configuration options are exported for the virtual machine.
-  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
+- `options` ([]string) - Advanced image export options. Available options can include:
+  - mac - MAC address is exported for each Ethernet device.
+  - uuid - UUID is exported for the virtual machine.
+  - extraconfig - Extra configuration options are exported for the virtual machine.
+  - nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
   For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
@@ -1121,6 +1121,18 @@ The above configuration would create the following files:
       options = ["mac"]
     }
   ```
+
+- `output_format` (string) - The output format for the exported virtual machine image. Defaults to `ovf`.
+  Available options include `ovf` and `ova`.
+  
+  When set to `ova`, the image is first exported using Open Virtualization
+  / Format (`.ovf`) and then converted to an Open Virtualization Archive
+  (`.ova`) using the VMware [Open Virtualization Format Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest)
+  (ovftool). The intermediate files are removed after the conversion.
+  
+  ~> **Note:** To use the `ova` format option, VMware ovftool must be
+  installed on the Packer host and accessible in either the system `PATH`
+  or the user's `PATH`.
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->
 
@@ -1169,7 +1181,7 @@ The template is stored in a existing or newly created library item.
   For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
   exists it will be then updated with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+  ~> **Note:** It's not possible to update existing library items with a new VM template. If updating an existing library
   item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
 - `description` (string) - Description of the library item that will be created.

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -162,6 +162,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Manifest:   b.config.Export.Manifest,
 			OutputDir:  b.config.Export.OutputDir.OutputDir,
 			Options:    b.config.Export.Options,
+			Format:     b.config.Export.Format,
 		})
 	}
 

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatExportConfig struct {
 	OutputDir  *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
 	DirPerm    *fs.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 	Options    []string     `mapstructure:"options" cty:"options" hcl:"options"`
+	Format     *string      `mapstructure:"output_format" cty:"output_format" hcl:"output_format"`
 }
 
 // FlatMapstructure returns a new FlatExportConfig.
@@ -40,6 +41,7 @@ func (*FlatExportConfig) HCL2Spec() map[string]hcldec.Spec {
 		"output_directory":     &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"directory_permission": &hcldec.AttrSpec{Name: "directory_permission", Type: cty.Number, Required: false},
 		"options":              &hcldec.AttrSpec{Name: "options", Type: cty.List(cty.String), Required: false},
+		"output_format":        &hcldec.AttrSpec{Name: "output_format", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -29,7 +29,7 @@ type ContentLibraryDestinationConfig struct {
 	// For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
 	// exists it will be then updated with the new OVF template, otherwise a new item will be created.
 	//
-	// ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+	// ~> **Note:** It's not possible to update existing library items with a new VM template. If updating an existing library
 	// item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 	//
 	Name string `mapstructure:"name"`

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -172,6 +172,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Manifest:   b.config.Export.Manifest,
 			OutputDir:  b.config.Export.OutputDir.OutputDir,
 			Options:    b.config.Export.Options,
+			Format:     b.config.Export.Format,
 		})
 	}
 

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -9,7 +9,7 @@
   For OVF templates, the name defaults to [vm_name](#vm_name) when not set, and if an item with the same name already
   exists it will be then updated with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note**: It's not possible to update existing library items with a new VM template. If updating an existing library
+  ~> **Note:** It's not possible to update existing library items with a new VM template. If updating an existing library
   item is necessary, use an OVF template instead by setting the [ovf](#ovf) option as `true`.
 
 - `description` (string) - Description of the library item that will be created.

--- a/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ExportConfig-not-required.mdx
@@ -3,20 +3,20 @@
 - `name` (string) - Name of the exported image in Open Virtualization Format (OVF).
   The name of the virtual machine with the `.ovf` extension is used if this option is not specified.
 
-- `force` (bool) - Forces the export to overwrite existing files. Defaults to false.
-  If set to false, the export will fail if the files already exists.
+- `force` (bool) - Forces the export to overwrite existing files. Defaults to `false`.
+  If set to `false`, an error is returned if the file(s) already exists.
 
-- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to false.
+- `image_files` (bool) - Include additional image files that are that are associated with the virtual machine. Defaults to `false`.
   For example, `.nvram` and `.log` files.
 
 - `manifest` (string) - Generate a manifest file with the specified hash algorithm. Defaults to `sha256`.
   Available options include `none`, `sha1`, `sha256`, and `sha512`. Use `none` for no manifest.
 
-- `options` ([]string) - Advanced image export options. Options can include:
-  * mac - MAC address is exported for each Ethernet device.
-  * uuid - UUID is exported for the virtual machine.
-  * extraconfig - Extra configuration options are exported for the virtual machine.
-  * nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
+- `options` ([]string) - Advanced image export options. Available options can include:
+  - mac - MAC address is exported for each Ethernet device.
+  - uuid - UUID is exported for the virtual machine.
+  - extraconfig - Extra configuration options are exported for the virtual machine.
+  - nodevicesubtypes - Resource subtypes for CD/DVD drives, floppy drives, and serial and parallel ports are not exported.
   
   For example, adding the following export config option outputs the MAC addresses for each Ethernet device in the OVF descriptor:
   
@@ -34,5 +34,17 @@
       options = ["mac"]
     }
   ```
+
+- `output_format` (string) - The output format for the exported virtual machine image. Defaults to `ovf`.
+  Available options include `ovf` and `ova`.
+  
+  When set to `ova`, the image is first exported using Open Virtualization
+  / Format (`.ovf`) and then converted to an Open Virtualization Archive
+  (`.ova`) using the VMware [Open Virtualization Format Tool](https://developer.broadcom.com/tools/open-virtualization-format-ovf-tool/latest)
+  (ovftool). The intermediate files are removed after the conversion.
+  
+  ~> **Note:** To use the `ova` format option, VMware ovftool must be
+  installed on the Packer host and accessible in either the system `PATH`
+  or the user's `PATH`.
 
 <!-- End of code generated from the comments of the ExportConfig struct in builder/vsphere/common/step_export.go; -->


### PR DESCRIPTION
### Summary

Adds support to export a virtual machine image to either to the default Open Virtualization Format (`ovf`) or convert to Open Virtualization Archive (.ova).

> [!NOTE]
> To use the `ova` format option, VMware ovftool must be installed on the Packer host and accessible in either the system `PATH` or the user's `PATH`. This is noted in the documentation.

### Testing

Standard Build and Tests:

```sh
➜  packer-plugin-vsphere git:(feat/export-to-ova) ✗ make generate
2024/04/18 15:30:19 Copying "docs" to ".docs/"
2024/04/18 15:30:19 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

➜  packer-plugin-vsphere git:(feat/export-to-ova) make build

➜  packer-plugin-vsphere git:(feat/export-to-ova) make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.655s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       4.941s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       11.917s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  5.328s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   8.156s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.179s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      3.547s
```

**Additional Tests**

✅ PASS: Export without setting `Format`. Defaults to `ovf`.
✅ PASS: Export without setting `Format`. Defaults to `ovf`. Expected error for existing `ovf` file found.
✅ PASS: Export without setting `Format` with `force = true`. Defaults to `ovf`. Existing `ovf` overwritten.
✅ PASS: Export setting `Format` to `ova` without `ovftool` installed or in `PATH`. Expected error.
✅ PASS: Export setting `Format` to `ova`.
✅ PASS: Export setting `Format` to `ova`.  Expected error for existing `ova` file found and intermediate files removed.
✅ PASS: Export setting `Format` to `ova` with `force = true`.  Existing `ova` overwritten and intermediate files removed.

### Reference

Closes #17

[VMware Open Virtualization Format Tool](https://developer.vmware.com/web/tool/ovf/) (`ovftool`).

