### PR TITLE
 fix: use mixed caps

### DIFF
--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -202,25 +202,25 @@ func (c *CustomizeConfig) Prepare() ([]string, []error) {
 		errs = append(errs, fmt.Errorf("one or more `network_interface` must be provided"))
 	}
 
-	options_number := 0
+	optionsNumber := 0
 	if c.LinuxOptions != nil {
-		options_number = options_number + 1
+		optionsNumber++
 	}
 	if c.WindowsOptions != nil {
-		options_number = options_number + 1
+		optionsNumber++
 	}
 	if c.WindowsSysPrepFile != "" {
 		warnings = append(warnings, windowsSysprepFileDeprecatedMessage)
-		options_number = options_number + 1
+		optionsNumber++
 	}
 	if c.WindowsSysPrepText != "" {
-		options_number = options_number + 1
+		optionsNumber++
 	}
 
-	if options_number > 1 {
+	if optionsNumber > 1 {
 		errs = append(errs, errCustomizeOptionMutualExclusive)
-	} else if options_number == 0 {
-		errs = append(errs, fmt.Errorf("one of `linux_options`, `windows_options`, `windows_sysprep_file` must be set"))
+	} else if optionsNumber == 0 {
+		errs = append(errs, fmt.Errorf("one of `linux_options`, `windows_options`, `windows_sysprep_file`, or 'windows_sysprep_text' must be set"))
 	}
 
 	if c.LinuxOptions != nil {

--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -96,9 +96,9 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 		s.Config.ISOPaths = append([]string{path.(string)}, s.Config.ISOPaths...)
 	}
 
-	// Add our custom CD, if it exists
-	if cd_path, _ := state.Get("cd_path").(string); cd_path != "" {
-		s.Config.ISOPaths = append(s.Config.ISOPaths, cd_path)
+	// Add our custom CD, if it exists.
+	if cdPath, _ := state.Get("cd_path").(string); cdPath != "" {
+		s.Config.ISOPaths = append(s.Config.ISOPaths, cdPath)
 	}
 
 	ui.Say("Mounting ISO images...")

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -67,7 +67,7 @@ type VirtualMachine interface {
 	AddCdrom(controllerType string, datastoreIsoPath string) error
 	CreateCdrom(c *types.VirtualController) (*types.VirtualCdrom, error)
 	RemoveCdroms() error
-	RemoveNCdroms(n_cdroms int) error
+	RemoveNCdroms(nCdroms int) error
 	EjectCdroms() error
 	AddSATAController() error
 	FindSATAController() (*types.VirtualAHCIController, error)

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -284,12 +284,12 @@ func (vm *VirtualMachineMock) RemoveCdroms() error {
 	return vm.RemoveCdromsErr
 }
 
-func (vm *VirtualMachineMock) RemoveNCdroms(n_cdroms int) error {
+func (vm *VirtualMachineMock) RemoveNCdroms(nCdroms int) error {
 	vm.RemoveNCdromsCalled = true
-	if n_cdroms == 0 {
+	if nCdroms == 0 {
 		return nil
 	}
-	vm.CdromDevicesList = vm.CdromDevicesList[:n_cdroms]
+	vm.CdromDevicesList = vm.CdromDevicesList[:nCdroms]
 	return vm.RemoveNCdromsErr
 }
 

--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -173,16 +173,16 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 func (p *PostProcessor) generateURI() (*url.URL, error) {
 	// use net/url lib to encode and escape url elements
-	ovftool_uri := fmt.Sprintf("vi://%s/%s/host/%s",
+	ovftoolURI := fmt.Sprintf("vi://%s/%s/host/%s",
 		p.config.Host,
 		p.config.Datacenter,
 		p.config.Cluster)
 
 	if p.config.ResourcePool != "" {
-		ovftool_uri += "/Resources/" + p.config.ResourcePool
+		ovftoolURI += "/Resources/" + p.config.ResourcePool
 	}
 
-	u, err := url.Parse(ovftool_uri)
+	u, err := url.Parse(ovftoolURI)
 	if err != nil {
 		return nil, fmt.Errorf("error generating uri for ovftool: %s", err)
 	}
@@ -223,16 +223,16 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		return nil, false, false, fmt.Errorf("error locating expected .vmx, .ovf, or .ova artifact")
 	}
 
-	ovftool_uri, err := p.generateURI()
+	ovftoolURI, err := p.generateURI()
 	if err != nil {
 		return nil, false, false, err
 	}
-	encodedPassword, isSet := getEncodedPassword(ovftool_uri)
+	encodedPassword, isSet := getEncodedPassword(ovftoolURI)
 	if isSet {
 		packersdk.LogSecretFilter.Set(encodedPassword)
 	}
 
-	args, err := p.BuildArgs(source, ovftool_uri.String())
+	args, err := p.BuildArgs(source, ovftoolURI.String())
 	if err != nil {
 		return nil, false, false, fmt.Errorf("error building ovftool arguments: %s", err)
 	}
@@ -313,7 +313,7 @@ func (p *PostProcessor) ValidateOvfTool(args []string, ofvtool string, ui packer
 	return nil
 }
 
-func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) {
+func (p *PostProcessor) BuildArgs(source, ovftoolURI string) ([]string, error) {
 	args := []string{
 		"--acceptAllEulas",
 		fmt.Sprintf(`--name=%s`, p.config.VMName),
@@ -349,7 +349,7 @@ func (p *PostProcessor) BuildArgs(source, ovftool_uri string) ([]string, error) 
 	}
 
 	args = append(args, source)
-	args = append(args, ovftool_uri)
+	args = append(args, ovftoolURI)
 
 	return args, nil
 }

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -31,7 +31,7 @@ func TestArgs(t *testing.T) {
 	p.config = getTestConfig()
 
 	source := "something.vmx"
-	ovftool_uri := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
+	ovftoolURI := fmt.Sprintf("vi://%s:%s@%s/%s/host/%s",
 		url.QueryEscape(p.config.Username),
 		url.QueryEscape(p.config.Password),
 		p.config.Host,
@@ -39,10 +39,10 @@ func TestArgs(t *testing.T) {
 		p.config.Cluster)
 
 	if p.config.ResourcePool != "" {
-		ovftool_uri += "/Resources/" + p.config.ResourcePool
+		ovftoolURI += "/Resources/" + p.config.ResourcePool
 	}
 
-	args, err := p.BuildArgs(source, ovftool_uri)
+	args, err := p.BuildArgs(source, ovftoolURI)
 	if err != nil {
 		t.Errorf("Error: %s", err)
 	}
@@ -59,9 +59,9 @@ func TestGenerateURI_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("had error: %s", err)
 	}
-	expected_uri := "vi://me:notpassword@myhost/mydc/host/mycluster"
-	if uri.String() != expected_uri {
-		t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expected_uri)
+	expectedURI := "vi://me:notpassword@myhost/mydc/host/mycluster"
+	if uri.String() != expectedURI {
+		t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expectedURI)
 	}
 }
 
@@ -97,10 +97,10 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 		if err != nil {
 			t.Fatalf("had error: %s", err)
 		}
-		expected_uri := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
+		expectedURI := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
 
-		if uri.String() != expected_uri {
-			t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expected_uri)
+		if uri.String() != expectedURI {
+			t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expectedURI)
 		}
 	}
 }
@@ -108,9 +108,9 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 func TestGetEncodedPassword(t *testing.T) {
 
 	// Password is encoded, and contains a colon
-	ovftool_uri := "vi://hostname/Datacenter/host/cluster"
+	ovftoolURI := "vi://hostname/Datacenter/host/cluster"
 
-	u, _ := url.Parse(ovftool_uri)
+	u, _ := url.Parse(ovftoolURI)
 	u.User = url.UserPassword("us:ername", "P@ssW:rd")
 
 	encoded, isSet := getEncodedPassword(u)


### PR DESCRIPTION
### Description

Updates variable names that do not use mixed caps to be more idiomatic Go code.

In Go, the convention is to use `MixedCaps` or `mixedCaps` rather than underscores to write multi-word names. This applies to both exported and unexported identifiers, such as constants, variables, types, fields, functions, etc.

This is not a functional change, but it makes your code more consistent with the style that Go developers expect.

### Testing

```sh
packer-plugin-vsphere on fix/use-mixed-caps
➜ make generate
2024/06/18 22:39:03 Copying "docs" to ".docs/"
2024/06/18 22:39:03 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on fix/use-mixed-caps
➜ make build

packer-plugin-vsphere on fix/use-mixed-caps
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.529s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.295s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       5.177s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.266s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   3.849s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.057s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.472s

packer-plugin-vsphere on  fix/use-mixed-caps via 🐹 v1.22.4 took 30.0s 
➜ 
```

### Reference

[Effective Go](https://golang.org/doc/effective_go#mixed-caps)