### PR TITLE
feat: set template name

### DIFF
--- a/.web-docs/components/post-processor/vsphere-template/README.md
+++ b/.web-docs/components/post-processor/vsphere-template/README.md
@@ -31,9 +31,12 @@ Optional:
 - `datacenter` (string) - Specifies the name of the datacenter to use.
   Required when the vCenter Server instance endpoint has more than one datacenter.
 
+- `template_name` (string) - Specifies the name of the template.
+  If not specified, the name of the virtual machine will be used.
+
 - `folder` (string) - Specifies the name of the virtual machine folder path where the template will be created.
 
-- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.\
+- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.
 
 - `snapshot_name` (string) - Specifies the name of the snapshot. Required when `snapshot_enable` is `true`.
 

--- a/docs-partials/post-processor/vsphere-template/Config-not-required.mdx
+++ b/docs-partials/post-processor/vsphere-template/Config-not-required.mdx
@@ -5,9 +5,12 @@
 - `datacenter` (string) - Specifies the name of the datacenter to use.
   Required when the vCenter Server instance endpoint has more than one datacenter.
 
+- `template_name` (string) - Specifies the name of the template.
+  If not specified, the name of the virtual machine will be used.
+
 - `folder` (string) - Specifies the name of the virtual machine folder path where the template will be created.
 
-- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.\
+- `snapshot_enable` (bool) - Specifies whether to create a snapshot before marking as a template. Defaults to `false`.
 
 - `snapshot_name` (string) - Specifies the name of the snapshot. Required when `snapshot_enable` is `true`.
 

--- a/post-processor/vsphere-template/post-processor.go
+++ b/post-processor/vsphere-template/post-processor.go
@@ -51,9 +51,12 @@ type Config struct {
 	// Specifies the name of the datacenter to use.
 	// Required when the vCenter Server instance endpoint has more than one datacenter.
 	Datacenter string `mapstructure:"datacenter"`
+	// Specifies the name of the template.
+	// If not specified, the name of the virtual machine will be used.
+	TemplateName string `mapstructure:"template_name"`
 	// Specifies the name of the virtual machine folder path where the template will be created.
 	Folder string `mapstructure:"folder"`
-	// Specifies whether to create a snapshot before marking as a template. Defaults to `false`.\
+	// Specifies whether to create a snapshot before marking as a template. Defaults to `false`.
 	SnapshotEnable bool `mapstructure:"snapshot_enable"`
 	// Specifies the name of the snapshot. Required when `snapshot_enable` is `true`.
 	SnapshotName string `mapstructure:"snapshot_name"`
@@ -122,7 +125,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	// Check if the artifact is supported by the post-processor.
 	if _, ok := builtins[artifact.BuilderId()]; !ok {
 		return nil, false, false, fmt.Errorf(
-			"error: unsupported artifact type %s. supported types: vmware-iso (ESXi) or vSphere post-processor", artifact.BuilderId())
+			"error: unsupported artifact type %s. supported types: vsphere-iso exported OVF or vSphere post-processor", artifact.BuilderId())
 	}
 
 	f := artifact.State(ArtifactConfFormat)

