### PR TITLE
chore: add issues `config.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+blank_issues_enabled: false
+contact_links:
+  - name: Community Discussions
+    url: https://discuss.hashicorp.com/tags/c/packer/23/vsphere
+    about: Need some help? Join the community discussions.
+  - name: Packer Plugin Documentation
+    url: https://developer.hashicorp.com/packer/integrations/hashicorp/vsphere
+    about: Having trouble with this Packer plugin? Check out the plugin documentation.
+  - name: Packer Documentation
+    url: https://developer.hashicorp.com/packer/
+    about: Having trouble with Packer? Check out the product documentation.


### PR DESCRIPTION
## Description

Adds the `config.yml` for issues to show contact links to the following alongside the options for bugs, enhancements, questions, etc.

The result is that it will look similar to what is used for `hashicorp/terraform-provider-vsphere`.

Example:

<img width="1326" alt="image" src="https://github.com/hashicorp/packer-plugin-vsphere/assets/7771363/02e0e2e4-5846-4fbb-90a6-7798e6fc9135">
