### PR TITLE
feat: add support for `http_interface` and `http_bind_address`

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -773,14 +773,6 @@ For more examples of various boot commands, see the sample projects from our
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
 
 
-<!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
-
-- `http_ip` (string) - The IP address to use for the HTTP server started to serve the `http_directory`.
-  If unset, Packer will automatically discover and assign an IP.
-
-<!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->
-
-
 ### HTTP Directory Configuration
 
 <!-- Code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; DO NOT EDIT MANUALLY -->
@@ -838,6 +830,27 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
 
+
+- `http_interface` (string) - The network interface (for example, `en0`, `ens192`, etc.) that the
+  HTTP server will use to serve the `http_directory`. The plugin will identify the IP address
+  associated with this network interface and bind to it.
+
+<!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
+
+- `http_ip` (string) - The IP address to use for the HTTP server to serve the `http_directory`.
+
+<!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->
+
+
+~> **Notes:**
+  - The options `http_bind_address` and `http_interface` are mutually exclusive.
+  - Both `http_bind_address` and `http_interface` have higher priority than `http_ip`.
+  - The `http_bind_address` is matched against the IP addresses of the host's network interfaces. If
+    no match is found, the plugin will terminate.
+  - Similarly, `http_interface` is compared with the host's network interfaces. If there's no
+    corresponding network interface, the plugin will also terminate.
+  - If neither `http_bind_address`, `http_interface`, and `http_ip` are provided, the plugin will
+    automatically find and use the IP address of the first non-loopback interface for `http_ip`.
 
 ### Floppy Configuration
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -77,6 +77,27 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 <!-- End of code generated from the comments of the HTTPConfig struct in multistep/commonsteps/http_config.go; -->
 
 
+- `http_interface` (string) - The network interface (for example, `en0`, `ens192`, etc.) that the
+  HTTP server will use to serve the `http_directory`. The plugin will identify the IP address
+  associated with this network interface and bind to it.
+
+<!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
+
+- `http_ip` (string) - The IP address to use for the HTTP server to serve the `http_directory`.
+
+<!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->
+
+
+~> **Notes:**
+  - The options `http_bind_address` and `http_interface` are mutually exclusive.
+  - Both `http_bind_address` and `http_interface` have higher priority than `http_ip`.
+  - The `http_bind_address` is matched against the IP addresses of the host's network interfaces. If
+    no match is found, the plugin will terminate.
+  - Similarly, `http_interface` is compared with the host's network interfaces. If there's no
+    corresponding network interface, the plugin will also terminate.
+  - If neither `http_bind_address`, `http_interface`, and `http_ip` are provided, the plugin will
+    automatically find and use the IP address of the first non-loopback interface for `http_ip`.
+
 ### Connection Configuration
 
 **Optional**:
@@ -1085,14 +1106,6 @@ JSON Example:
   is not specified, it is assumed the installer will start itself.
 
 <!-- End of code generated from the comments of the BootConfig struct in bootcommand/config.go; -->
-
-
-<!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
-
-- `http_ip` (string) - The IP address to use for the HTTP server started to serve the `http_directory`.
-  If unset, Packer will automatically discover and assign an IP.
-
-<!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->
 
 
 ### Wait Configuration

