### PR TITLE
chore: update supervisor plugin example jenkins template

### DIFF
--- a/examples/builder/vsphere-supervisor/jenkins-template.pkr.hcl
+++ b/examples/builder/vsphere-supervisor/jenkins-template.pkr.hcl
@@ -119,6 +119,9 @@ EOF
 
   provisioner "shell" {
     inline = [
+      # Display the commands being executed.
+      "set -x",
+
       # Download Jenkins repository key and add it to the trusted keyrings.
       "curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo gpg --dearmor -o /usr/share/keyrings/jenkins-keyring.gpg",
       "echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.gpg] https://pkg.jenkins.io/debian binary/ | sudo tee /etc/apt/sources.list.d/jenkins.list",
@@ -129,7 +132,7 @@ EOF
 
       # Sometimes apt-get uses IPv6 and causes failure, force to use IPv4 address.
       "sudo apt-get -qq -o Acquire::ForceIPv4=true update",
-      "sudo apt-get -qq -o Acquire::ForceIPv4=true install -f -y ca-certificates openjdk-11-jre-headless",
+      "sudo apt-get -qq -o Acquire::ForceIPv4=true install -f -y ca-certificates openjdk-21-jre-headless",
       "sudo apt-get -qq -o Acquire::ForceIPv4=true install -f -y jenkins",
       # Restart Jenkins service, in case it didn't initialize successfully.
       "sudo systemctl restart jenkins",


### PR DESCRIPTION
### Description

This PR updates the Supervisor builder example template to install a newer JDK version.
The current JDK version (11) is no longer supported by the latest Jenkins release (2.426.1):
```console
packer@jenkins-test:~$ jenkins
Running with Java 11 from /usr/lib/jvm/java-11-openjdk-amd64, which is older than the minimum required version (Java 17).
Supported Java versions are: [17, 21]
```

### Testing

The Packer command ran successfully using the updated template file:

```console
$ packer build jenkins-template.pkr.hcl
vsphere-supervisor.vm: output will be in this color.

==> vsphere-supervisor.vm: Creating temporary RSA SSH key for instance...
    vsphere-supervisor.vm: Connecting to Supervisor cluster...
    ...
    vsphere-supervisor.vm: Source VM is now ready in Supervisor cluster
    ...
==> vsphere-supervisor.vm: Provisioning with shell script: /var/folders/nf/cndlm4ts2bd9jz3dd667jfb80000gr/T/packer-shell3086856209
    ...
==> vsphere-supervisor.vm: + sudo apt-get -qq -o Acquire::ForceIPv4=true install -f -y ca-certificates openjdk-21-jre-headless
    ...
    vsphere-supervisor.vm: Completed sample-job #1 : SUCCESS
    vsphere-supervisor.vm: Skip cleaning up the VirtualMachinePublishRequest object as specified in config
    vsphere-supervisor.vm: Skip cleaning up the source objects as specified in config
    vsphere-supervisor.vm: Build 'vsphere-supervisor' finished successfully.
Build 'vsphere-supervisor.vm' finished after 3 minutes 17 seconds.

==> Wait completed after 3 minutes 17 seconds

==> Builds finished but no artifacts were created.
```

### Reference
https://www.jenkins.io/doc/book/platform-information/support-policy-java/#java-support-policy
