### PR TITLE
fix: run once command list

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -458,7 +458,7 @@ Example of usage:
 
 <!-- Code generated from the comments of the WindowsOptions struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
 
-- `run_once_command_list` (\*[]string) - Specifies a list of commands to run at first logon after the guest operating system is customized.
+- `run_once_command_list` ([]string) - Specifies a list of commands to run at first logon after the guest operating system is customized.
 
 - `auto_logon` (\*bool) - Specifies whether the guest operating system automatically logs on as Administrator.
 

--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -82,7 +82,7 @@ type LinuxOptions struct {
 
 type WindowsOptions struct {
 	// Specifies a list of commands to run at first logon after the guest operating system is customized.
-	RunOnceCommandList *[]string `mapstructure:"run_once_command_list"`
+	RunOnceCommandList []string `mapstructure:"run_once_command_list"`
 	// Specifies whether the guest operating system automatically logs on as Administrator.
 	AutoLogon *bool `mapstructure:"auto_logon"`
 	// Specifies how many times the guest operating system should auto-logon the Administrator account when `auto_logon` is set to `true`. Default:s to `1`.
@@ -389,11 +389,14 @@ func (w *WindowsOptions) sysprep() *types.CustomizationSysprep {
 }
 
 func (w *WindowsOptions) guiRunOnce() *types.CustomizationGuiRunOnce {
-	if w.RunOnceCommandList == nil || len(*w.RunOnceCommandList) < 1 {
-		return nil
+	if w.RunOnceCommandList == nil || len(w.RunOnceCommandList) == 0 {
+		return &types.CustomizationGuiRunOnce{
+			CommandList: []string{""},
+		}
 	}
+
 	return &types.CustomizationGuiRunOnce{
-		CommandList: *w.RunOnceCommandList,
+		CommandList: w.RunOnceCommandList,
 	}
 }
 

--- a/docs-partials/builder/vsphere/clone/WindowsOptions-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/WindowsOptions-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the WindowsOptions struct in builder/vsphere/clone/step_customize.go; DO NOT EDIT MANUALLY -->
 
-- `run_once_command_list` (\*[]string) - Specifies a list of commands to run at first logon after the guest operating system is customized.
+- `run_once_command_list` ([]string) - Specifies a list of commands to run at first logon after the guest operating system is customized.
 
 - `auto_logon` (\*bool) - Specifies whether the guest operating system automatically logs on as Administrator.
 


### PR DESCRIPTION
### Summary

Updates `RunOnceCommandList` to a slice of strings `[]string` and updates `guiRunOnce()` to pass `""` if no commands are provided. This will ensure that the function addresses each case.

### Testing

Basic:

```console
➜  packer-plugin-vsphere git:(fix/run-once-command-list) make generate             
2024/05/09 22:24:23 Copying "docs" to ".docs/"
2024/05/09 22:24:23 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...
➜  packer-plugin-vsphere git:(fix/run-once-command-list) make build
➜  packer-plugin-vsphere git:(fix/run-once-command-list) make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.923s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.614s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.161s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  4.477s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   8.391s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       3.897s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      4.728s
➜  packer-plugin-vsphere git:(fix/run-once-command-list) 
```

Scenarios:

✅ `run_once_command_list` not provided.
✅ `run_once_command_list []` used.
✅ `run_once_command_list [""]` used.
✅ `run_once_command_list ["command1", "command2"]` used.

### Reference

Closes #419
