### PR TITLE
refactor: post-processor ui errors

### DIFF
--- a/post-processor/vsphere-template/step_choose_datacenter.go
+++ b/post-processor/vsphere-template/step_choose_datacenter.go
@@ -29,7 +29,7 @@ func (s *stepChooseDatacenter) Run(ctx context.Context, state multistep.StateBag
 	if err != nil {
 		err = fmt.Errorf("error finding datacenter %s: %s", s.Datacenter, err)
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 

--- a/post-processor/vsphere-template/step_create_folder.go
+++ b/post-processor/vsphere-template/step_create_folder.go
@@ -39,7 +39,7 @@ func (s *stepCreateFolder) Run(ctx context.Context, state multistep.StateBag) mu
 		ref, err = si.FindByInventoryPath(context.Background(), fullPath)
 		if err != nil {
 			state.Put("error", err)
-			ui.Error(err.Error())
+			ui.Errorf("%s", err)
 			return multistep.ActionHalt
 		}
 
@@ -50,7 +50,7 @@ func (s *stepCreateFolder) Run(ctx context.Context, state multistep.StateBag) mu
 			if fullPath == dcPath {
 				err = fmt.Errorf("error finding base path %s", base)
 				state.Put("error", err)
-				ui.Error(err.Error())
+				ui.Errorf("%s", err)
 				return multistep.ActionHalt
 			}
 
@@ -67,7 +67,7 @@ func (s *stepCreateFolder) Run(ctx context.Context, state multistep.StateBag) mu
 			root, err = root.CreateFolder(context.Background(), folders[i])
 			if err != nil {
 				state.Put("error", err)
-				ui.Error(err.Error())
+				ui.Errorf("%s", err)
 				return multistep.ActionHalt
 			}
 
@@ -78,7 +78,7 @@ func (s *stepCreateFolder) Run(ctx context.Context, state multistep.StateBag) mu
 	} else {
 		err = fmt.Errorf("error finding virtual machine folder at path %v", ref)
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 

--- a/post-processor/vsphere-template/step_create_snapshot.go
+++ b/post-processor/vsphere-template/step_create_snapshot.go
@@ -55,20 +55,20 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	vm, err := findRuntimeVM(cli, dcPath, s.VMName, s.RemoteFolder)
 	if err != nil {
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 
 	task, err := vm.CreateSnapshot(context.Background(), s.SnapshotName, s.SnapshotDescription, false, false)
 	if err != nil {
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 
 	if err = task.Wait(context.Background()); err != nil {
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -60,7 +60,7 @@ func (s *stepMarkAsTemplate) Run(ctx context.Context, state multistep.StateBag) 
 	vm, err := findRuntimeVM(cli, dcPath, s.VMName, s.RemoteFolder)
 	if err != nil {
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 


### PR DESCRIPTION
### Description

Refactors instances of `ui.Error(err.Error())` to use `ui.Errorf("%s", err)` in the post processors, as introduced in v0.5.3 of the `packer-plugin-sdk`.