--- a/post-processor/vsphere-template/post-processor.hcl2spec.go
+++ b/post-processor/vsphere-template/post-processor.hcl2spec.go
@@ -23,6 +23,7 @@ type FlatConfig struct {
 	Password            *string           `mapstructure:"password" required:"true" cty:"password" hcl:"password"`
 	Insecure            *bool             `mapstructure:"insecure" cty:"insecure" hcl:"insecure"`
 	Datacenter          *string           `mapstructure:"datacenter" cty:"datacenter" hcl:"datacenter"`
+	TemplateName        *string           `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	Folder              *string           `mapstructure:"folder" cty:"folder" hcl:"folder"`
 	SnapshotEnable      *bool             `mapstructure:"snapshot_enable" cty:"snapshot_enable" hcl:"snapshot_enable"`
 	SnapshotName        *string           `mapstructure:"snapshot_name" cty:"snapshot_name" hcl:"snapshot_name"`
@@ -55,6 +56,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"password":                   &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"insecure":                   &hcldec.AttrSpec{Name: "insecure", Type: cty.Bool, Required: false},
 		"datacenter":                 &hcldec.AttrSpec{Name: "datacenter", Type: cty.String, Required: false},
+		"template_name":              &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
 		"folder":                     &hcldec.AttrSpec{Name: "folder", Type: cty.String, Required: false},
 		"snapshot_enable":            &hcldec.AttrSpec{Name: "snapshot_enable", Type: cty.Bool, Required: false},
 		"snapshot_name":              &hcldec.AttrSpec{Name: "snapshot_name", Type: cty.String, Required: false},


### PR DESCRIPTION
### Summary

Adds the ability to set the name of the of the template in the `vsphere-template` post-processor. If `template_name` is not provided, the name of the source virtual machine will be used.

### Testing

**General**: PASS ✅ 

```console
packer-plugin-vsphere1 on  feat/set-template-name [$!] via 🐹 v1.22.2 
➜ make generate
2024/04/27 21:02:44 Copying "docs" to ".docs/"
2024/04/27 21:02:44 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...


packer-plugin-vsphere1 on  feat/set-template-name [$!] via 🐹 v1.22.2 took 11.6s 
➜ make build


packer-plugin-vsphere1 on  feat/set-template-name [$!] via 🐹 v1.22.2 took 3.5s 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.526s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.218s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.048s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.238s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   4.171s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.378s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.764s
```

**End-to-End**: ✅ 

No value for `template_name`:

```hcl
build {
  sources = ["source.vsphere-iso.linux-photon"]

  post-processors {
    post-processor "vsphere-template"{
        host                = var.vsphere_endpoint
        username            = var.vsphere_username
        password            = var.vsphere_password
        insecure            = var.vsphere_insecure_connection
        datacenter          = var.vsphere_datacenter
        folder              = var.vsphere_folder
    }
  }
}
```

```console
==> vsphere-iso.linux-photon: Reattaching CD-ROM devices...
==> vsphere-iso.linux-photon: Adding SATA controller...
==> vsphere-iso.linux-photon: Adding CD-ROM devices...
==> vsphere-iso.linux-photon: Exporting to Open Virtualization Format (OVF)...
==> vsphere-iso.linux-photon: Downloading linux-photon-5.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Exporting linux-photon-5.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Writing OVF descriptor linux-photon-5.0-develop.ovf...
==> vsphere-iso.linux-photon: Creating SHA256 manifest linux-photon-5.0-develop.mf...
==> vsphere-iso.linux-photon: Completed export to Open Virtualization Format (OVF).
    vsphere-iso.linux-photon: Closing sessions ....
==> vsphere-iso.linux-photon: Running post-processor:  (type vsphere-template)
    vsphere-iso.linux-photon (vsphere-template): Pausing momentarily to prepare for the next step...
    vsphere-iso.linux-photon (vsphere-template): Choosing datacenter...
    vsphere-iso.linux-photon (vsphere-template): Creating or checking destination folder...
    vsphere-iso.linux-photon (vsphere-template): Registering virtual machine as a template: linux-photon-5.0-develop
Build 'vsphere-iso.linux-photon' finished after 2 minutes 36 seconds.

==> Wait completed after 2 minutes 36 seconds
==> Builds finished. The artifacts of successful builds are:
--> vsphere-iso.linux-photon: linux-photon-5.0-develop
```

Value set for `template_name` to `i-am-a-template`:

```hcl
build {
  sources = ["source.vsphere-iso.linux-photon"]

  post-processors {
    post-processor "vsphere-template"{
        template_name       = "i-am-a-template"        # <<<< --- template name
        host                = var.vsphere_endpoint
        username            = var.vsphere_username
        password            = var.vsphere_password
        insecure            = var.vsphere_insecure_connection
        datacenter          = var.vsphere_datacenter
        folder              = var.vsphere_folder
    }
  }
}
```

```console
==> vsphere-iso.linux-photon: Reattaching CD-ROM devices...
==> vsphere-iso.linux-photon: Adding SATA controller...
==> vsphere-iso.linux-photon: Adding CD-ROM devices...
==> vsphere-iso.linux-photon: Exporting to Open Virtualization Format (OVF)...
==> vsphere-iso.linux-photon: Downloading linux-photon-5.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Exporting linux-photon-5.0-develop-disk-0.vmdk...
==> vsphere-iso.linux-photon: Writing OVF descriptor linux-photon-5.0-develop.ovf...
==> vsphere-iso.linux-photon: Creating SHA256 manifest linux-photon-5.0-develop.mf...
==> vsphere-iso.linux-photon: Completed export to Open Virtualization Format (OVF).
    vsphere-iso.linux-photon: Closing sessions ....
==> vsphere-iso.linux-photon: Running post-processor:  (type vsphere-template)
    vsphere-iso.linux-photon (vsphere-template): Pausing momentarily to prepare for the next step...
    vsphere-iso.linux-photon (vsphere-template): Choosing datacenter...
    vsphere-iso.linux-photon (vsphere-template): Creating or checking destination folder...
    vsphere-iso.linux-photon (vsphere-template): Registering virtual machine as a template: i-am-a-template
    # ^^^ template name ^^^ 
Build 'vsphere-iso.linux-photon' finished after 2 minutes 35 seconds.

==> Wait completed after 2 minutes 35 seconds

==> Builds finished. The artifacts of successful builds are:
--> vsphere-iso.linux-photon: linux-photon-5.0-develop
```

> [!NOTE]
>
> When using the `template_name` option the virtual machine will be registered with the new name; however, please note that the directory path and files will still retain the prior name. Renaming the directory and files is beyond the scope of this pull request.

### Reference

Closes #397