--- a/builder/vsphere/common/http_address.go
+++ b/builder/vsphere/common/http_address.go
@@ -1,0 +1,63 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"fmt"
+	"net"
+)
+
+// DefaultHttpBindAddress defines the default IP address for the HTTP server.
+const DefaultHttpBindAddress = "0.0.0.0"
+
+// ValidateHTTPAddress validates if the provided HTTP address is valid and
+// assigned to an interface.
+func ValidateHTTPAddress(httpAddress string) error {
+	if httpAddress == "" {
+		return fmt.Errorf("address cannot be empty")
+	}
+	if httpAddress == DefaultHttpBindAddress {
+		return fmt.Errorf("default bind address %s is not allowed", DefaultHttpBindAddress)
+	}
+	if net.ParseIP(httpAddress) == nil {
+		return fmt.Errorf("invalid IP address format: %s", httpAddress)
+	}
+	if !IsIPInInterfaces(httpAddress) {
+		return fmt.Errorf("%s is not assigned to an interface", httpAddress)
+	}
+	return nil
+}
+
+// IsIPInInterfaces checks if the provided IP address is assigned to any
+// interface in the system.
+func IsIPInInterfaces(ipStr string) bool {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return false
+	}
+
+	for _, i := range interfaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			parsedIP := net.ParseIP(ipStr)
+			if ip.Equal(parsedIP) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/builder/vsphere/common/step_http_ip_discover.go
+++ b/builder/vsphere/common/step_http_ip_discover.go
@@ -25,6 +25,7 @@ func (s *StepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) 
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
+
 	state.Put("http_ip", ip)
 
 	return multistep.ActionContinue

--- a/docs-partials/builder/vsphere/common/BootConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/BootConfig-not-required.mdx
@@ -1,6 +1,5 @@
 <!-- Code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; DO NOT EDIT MANUALLY -->
 
-- `http_ip` (string) - The IP address to use for the HTTP server started to serve the `http_directory`.
-  If unset, Packer will automatically discover and assign an IP.
+- `http_ip` (string) - The IP address to use for the HTTP server to serve the `http_directory`.
 
 <!-- End of code generated from the comments of the BootConfig struct in builder/vsphere/common/step_boot_command.go; -->

--- a/docs/builders/vsphere-clone.mdx
+++ b/docs/builders/vsphere-clone.mdx
@@ -204,8 +204,6 @@ JSON Example:
 
 @include 'packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx'
 
-@include 'builder/vsphere/common/BootConfig-not-required.mdx'
-
 ### HTTP Directory Configuration
 
 @include 'packer-plugin-sdk/multistep/commonsteps/HTTPConfig.mdx'
@@ -213,6 +211,22 @@ JSON Example:
 **Optional:**
 
 @include 'packer-plugin-sdk/multistep/commonsteps/HTTPConfig-not-required.mdx'
+
+- `http_interface` (string) - The network interface (for example, `en0`, `ens192`, etc.) that the
+  HTTP server will use to serve the `http_directory`. The plugin will identify the IP address
+  associated with this network interface and bind to it.
+
+@include 'builder/vsphere/common/BootConfig-not-required.mdx'
+
+~> **Notes:**
+  - The options `http_bind_address` and `http_interface` are mutually exclusive.
+  - Both `http_bind_address` and `http_interface` have higher priority than `http_ip`.
+  - The `http_bind_address` is matched against the IP addresses of the host's network interfaces. If
+    no match is found, the plugin will terminate.
+  - Similarly, `http_interface` is compared with the host's network interfaces. If there's no
+    corresponding network interface, the plugin will also terminate.
+  - If neither `http_bind_address`, `http_interface`, and `http_ip` are provided, the plugin will
+    automatically find and use the IP address of the first non-loopback interface for `http_ip`.
 
 ### Floppy Configuration
 

--- a/docs/builders/vsphere-iso.mdx
+++ b/docs/builders/vsphere-iso.mdx
@@ -39,6 +39,22 @@ their respective End of General Support dates. For detailed information, refer t
 
 @include 'packer-plugin-sdk/multistep/commonsteps/HTTPConfig-not-required.mdx'
 
