### PR TITLE
chore: update `golangci.yml`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - goimports
     - gosimple
@@ -39,7 +38,6 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - varcheck
   fast: true
 
 # options for analysis running


### PR DESCRIPTION
### Description

Removes the use of the following linters: `deadcode` and `varcheck`.

Both are deprecated as of `golangci-lint` v1.49.0. The owners seem to have abandoned these linters and they are replaced by `unused`.

Also corrected deprecated configuration options: `run.skip-files`, `output.format`, and `linters.errcheck.ignore`.

**Before**:

```sh
packer-plugin-vsphere on chore/update-golangci
➜ golangci-lint run
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`. 
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats` 
WARN [config_reader] The configuration option `linters.errcheck.ignore` is deprecated, please use `linters.errcheck.exclude-functions`. 
WARN The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
ERRO [linters_context] deadcode: This linter is fully inactivated: it will not produce any reports. 
ERRO [linters_context] varcheck: This linter is fully inactivated: it will not produce any reports. 
```

**After**:

```sh
packer-plugin-vsphere on chore/update-golangci
➜ golangci-lint run

packer-plugin-vsphere on chore/update-golangci
```