### PR TITLE
chore(deps): bump github.com/vmware/govmomi from 0.36.2 to 0.37.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec5758f097
 	github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1
-	github.com/vmware/govmomi v0.36.2
+	github.com/vmware/govmomi v0.37.1
 	github.com/zclconf/go-cty v1.13.3
 	golang.org/x/mobile v0.0.0-20210901025245-1fde1d6c3ca1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -499,8 +499,8 @@ github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec57
 github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20230523235530-62ec5758f097/go.mod h1:S0HMBgdo3S/0a5hwq+Ya4XZI2aEDtGkSGeojU1cINOg=
 github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1 h1:krW4K3Vj8DkVqLMUOlW1OMLr1BY9Lg+PLZ7mAzlJz/A=
 github.com/vmware-tanzu/vm-operator/api v0.0.0-20230424164826-7ee71aebc7b1/go.mod h1:vauVboD3sQxP+pb28TnI9wfrj+0nH2zSEc9Q7AzWJ54=
-github.com/vmware/govmomi v0.36.2 h1:fFTicZmjwPCiBJGyKLZ5Ty9JbTgBPVSXJDv1Duw0r7c=
-github.com/vmware/govmomi v0.36.2/go.mod h1:mtGWtM+YhTADHlCgJBiskSRPOZRsN9MSjPzaZLte/oQ=
+github.com/vmware/govmomi v0.37.1 h1:SpI+Ofq+lC1zsLcJ9szLSb7fL4TypReVvUoWIgk2b6U=
+github.com/vmware/govmomi v0.37.1/go.mod h1:mtGWtM+YhTADHlCgJBiskSRPOZRsN9MSjPzaZLte/oQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
### Summary

- Updates `vmware/govmom` from 0.36.2 to 0.37.1.
- Due to a change in 0.37.0 of `vmware/govmom`, the `ReconfigureFail` needed to be removed. The CreateTask method in the TaskManager struct was updated. The new method now checks if the provided TaskTypeId is valid before proceeding. If it's not valid, it returns a SOAP fault with an InvalidArgument error.

### Testing

```console
➜  packer-plugin-vsphere git:(chore(deps)-govmomi) ✗ go get -u github.com/vmware/govmomi                                          
go: upgraded github.com/vmware/govmomi v0.36.2 => v0.37.1

➜  packer-plugin-vsphere git:(chore(deps)-govmomi) ✗ go mod tidy

➜  packer-plugin-vsphere git:(chore(deps)-govmomi) ✗ make generate
2024/05/01 13:44:33 Copying "docs" to ".docs/"
2024/05/01 13:44:33 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

➜  packer-plugin-vsphere git:(chore(deps)-govmomi) ✗ make build

➜  packer-plugin-vsphere git:(chore(deps)-govmomi) ✗ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.152s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.629s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       8.437s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.859s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   9.113s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       4.293s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      5.244s
```

### Reference

Ref: https://github.com/vmware/govmomi/commit/9c59e9c55da4d7bd7316a626404cc956da4f6c01#diff-b69f2c4e19456b811639643ed5dfe09357a280ac81b47249a14d6e625ef46317