+- `http_interface` (string) - The network interface (for example, `en0`, `ens192`, etc.) that the
+  HTTP server will use to serve the `http_directory`. The plugin will identify the IP address
+  associated with this network interface and bind to it.
+
+@include 'builder/vsphere/common/BootConfig-not-required.mdx'
+
+~> **Notes:**
+  - The options `http_bind_address` and `http_interface` are mutually exclusive.
+  - Both `http_bind_address` and `http_interface` have higher priority than `http_ip`.
+  - The `http_bind_address` is matched against the IP addresses of the host's network interfaces. If
+    no match is found, the plugin will terminate.
+  - Similarly, `http_interface` is compared with the host's network interfaces. If there's no
+    corresponding network interface, the plugin will also terminate.
+  - If neither `http_bind_address`, `http_interface`, and `http_ip` are provided, the plugin will
+    automatically find and use the IP address of the first non-loopback interface for `http_ip`.
+
 ### Connection Configuration
 
 **Optional**:
@@ -197,8 +213,6 @@ JSON Example:
 @include 'builder/vsphere/common/RunConfig-not-required.mdx'
 
 @include 'packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx'
-
-@include 'builder/vsphere/common/BootConfig-not-required.mdx'
 
 ### Wait Configuration
 


### PR DESCRIPTION
### Summary

Adds support for `http_interface` and `http_bind_interface` from the SDK.

> [!NOTE] 
> - The options `http_bind_address` and `http_interface` are mutually exclusive, per the SDK.
> - Both `http_bind_address` and `http_interface` have higher priority than `http_ip`.
> - The `http_bind_address` is matched against the IP addresses of the host's network interfaces. If no match is found, the plugin will terminate.
> - Similarly, `http_interface` is compared with the host's network interfaces. If there's no corresponding network interface, the plugin will also terminate.
> - If neither `http_bind_address`, `http_interface`, and `http_ip` are provided, the plugin will automatically find and use the IP address of the first non-loopback interface for `http_ip`.
> - If `http_ip` is provided and the IP address does not exist on any interface, the build will exit.

### Testing

**Basic**

```sh
packer-plugin-vsphere on  feat/http-interface [!] via 🐹 v1.22.6 
➜ go fmt ./...

packer-plugin-vsphere on  feat/http-interface [!] via 🐹 v1.22.6 
➜ make generate
2024/08/09 10:23:36 Copying "docs" to ".docs/"
2024/08/09 10:23:36 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on  feat/http-interface [!] via 🐹 v1.22.6 took 16.6s 
➜ make build

packer-plugin-vsphere on  feat/http-interface [!] via 🐹 v1.22.6 took 6.5s 
➜ make test

?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.664s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.108s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       6.676s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.554s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   5.676s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.746s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      3.037s

packer-plugin-vsphere took 1m 3.7s …
➜ 

packer-plugin-vsphere on  feat/http-interface [!] via 🐹 v1.22.6 
➜ make dev                       
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Personal/packer-plugin-vsphere/packer-plugin-vsphere to /Users/ryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64

```

