### PR TITLE
fix: don't assume driver isn't nil in StepConnect

### DIFF
--- a/builder/vsphere/common/step_connect.go
+++ b/builder/vsphere/common/step_connect.go
@@ -71,13 +71,13 @@ func (s *StepConnect) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packersdk.Ui)
 	d, ok := state.GetOk("driver")
 	if !ok {
-		log.Printf("[INFO] No driver in state - nothing to cleanup")
+		log.Printf("[INFO] No driver in state; nothing to cleanup.")
 		return
 	}
 
 	driver, ok := d.(driver.Driver)
 	if !ok {
-		log.Printf("[ERROR] The driver stored in state was not a driver.Driver (%s), something might be wrong", reflect.TypeOf(d))
+		log.Printf("[ERROR] The object stored in the state under 'driver' key is of type '%s', not 'driver.Driver'. This could indicate a problem with the state initialization or management.", reflect.TypeOf(d))
 		return
 	}
 


### PR DESCRIPTION
When attempting to cleanup the existing connections to the VSphere cluster, we get the driver from the state shared between all steps in order to run the commands necessary for that.

This can however fail, if the step couldn't succeed for any reason.

Then, if the connection fails and the driver isn't set in the state, when running Cleanup on the connect step, we get the driver from state and cast it to a driver.Driver.
This will make the plugin crash, and so we change how we proceed here, by getting the driver with a `GetOk`, exiting if it failed to be fetched from state, then casting the result if it was created in state.

This should prevent crashes like those.

Closes: #436 