### PR TITLE
chore: update use of `err.Error()`

### DIFF
--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -78,19 +78,19 @@ func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (str
 	log.Printf("Finding the equivalent datastore path for the Content Library ISO file path")
 	libItem, err := d.FindContentLibraryItem(lib.library.ID, itemName)
 	if err != nil {
-		log.Printf("[WARN] Couldn't find item %s: %s", itemName, err.Error())
+		log.Printf("[WARN] Content library item %s not found: %s", itemName, err)
 		return isoPath, err
 	}
 	datastoreName, err := d.GetDatastoreName(lib.library.Storage[0].DatastoreID)
 	if err != nil {
-		log.Printf("[WARN] Couldn't find datastore name for library %s", libraryName)
+		log.Printf("[WARN] Datastore not found for content library %s", libraryName)
 		return isoPath, err
 	}
 	libItemDir := fmt.Sprintf("[%s] contentlib-%s/%s", datastoreName, lib.library.ID, libItem.ID)
 
 	isoFilePath, err := d.GetDatastoreFilePath(lib.library.Storage[0].DatastoreID, libItemDir, isoFile)
 	if err != nil {
-		log.Printf("[WARN] Couldn't find datastore ID path for %s", isoFile)
+		log.Printf("[WARN] Datastore path not found for %s", isoFile)
 		return isoPath, err
 	}
 

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -398,7 +398,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 	if config.PrimaryDiskSize > 0 {
 		deviceResizeSpec, err := vm.ResizeDisk(config.PrimaryDiskSize)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resize primary disk: %s", err.Error())
+			return nil, fmt.Errorf("failed to resize primary disk: %s", err)
 		}
 		configSpec.DeviceChange = append(configSpec.DeviceChange, deviceResizeSpec...)
 	}
@@ -413,7 +413,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 	storageConfigSpec, err := config.StorageConfig.AddStorageDevices(existingDevices)
 	if err != nil {
-		return nil, fmt.Errorf("failed to add storage devices: %s", err.Error())
+		return nil, fmt.Errorf("failed to add storage devices: %s", err)
 	}
 	configSpec.DeviceChange = append(configSpec.DeviceChange, storageConfigSpec...)
 
@@ -535,7 +535,7 @@ func (vm *VirtualMachineDriver) AddPublicKeys(ctx context.Context, publicKeys st
 	newProps := map[string]string{"public-keys": publicKeys}
 	config, err := vm.updateVAppConfig(ctx, newProps)
 	if err != nil {
-		return fmt.Errorf("not possible to save temporary public key: %s", err.Error())
+		return fmt.Errorf("not possible to save temporary public key: %s", err)
 	}
 
 	confSpec := types.VirtualMachineConfigSpec{VAppConfig: config}
@@ -1056,7 +1056,7 @@ func findNetwork(network string, host string, d *VCenterDriver) (object.NetworkR
 		if host != "" {
 			h, err := d.FindHost(host)
 			if err != nil {
-				return nil, &MultipleNetworkFoundError{network, fmt.Sprintf("unable to match a network to the host %s: %s", host, err.Error())}
+				return nil, &MultipleNetworkFoundError{network, fmt.Sprintf("unable to match a network to the host %s: %s", host, err)}
 			}
 			for _, n := range networks {
 				info, err := n.Info("host")
@@ -1407,7 +1407,7 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 	for _, storage := range l.library.Storage {
 		name, err := vm.driver.GetDatastoreName(storage.DatastoreID)
 		if err != nil {
-			log.Printf("Failed to get Content Library datastore name: %s", err.Error())
+			log.Printf("Failed to get Content Library datastore name: %s", err)
 			continue
 		}
 		datastores = append(datastores, name)
@@ -1420,7 +1420,7 @@ func (vm *VirtualMachineDriver) logout() {
 		return
 	}
 	if err := vm.driver.restClient.Logout(vm.driver.ctx); err != nil {
-		log.Printf("cannot logout: %s ", err.Error())
+		log.Printf("cannot logout: %s ", err)
 	}
 }
 


### PR DESCRIPTION
### Description

Simplifies `err.Error()` to just `err`.