### PR TITLE
docs: `disk_size`

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -61,6 +61,7 @@ necessary for this build to succeed and can be found further down the page.
 
 - `disk_size` (int64) - Specifies the size of the primary disk in MiB.
   Cannot be used with `linked_clone`.
+  -> **Note:** Only the primary disk size can be specified. Additional disks are not supported.
 
 - `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
   Cannot be used with `disk_size`.`

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -38,6 +38,7 @@ type CloneConfig struct {
 	Template string `mapstructure:"template"`
 	// Specifies the size of the primary disk in MiB.
 	// Cannot be used with `linked_clone`.
+	// -> **Note:** Only the primary disk size can be specified. Additional disks are not supported.
 	DiskSize int64 `mapstructure:"disk_size"`
 	// Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
 	// Cannot be used with `disk_size`.`

--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -18,15 +18,14 @@ type Disk struct {
 }
 
 type StorageConfig struct {
-	DiskControllerType []string // example: "scsi", "pvscsi", "nvme", "lsilogic"
+	DiskControllerType []string // Example: "scsi", "pvscsi", "nvme", "lsilogic"
 	Storage            []Disk
 }
 
 func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	newDevices := object.VirtualDeviceList{}
 
-	// Create new controller based on existing devices list and add it to the new devices list
-	// to confirm creation
+	// Create new controller based on existing devices list and add it to the new devices list.
 	var controllers []types.BaseVirtualController
 	for _, controllerType := range c.DiskControllerType {
 		var device types.BaseVirtualDevice
@@ -69,6 +68,8 @@ func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceLi
 	return newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 }
 
+// Returns the first virtual disk found in the devices list.
+// TODO: Add support for multiple disks.
 func findDisk(devices object.VirtualDeviceList) (*types.VirtualDisk, error) {
 	var disks []*types.VirtualDisk
 	for _, device := range devices {
@@ -80,9 +81,12 @@ func findDisk(devices object.VirtualDeviceList) (*types.VirtualDisk, error) {
 
 	switch len(disks) {
 	case 0:
-		return nil, errors.New("VM has no disks")
+		// No disks found.
+		return nil, errors.New("error finding virtual disk")
 	case 1:
+		// Single disk found.
 		return disks[0], nil
 	}
-	return nil, errors.New("VM has multiple disks")
+	// More than one disk found.
+	return nil, errors.New("more than one virtual disk found, only a single disk is allowed")
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -704,6 +704,7 @@ func (vm *VirtualMachineDriver) Customize(spec types.CustomizationSpec) error {
 	return task.Wait(vm.driver.ctx)
 }
 
+// TODO: Add support to resize multiple disks.
 func (vm *VirtualMachineDriver) ResizeDisk(diskSize int64) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	devices, err := vm.vm.Device(vm.driver.ctx)
 	if err != nil {

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -4,6 +4,7 @@
 
 - `disk_size` (int64) - Specifies the size of the primary disk in MiB.
   Cannot be used with `linked_clone`.
+  -> **Note:** Only the primary disk size can be specified. Additional disks are not supported.
 
 - `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
   Cannot be used with `disk_size`.`


### PR DESCRIPTION
### Summary

- Clarifies that `disk_size` in the `vsphere-clone` builder only supports a single disk.
- Adds a `TODO` note for future enhancements to `findDisk` and `ResizeDisk` functions.

###Tessting

```sh
packer-plugin-vsphere1 on  docs/disk-size-usage via 🐹 v1.22.2 
➜ make generate
2024/04/18 21:14:24 Copying "docs" to ".docs/"
2024/04/18 21:14:24 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere1 on  docs/disk-size-usage via 🐹 v1.22.2 took 12.5s 
➜ make build   

packer-plugin-vsphere1 on  docs/disk-size-usage via 🐹 v1.22.2 took 5.2s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.908s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.869s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.798s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  1.466s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.109s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.307s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.693s

packer-plugin-vsphere1 on  docs/disk-size-usage via 🐹 v1.22.2 took 8.4s 
```

### Reference

Closes #303