### PR TITLE
fix: multiple network error msg

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -65,10 +65,22 @@ necessary for this build to succeed and can be found further down the page.
 - `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
   Cannot be used with `disk_size`.`
 
-- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
-  provide 'host' to allow Packer to search for an available network. For networks placed
-  within a network folder vCenter Server, provider the object path to the network.
-  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+- `network` (string) - Specifies the network to which the virtual machine will connect.
+  
+  For example:
+  
+  - Name: `<NetworkName>`
+  - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+  - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+  - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+  - Logical Switch UUID: `<uuid>`
+  - Segment ID: `/infra/segments/<SegmentID>`
+  
+  ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+  network or an ID must be provided.
+  
+  ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+  available network.
 
 - `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
   If set, the `network` must be also specified.

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -918,10 +918,22 @@ In HCL2:
 
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
-  provide 'host' to allow Packer to search for an available network. For networks placed
-  within a network folder vCenter Server, provider the object path to the network.
-  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+- `network` (string) - Specifies the network to which the virtual machine will connect.
+  
+  For example:
+  
+  - Name: `<NetworkName>`
+  - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+  - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+  - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+  - Logical Switch UUID: `<uuid>`
+  - Segment ID: `/infra/segments/<SegmentID>`
+  
+  ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+  network or an ID must be provided.
+  
+  ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+  available network.
 
 - `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
 

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -42,10 +42,22 @@ type CloneConfig struct {
 	// Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
 	// Cannot be used with `disk_size`.`
 	LinkedClone bool `mapstructure:"linked_clone"`
-	// Specifies the network to which the virtual machine will connect. If no network is specified,
-	// provide 'host' to allow Packer to search for an available network. For networks placed
-	// within a network folder vCenter Server, provider the object path to the network.
-	// For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+	// Specifies the network to which the virtual machine will connect.
+	//
+	// For example:
+	//
+	// - Name: `<NetworkName>`
+	// - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+	// - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+	// - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+	// - Logical Switch UUID: `<uuid>`
+	// - Segment ID: `/infra/segments/<SegmentID>`
+	//
+	// ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+	// network or an ID must be provided.
+	//
+	// ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+	// available network.
 	Network string `mapstructure:"network"`
 	// Specifies the network card MAC address. For example `00:50:56:00:00:00`.
 	// If set, the `network` must be also specified.

--- a/builder/vsphere/driver/network.go
+++ b/builder/vsphere/driver/network.go
@@ -76,5 +76,5 @@ type MultipleNetworkFoundError struct {
 }
 
 func (e *MultipleNetworkFoundError) Error() string {
-	return fmt.Sprintf("path '%s' resolves to multiple networks. %s", e.path, e.append)
+	return fmt.Sprintf("'%s' resolves to more than one network name; %s", e.path, e.append)
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -1051,7 +1051,7 @@ func findNetwork(network string, host string, d *VCenterDriver) (object.NetworkR
 			return nil, &MultipleNetworkFoundError{network, fmt.Sprintf("unable to match a network to the host %s", host)}
 		}
 
-		return nil, &MultipleNetworkFoundError{network, "please provide a host to match or the network full path"}
+		return nil, &MultipleNetworkFoundError{network, "specify the inventory path or id of the network"}
 	}
 
 	if host != "" {

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -53,10 +53,22 @@ import (
 //
 // ```
 type NIC struct {
-	// Specifies the network to which the virtual machine will connect. If no network is specified,
-	// provide 'host' to allow Packer to search for an available network. For networks placed
-	// within a network folder vCenter Server, provider the object path to the network.
-	// For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+	// Specifies the network to which the virtual machine will connect.
+	//
+	// For example:
+	//
+	// - Name: `<NetworkName>`
+	// - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+	// - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+	// - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+	// - Logical Switch UUID: `<uuid>`
+	// - Segment ID: `/infra/segments/<SegmentID>`
+	//
+	// ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+	// network or an ID must be provided.
+	//
+	// ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+	// available network.
 	Network string `mapstructure:"network"`
 	// Specifies the virtual machine network card type. For example `vmxnet3`.
 	NetworkCard string `mapstructure:"network_card" required:"true"`

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -8,10 +8,22 @@
 - `linked_clone` (bool) - Specifies that the virtual machine is created as a linked clone from the latest snapshot. Defaults to `false`.
   Cannot be used with `disk_size`.`
 
-- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
-  provide 'host' to allow Packer to search for an available network. For networks placed
-  within a network folder vCenter Server, provider the object path to the network.
-  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+- `network` (string) - Specifies the network to which the virtual machine will connect.
+  
+  For example:
+  
+  - Name: `<NetworkName>`
+  - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+  - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+  - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+  - Logical Switch UUID: `<uuid>`
+  - Segment ID: `/infra/segments/<SegmentID>`
+  
+  ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+  network or an ID must be provided.
+  
+  ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+  available network.
 
 - `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
   If set, the `network` must be also specified.

--- a/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
+++ b/docs-partials/builder/vsphere/iso/NIC-not-required.mdx
@@ -1,9 +1,21 @@
 <!-- Code generated from the comments of the NIC struct in builder/vsphere/iso/step_create.go; DO NOT EDIT MANUALLY -->
 
-- `network` (string) - Specifies the network to which the virtual machine will connect. If no network is specified,
-  provide 'host' to allow Packer to search for an available network. For networks placed
-  within a network folder vCenter Server, provider the object path to the network.
-  For example, `network = "/<DatacenterName>/<FolderName>/<NetworkName>"`.
+- `network` (string) - Specifies the network to which the virtual machine will connect.
+  
+  For example:
+  
+  - Name: `<NetworkName>`
+  - Inventory Path: `/<DatacenterName>/<FolderName>/<NetworkName>`
+  - Managed Object ID (Port Group): `Network:network-<xxxxx>`
+  - Managed Object ID (Distributed Port Group): `DistributedVirtualPortgroup::dvportgroup-<xxxxx>`
+  - Logical Switch UUID: `<uuid>`
+  - Segment ID: `/infra/segments/<SegmentID>`
+  
+  ~> **Note:** If more than one network resolves to the same name, either the inventory path to
+  network or an ID must be provided.
+  
+  ~> **Note:** If no network is specified, provide `host` to allow the plugin to search for an
+  available network.
 
 - `mac_address` (string) - Specifies the network card MAC address. For example `00:50:56:00:00:00`.
 


### PR DESCRIPTION
### Summary

- Updates the error messages when more than one network with the same name resolves to more than one network.
- Updated the documentation for `network` in `vsphere-iso` and `vsphere-clone` builders.

### Testing

```console
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ go fmt builder/vsphere/driver/vm.go
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ go fmt builder/vsphere/driver/network.go 
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ go fmt builder/vsphere/iso/step_create.go
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ go fmt builder/vsphere/clone/step_clone.go
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ make generate
2024/04/25 22:52:24 Copying "docs" to ".docs/"
2024/04/25 22:52:24 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ make build
➜  packer-plugin-vsphere git:(fix/multiple-network-error-msg) ✗ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.117s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       4.388s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       6.576s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  4.647s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   7.780s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       3.234s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      4.134s
```

### Reference

Ref: #237