✅  **PASS** : `http_ip` not provided. (Default)

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8091
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8091/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:30:06 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8950[0m
2024/08/09 10:30:06 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:30:06 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:30:07 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:30:09 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:30:09 Using IP address 192.168.86.58 from http_ip.
2024/08/09 10:30:09 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8950/.[0m
2024/08/09 10:30:09 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

✅  **PASS** : `http_ip` provided with a **valid** IP address.

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8457
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8457/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:31:21 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8457[0m
2024/08/09 10:31:21 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:31:21 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:31:21 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:31:23 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:31:23 Using IP address 192.168.86.58 from http_ip.
2024/08/09 10:31:23 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8457/.[0m
2024/08/09 10:31:23 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

✅  **PASS** : `http_ip` provided with an **invalid** IP address.

```sh
--> vsphere-iso.appliance: error using IP address 192.168.86.57: 192.168.86.57 is not assigned to an interface
```

```log
2024/08/09 10:32:14 ui error: [1;31m==> vsphere-iso.appliance: error using IP address 192.168.86.57: 192.168.86.57 is not assigned to an interface[0m
```

✅  **PASS** : `http_bind_address` provided with matching interface.

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8996
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8996/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:36:50 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8996[0m
2024/08/09 10:36:50 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:36:51 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:36:51 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:36:53 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:36:53 Using IP address 192.168.86.58 from http_bind_address.
2024/08/09 10:36:53 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8996/.[0m
2024/08/09 10:36:53 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

✅  **PASS** : `http_bind_address` provided with non-matching interface.

```sh
--> vsphere-iso.appliance: 192.168.86.57 is not assigned to an interface
```

```log
2024/08/09 10:35:33 ui error: [1;31m==> vsphere-iso.appliance: error validating IP address for HTTP server: 192.168.86.57 is not assigned to an interface[0m
```

✅  **PASS** : `http_bind_address` provided with `http_interface`.

```sh
Error: 1 error(s) occurred:

* either http_interface or http_bind_address can be specified
```

```log
2024/08/09 10:37:58 ui error: Error: 1 error(s) occurred:

* either http_interface or http_bind_address can be specified
```

✅  **PASS** : `http_bind_address` provided with `http_ip`. `http_bind_address` takes precedence.

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8665
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8665/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:39:17 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8665[0m
2024/08/09 10:39:17 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:39:17 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:39:18 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:39:20 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:39:20 Using IP address 192.168.86.58 from http_bind_address.
2024/08/09 10:39:20 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8665/.[0m
2024/08/09 10:39:20 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

✅  **PASS** : `http_interface` provided.

🟢 Interface `en0`:

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8259
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8259/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:40:41 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8259[0m
2024/08/09 10:40:41 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:40:41 Found available port: 8259 on IP: 0.0.0.0
2024/08/09 10:40:41 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:40:41 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:40:41 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:40:43 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:40:43 Using IP address 192.168.86.58 from http_interface en0.
2024/08/09 10:40:43 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8259/.[0m
2024/08/09 10:40:43 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

🟢 Interface `en1`:

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8186
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.87.57:8186/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:41:24 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8186[0m
2024/08/09 10:41:24 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:41:24 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:41:24 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:41:26 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.213.1:8186/.[0m
2024/08/09 10:41:26 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:41:26 Using IP address 192.168.87.57 from http_interface en1.
2024/08/09 10:41:26 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```

✅  **PASS** : `http_interface` provided with no matching interface.

```sh
--> vsphere-iso.appliance: error using interface foo: route ip+net: no such network interface
```

```log
2024/08/09 10:43:02 ui error: [1;31mBuild 'vsphere-iso.appliance' errored after 3 seconds 808 milliseconds: error using interface foo: route ip+net: no such network interface[0m
```

✅  **PASS** : `http_interface` provided with `http_ip`. `http_interface` takes precedence.

```sh
==> vsphere-iso.appliance: Starting HTTP server on port 8564
==> vsphere-iso.appliance: Setting boot order...
==> vsphere-iso.appliance: Powering on virtual machine...
==> vsphere-iso.appliance: Waiting 2s for boot...
==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8564/.
==> vsphere-iso.appliance: Typing boot command...
```

```log
2024/08/09 10:44:23 ui: [1;32m==> vsphere-iso.appliance: Starting HTTP server on port 8564[0m
2024/08/09 10:44:23 ui: [1;32m==> vsphere-iso.appliance: Setting boot order...[0m
2024/08/09 10:44:23 ui: [1;32m==> vsphere-iso.appliance: Powering on virtual machine...[0m
2024/08/09 10:44:23 ui: [1;32m==> vsphere-iso.appliance: Waiting 2s for boot...[0m
2024/08/09 10:44:25 packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_arm64 plugin: 2024/08/09 10:44:25 Using IP address 192.168.86.58 from http_interface en0.
2024/08/09 10:44:25 ui: [1;32m==> vsphere-iso.appliance: Serving HTTP requests at http://192.168.86.58:8564/.[0m
2024/08/09 10:44:25 ui: [1;32m==> vsphere-iso.appliance: Typing boot command...[0m
```