### PR TITLE
refactor(tests): standardize messages

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1331,7 +1331,7 @@ boot time.
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  with SFTP instead `ssh_file_transfer_method = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1331,7 +1331,7 @@ boot time.
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_method = "sftp"`.
+  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1515,7 +1515,7 @@ JSON Example:
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  with SFTP instead `ssh_file_transfer_method = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1515,7 +1515,7 @@ JSON Example:
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_method = "sftp"`.
+  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/.web-docs/components/builder/vsphere-supervisor/README.md
+++ b/.web-docs/components/builder/vsphere-supervisor/README.md
@@ -219,7 +219,7 @@ items are listed below as well as the _optional_ configurations.
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
+  with SFTP instead `ssh_file_transfer_method = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/.web-docs/components/builder/vsphere-supervisor/README.md
+++ b/.web-docs/components/builder/vsphere-supervisor/README.md
@@ -219,7 +219,7 @@ items are listed below as well as the _optional_ configurations.
   **NOTE**: Guests using Windows with Win32-OpenSSH v9.1.0.0p1-Beta, scp
   (the default protocol for copying data) returns a a non-zero error code since the MOTW
   cannot be set, which cause any file transfer to fail. As a workaround you can override the transfer protocol
-  with SFTP instead `ssh_file_transfer_method = "sftp"`.
+  with SFTP instead `ssh_file_transfer_protocol = "sftp"`.
 
 - `ssh_proxy_host` (string) - A SOCKS proxy host to use for SSH connection
 

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -32,7 +32,7 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	warns, err := conf.Prepare(raw)
 	testConfigOk(t, warns, err)
 	if conf.ShutdownConfig.Timeout != 3*time.Minute {
-		t.Fatalf("shutdown_timeout should be equal 3 minutes, got %v", conf.ShutdownConfig.Timeout)
+		t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.ShutdownConfig.Timeout)
 	}
 }
 
@@ -47,31 +47,31 @@ func TestCloneConfig_RAMReservation(t *testing.T) {
 
 func minimalConfig() map[string]interface{} {
 	return map[string]interface{}{
-		"vcenter_server": "vcenter.domain.local",
-		"username":       "root",
-		"password":       "vmware",
+		"vcenter_server": "vcenter.example.com",
+		"username":       "administrator@vsphere.local",
+		"password":       "VMw@re1!",
 		"template":       "ubuntu",
-		"vm_name":        "vm1",
-		"host":           "esxi1.domain.local",
+		"vm_name":        "vm-01",
+		"host":           "esxi-01.example.com",
 		"ssh_username":   "root",
-		"ssh_password":   "secret",
+		"ssh_password":   "VMw@re1!",
 	}
 }
 
 func testConfigOk(t *testing.T, warns []string, err error) {
 	if len(warns) > 0 {
-		t.Errorf("Should be no warnings: %#v", warns)
+		t.Errorf("unexpected warning: %#v", warns)
 	}
 	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
+		t.Errorf("unexpected error: %s", err)
 	}
 }
 
 func testConfigErr(t *testing.T, context string, warns []string, err error) {
 	if len(warns) > 0 {
-		t.Errorf("Should be no warnings: %#v", warns)
+		t.Errorf("unexpected warning: %#v", warns)
 	}
 	if err == nil {
-		t.Error("An error is not raised for", context)
+		t.Errorf("unexpected result: expected '%s', but returned 'nil'", context)
 	}
 }

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -127,14 +127,14 @@ func TestCreateConfig_Prepare(t *testing.T) {
 			errs := c.config.Prepare()
 			if c.fail {
 				if len(errs) == 0 {
-					t.Fatalf("Config prepare should fail")
+					t.Fatal("unexpected success: expected failure")
 				}
 				if errs[0].Error() != c.expectedErrMsg {
-					t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
 				}
 			} else {
 				if len(errs) != 0 {
-					t.Fatalf("Config prepare should not fail: %s", errs[0])
+					t.Fatalf("unexpected failure: expected success, but failed: %s", errs[0])
 				}
 			}
 		})
@@ -156,36 +156,36 @@ func TestStepCreateVM_Run(t *testing.T) {
 	driverMock.VM = vmMock
 
 	if action := step.Run(context.TODO(), state); action == multistep.ActionHalt {
-		t.Fatalf("Should not halt.")
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	// Pre clean VM
 	if !driverMock.PreCleanVMCalled {
-		t.Fatalf("driver.PreCleanVM should be called.")
+		t.Fatalf("unexpected result: expected '%s' to be called", "PreCleanVM")
 	}
 	if driverMock.PreCleanForce != step.Force {
-		t.Fatalf("Force PreCleanVM should be %t but was %t.", step.Force, driverMock.PreCleanForce)
+		t.Fatalf("unexpected result: expected '%t', but returned '%t'", step.Force, driverMock.PreCleanForce)
 	}
 	if driverMock.PreCleanVMPath != vmPath {
-		t.Fatalf("VM path expected to be %s but was %s", vmPath, driverMock.PreCleanVMPath)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", vmPath, driverMock.PreCleanVMPath)
 	}
 
 	if !driverMock.FindVMCalled {
-		t.Fatalf("driver.FindVM should be called.")
+		t.Fatalf("unexpected result: expected '%s' to be called", "FindVM")
 	}
 	if !vmMock.CloneCalled {
-		t.Fatalf("vm.Clone should be called.")
+		t.Fatalf("unexpected result: expected '%s' to be called", "Clone")
 	}
 
 	if diff := cmp.Diff(vmMock.CloneConfig, driverCreateConfig(step.Config, step.Location)); diff != "" {
-		t.Fatalf("wrong driver.CreateConfig: %s", diff)
+		t.Fatalf("unexpected result: '%s'", diff)
 	}
 	vm, ok := state.GetOk("vm")
 	if !ok {
-		t.Fatal("state must contain the VM")
+		t.Fatalf("unexpected state: '%s' not found", "vm")
 	}
 	if vm != driverMock.VM {
-		t.Fatalf("state doesn't contain the created VM.")
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", driverMock.VM, vm)
 	}
 }
 

--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -28,12 +28,12 @@ func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
 	// Make sure we only received on error
 	expectedErrorLength := 1
 	if len(errors) != expectedErrorLength {
-		t.Fatalf("expected errors of length %d but got %d", expectedErrorLength, len(errors))
+		t.Fatalf("unexpected result: expected '%d', but returned: '%d'", expectedErrorLength, len(errors))
 	}
 
 	// Validate the error messages are what we expect.
-	if errors[0].Error() != expectedError.Error() {
-		t.Fatalf("expected error message %s, but got error message %s", expectedError, errors[0].Error())
+	if errors[0] != expectedError {
+		t.Fatalf("unexpected error: expected '%s', but returned: '%s'", expectedError, errors[0])
 	}
 }
 
@@ -54,7 +54,7 @@ func TestWindowsSysprepFilePrintsWarning(t *testing.T) {
 
 	// Fail if there were errors
 	if len(errors) > 0 {
-		t.Fatalf("there were errors when running prepare")
+		t.Fatalf("unexpected error: %s", errors)
 	}
 
 	// Search warnings array for the warning message
@@ -68,7 +68,7 @@ func TestWindowsSysprepFilePrintsWarning(t *testing.T) {
 
 	// If we didn't find the expect warning message fail.
 	if found == false {
-		t.Fatalf("didn't find %s in warnings array", expectedWarning)
+		t.Fatalf("unexpected result: expected '%s' to be in warnings", expectedWarning)
 	}
 
 }
@@ -91,17 +91,17 @@ func TestWindowsSysprepTextSetsContent(t *testing.T) {
 	// Get the identity settings for the customize step
 	baseCustomizationSettings, err := stepCustomize.identitySettings()
 	if err != nil {
-		t.Fatalf("identity settings had unexpected errors. %v", err)
+		t.Fatalf("unexpected error: '%v'", err)
 	}
 
 	// Cast the result to the vsphere govmomi type
 	sysprepText, ok := baseCustomizationSettings.(*types.CustomizationSysprepText)
 	if !ok {
-		t.Fatalf("identity settings did not return CustomizationSysprepText type")
+		t.Fatalf("unexpected result: expected '%s', but returned %s", text, sysprepText)
 	}
 
 	// Make sure the sysprep text value is equal to what was passed in via the config.
 	if sysprepText.Value != text {
-		t.Fatalf("expected the customization spec to contain %s but was %s", text, sysprepText.Value)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", text, sysprepText.Value)
 	}
 }

--- a/builder/vsphere/common/artifact_test.go
+++ b/builder/vsphere/common/artifact_test.go
@@ -17,14 +17,14 @@ import (
 func TestArtifactHCPPackerMetadata(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
 	vm, vmSim := sim.ChooseSimulatorPreCreatedVM()
 	confSpec := types.VirtualMachineConfigSpec{Annotation: "simple vm description"}
 	if err := vm.Reconfigure(confSpec); err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	datastore := simulator.Map.Get(vmSim.Datastore[0]).(*simulator.Datastore)
 	host := simulator.Map.Get(*vmSim.Runtime.Host).(*simulator.HostSystem)
@@ -59,18 +59,18 @@ func TestArtifactHCPPackerMetadata(t *testing.T) {
 
 	metadata, ok := artifact.State(registryimage.ArtifactStateURI).(*registryimage.Image)
 	if !ok {
-		t.Fatalf("expecting a metadata of time registryimage.Image")
+		t.Fatalf("unexpected result: expected '%t', but returned '%t'", true, ok)
 	}
 	if metadata.ImageID != vmSim.Name {
-		t.Fatalf("unexpected image id: %s", metadata.ImageID)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", vmSim.Name, metadata.ImageID)
 	}
 	if metadata.ProviderName != "vsphere" {
-		t.Fatalf("unexpected provider name: %s", metadata.ProviderName)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", "vsphere", metadata.ProviderName)
 	}
 	if metadata.ProviderRegion != vm.Datacenter().Name() {
-		t.Fatalf("unexpected provider region: %s", metadata.ProviderRegion)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", vm.Datacenter().Name(), metadata.ProviderRegion)
 	}
 	if diff := cmp.Diff(expectedLabels, metadata.Labels); diff != "" {
-		t.Fatalf("wrong labels: %s", diff)
+		t.Fatalf("unexpected result: '%s'", diff)
 	}
 }

--- a/builder/vsphere/common/cleanup_vm.go
+++ b/builder/vsphere/common/cleanup_vm.go
@@ -32,6 +32,6 @@ func CleanupVM(state multistep.StateBag) {
 	ui.Say("Destroying VM...")
 	err := vm.Destroy()
 	if err != nil {
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 	}
 }

--- a/builder/vsphere/common/cleanup_vm_test.go
+++ b/builder/vsphere/common/cleanup_vm_test.go
@@ -58,7 +58,7 @@ func Test_CleanupVM(t *testing.T) {
 		}
 		CleanupVM(state)
 		if mockVM.DestroyCalled != tc.ExpectDestroy {
-			t.Fatalf("Problem with cleanup: %s", tc.Reason)
+			t.Fatalf("unexpected result: expected '%s' to be called", "Destroy")
 		}
 	}
 

--- a/builder/vsphere/common/hcp_metadata_test.go
+++ b/builder/vsphere/common/hcp_metadata_test.go
@@ -17,7 +17,7 @@ import (
 func TestGetVMMetadata(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -27,7 +27,7 @@ func TestGetVMMetadata(t *testing.T) {
 	vm, vmSim := sim.ChooseSimulatorPreCreatedVM()
 	confSpec := types.VirtualMachineConfigSpec{Annotation: "simple vm description"}
 	if err := vm.Reconfigure(confSpec); err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	datastore := simulator.Map.Get(vmSim.Datastore[0]).(*simulator.Datastore)
 
@@ -44,6 +44,6 @@ func TestGetVMMetadata(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(expectedLabels, metadata); diff != "" {
-		t.Fatalf("wrong labels: %s", diff)
+		t.Fatalf("unexpected result: '%s'", diff)
 	}
 }

--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -58,14 +58,14 @@ func TestCDRomConfig_Prepare(t *testing.T) {
 		errs := c.config.Prepare(c.keepConfig)
 		if c.fail {
 			if len(errs) == 0 {
-				t.Fatalf("Config prepare should fail")
+				t.Fatal("unexpected success: expected failure")
 			}
 			if errs[0].Error() != c.expectedErrMsg {
-				t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
+				t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
 			}
 		} else {
 			if len(errs) != 0 {
-				t.Fatalf("Config prepare should not fail")
+				t.Fatalf("unexpected failure: expected success, but failed: %s", errs[0])
 			}
 		}
 	}
@@ -209,22 +209,22 @@ func TestStepAddCDRom_Run(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			c.state.Put("vm", c.vmMock)
 			if action := c.step.Run(context.TODO(), c.state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := c.state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected result: %s", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_add_flag_test.go
+++ b/builder/vsphere/common/step_add_flag_test.go
@@ -85,14 +85,14 @@ func TestFlagConfig_Prepare(t *testing.T) {
 		errs := c.config.Prepare(c.hardwareConfig)
 		if c.fail {
 			if len(errs) == 0 {
-				t.Fatalf("Config prepare should fail")
+				t.Fatal("unexpected success: expected failure")
 			}
 			if errs[0].Error() != c.expectedErrMsg {
-				t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
+				t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
 			}
 		} else {
 			if len(errs) != 0 {
-				t.Fatalf("Config prepare should not fail")
+				t.Fatalf("unexpected failure: expected success, but failed: %s", errs[0])
 			}
 		}
 	}
@@ -157,22 +157,22 @@ func TestStepAddFlag_Run(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			c.state.Put("vm", c.vmMock)
 			if action := c.step.Run(context.TODO(), c.state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := c.state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_add_floppy_test.go
+++ b/builder/vsphere/common/step_add_floppy_test.go
@@ -256,39 +256,39 @@ func TestStepAddFloppy_Run(t *testing.T) {
 			}
 
 			if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if c.driverMock.DatastoreMock.UploadFileDst != "" {
 				pattern := regexp.MustCompile(`vm/dir/packer-(\d{10}|tmp-created-floppy)\.flp`)
 				if !pattern.MatchString(c.driverMock.DatastoreMock.UploadFileDst) {
-					t.Fatalf("unexpected UploadFileDst %v", c.driverMock.DatastoreMock.UploadFileDst)
+					t.Fatalf("unexpected result: expected '%s' to match pattern '%s'", c.driverMock.DatastoreMock.UploadFileDst, pattern)
 				}
 				c.driverMock.DatastoreMock.UploadFileDst = "vm/dir/packer-*.flp"
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 			c.expectedDriverMock.DatastoreMock = c.expectedDsMock
 			if diff := cmp.Diff(c.driverMock, c.expectedDriverMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Driver calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "Driver", diff)
 			}
 			if diff := cmp.Diff(c.dsMock, c.expectedDsMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Datastore calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "Datastore", diff)
 			}
 		})
 	}
@@ -438,22 +438,22 @@ func TestStepAddFloppy_Cleanup(t *testing.T) {
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			c.expectedDriverMock.DatastoreMock = c.expectedDsMock
 			if diff := cmp.Diff(c.driverMock, c.expectedDriverMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Driver calls: %s", diff)
+				t.Fatalf("unexpected result: %s", diff)
 			}
 			if diff := cmp.Diff(c.dsMock, c.expectedDsMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Datastore calls: %s", diff)
+				t.Fatalf("unexpected result: %s", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_boot_command.go
+++ b/builder/vsphere/common/step_boot_command.go
@@ -126,7 +126,7 @@ func (s *StepBootCommand) Run(ctx context.Context, state multistep.StateBag) mul
 	if err != nil {
 		err := fmt.Errorf("error preparing boot command: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 
@@ -134,14 +134,14 @@ func (s *StepBootCommand) Run(ctx context.Context, state multistep.StateBag) mul
 	if err != nil {
 		err := fmt.Errorf("error generating boot command: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 
 	if err := seq.Do(ctx, d); err != nil {
 		err := fmt.Errorf("error running boot command: %s", err)
 		state.Put("error", err)
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 		return multistep.ActionHalt
 	}
 

--- a/builder/vsphere/common/step_download_test.go
+++ b/builder/vsphere/common/step_download_test.go
@@ -75,13 +75,13 @@ func TestStepDownload_Run(t *testing.T) {
 		}
 		stepAction := step.Run(context.TODO(), state)
 		if stepAction != tc.expectedAction {
-			t.Fatalf("%s: Recieved wrong step action; step exists, should return early.", tc.name)
+			t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", tc.expectedAction, stepAction)
 		}
 		if tc.expectInternalStepCalled != internalStep.RunCalled {
 			if tc.expectInternalStepCalled {
-				t.Fatalf("%s: Expected internal download step to be called", tc.name)
+				t.Fatalf("unexpected result: expected '%s' to be called", tc.name)
 			} else {
-				t.Fatalf("%s: Expected internal download step not to be called", tc.name)
+				t.Fatalf("unexpected result: expected '%s' not to be called", tc.name)
 			}
 		}
 	}

--- a/builder/vsphere/common/step_hardware_test.go
+++ b/builder/vsphere/common/step_hardware_test.go
@@ -118,14 +118,14 @@ func TestHardwareConfig_Prepare(t *testing.T) {
 			errs := c.config.Prepare()
 			if c.fail {
 				if len(errs) == 0 {
-					t.Fatalf("Config preprare should fail")
+					t.Fatal("unexpected success: expected failure")
 				}
 				if errs[0].Error() != c.expectedErrMsg {
-					t.Fatalf("Expected error message: %s but was '%s'", c.expectedErrMsg, errs[0].Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
 				}
 			} else {
 				if len(errs) != 0 {
-					t.Fatalf("Config preprare should not fail")
+					t.Fatalf("unexpected failure: expected success, but failed: %s", errs[0])
 				}
 			}
 		})
@@ -174,23 +174,23 @@ func TestStepConfigureHardware_Run(t *testing.T) {
 
 			action := c.step.Run(context.TODO(), state)
 			if action != c.action {
-				t.Fatalf("expected action '%v' but actual action was '%v'", c.action, action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.action, action)
 			}
 			if vmMock.ConfigureCalled != c.configureCalled {
-				t.Fatalf("expecting vm.Configure called to %t but was %t", c.configureCalled, vmMock.ConfigureCalled)
+				t.Fatalf("unexpected result: expected '%t', but returned '%t'", c.configureCalled, vmMock.ConfigureCalled)
 			}
 			if diff := cmp.Diff(vmMock.ConfigureHardwareConfig, c.hardwareConfig); diff != "" {
-				t.Fatalf("wrong driver.HardwareConfig: %s", diff)
+				t.Fatalf("unexpected result: '%s'", diff)
 			}
 
 			err, ok := state.GetOk("error")
 			containsError := c.configureError != nil
 			if containsError != ok {
-				t.Fatalf("Contain error - expecting %t but was %t", containsError, ok)
+				t.Fatalf("unexpected result: expected '%t', but returned '%t'", ok, containsError)
 			}
 			if containsError {
 				if !strings.Contains(err.(error).Error(), c.configureError.Error()) {
-					t.Fatalf("Destroy should fail with error message '%s' but failed with '%s'", c.configureError.Error(), err.(error).Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.configureError.Error(), err.(error).Error())
 				}
 			}
 		})

--- a/builder/vsphere/common/step_http_ip_discover_test.go
+++ b/builder/vsphere/common/step_http_ip_discover_test.go
@@ -17,14 +17,14 @@ func TestStepHTTPIPDiscover_Run(t *testing.T) {
 
 	// without setting HTTPIP
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("unexpected error: expected no error")
 	}
 	_, ok := state.GetOk("http_ip")
 	if !ok {
-		t.Fatal("should have http_ip")
+		t.Fatalf("unexpected state: '%s' not found", "http_ip")
 	}
 
 	// setting HTTPIP
@@ -33,36 +33,36 @@ func TestStepHTTPIPDiscover_Run(t *testing.T) {
 		HTTPIP: ip,
 	}
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("unexpected error: expected no error")
 	}
 	httpIp, ok := state.GetOk("http_ip")
 	if !ok {
-		t.Fatal("should have http_ip")
+		t.Fatalf("unexpected state: '%s' not found", "http_ip")
 	}
 	if httpIp != ip {
-		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, ip)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", ip, httpIp)
 	}
 
 	_, ipNet, err := net.ParseCIDR("0.0.0.0/0")
 	if err != nil {
-		t.Fatal("error getting ipNet", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	step = new(StepHTTPIPDiscover)
 	step.Network = ipNet
 
 	// without setting HTTPIP with Network
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("unexpected error: expected no error")
 	}
 	_, ok = state.GetOk("http_ip")
 	if !ok {
-		t.Fatal("should have http_ip")
+		t.Fatalf("unexpected state: '%s' not found", "http_ip")
 	}
 
 	// setting HTTPIP with Network
@@ -71,16 +71,16 @@ func TestStepHTTPIPDiscover_Run(t *testing.T) {
 		Network: ipNet,
 	}
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
+		t.Fatal("unexpected error: expected no error")
 	}
 	httpIp, ok = state.GetOk("http_ip")
 	if !ok {
-		t.Fatal("should have http_ip")
+		t.Fatalf("unexpected state: '%s' not found", "http_ip")
 	}
 	if httpIp != ip {
-		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, ip)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", ip, httpIp)
 	}
 }

--- a/builder/vsphere/common/step_reattach_cdrom_test.go
+++ b/builder/vsphere/common/step_reattach_cdrom_test.go
@@ -166,7 +166,7 @@ func TestStepReattachCDRom_Run(t *testing.T) {
 			}
 
 			if action != tt.expectedAction {
-				t.Fatalf("expected action %v, but got %v", tt.expectedAction, action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", tt.expectedAction, action)
 			}
 		})
 	}
@@ -177,22 +177,22 @@ func TestStepReattachCDRom_Run(t *testing.T) {
 			state.Put("vm", c.vmMock)
 
 			if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action expected '%s', but returned '%s'", c.expectedAction, action)
 			}
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_remote_upload_test.go
+++ b/builder/vsphere/common/step_remote_upload_test.go
@@ -29,28 +29,28 @@ func TestStepRemoteUpload_Run(t *testing.T) {
 	}
 
 	if action := step.Run(context.TODO(), state); action == multistep.ActionHalt {
-		t.Fatalf("Should not halt.")
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	if !driverMock.FindDatastoreCalled {
-		t.Fatalf("driver.FindDatastore should be called.")
+		t.Fatalf("unexpected result: '%s' should be called", "FindDatastore")
 	}
 	if !driverMock.DatastoreMock.FileExistsCalled {
-		t.Fatalf("datastore.FindDatastore should be called.")
+		t.Fatalf("unexpected result: '%s' should be called", "FileExists")
 	}
 	if !driverMock.DatastoreMock.MakeDirectoryCalled {
-		t.Fatalf("datastore.MakeDirectory should be called.")
+		t.Fatalf("unexpected result: '%s' should be called", "MakeDirectory")
 	}
 	if !driverMock.DatastoreMock.UploadFileCalled {
-		t.Fatalf("datastore.UploadFile should be called.")
+		t.Fatalf("unexpected result: '%s' should be called", "UploadFile")
 	}
 	remotePath, ok := state.GetOk("iso_remote_path")
 	if !ok {
-		t.Fatalf("state should contain iso_remote_path")
+		t.Fatalf("unexpected state: '%s' not found", "iso_remote_path")
 	}
 	expectedRemovePath := fmt.Sprintf("[%s] packer_cache/path", driverMock.DatastoreMock.Name())
 	if remotePath != expectedRemovePath {
-		t.Fatalf("iso_remote_path expected to be %s but was %s", expectedRemovePath, remotePath)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s' for '%s'", expectedRemovePath, remotePath, "iso_remote_path")
 	}
 }
 
@@ -62,13 +62,13 @@ func TestStepRemoteUpload_SkipRun(t *testing.T) {
 	step := &StepRemoteUpload{}
 
 	if action := step.Run(context.TODO(), state); action == multistep.ActionHalt {
-		t.Fatalf("Should not halt.")
+		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	if driverMock.FindDatastoreCalled {
-		t.Fatalf("driver.FindDatastore should not be called.")
+		t.Fatalf("unexpected result: '%s' should not be called", "FindDatastore")
 	}
 	if _, ok := state.GetOk("iso_remote_path"); ok {
-		t.Fatalf("state should not contain iso_remote_path")
+		t.Fatalf("unexpected state: '%s' should not be found", "iso_remote_path")
 	}
 }

--- a/builder/vsphere/common/step_remove_cdrom_test.go
+++ b/builder/vsphere/common/step_remove_cdrom_test.go
@@ -92,22 +92,22 @@ func TestStepRemoveCDRom_Run(t *testing.T) {
 			state.Put("vm", c.vmMock)
 
 			if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_remove_floppy_test.go
+++ b/builder/vsphere/common/step_remove_floppy_test.go
@@ -179,37 +179,37 @@ func TestStepRemoveFloppy_Run(t *testing.T) {
 			}
 
 			if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if c.fail {
-					t.Fatalf("expected to fail but it didn't")
+					t.Fatal("unexpected success: expected failure")
 				}
 			}
 
 			if !c.fail {
 				if _, ok := state.GetOk("uploaded_floppy_path"); ok {
-					t.Fatalf("uploaded_floppy_path should not be in state")
+					t.Fatalf("unexpected state: '%s' should not be found", "uploaded_floppy_path")
 				}
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 			c.expectedDriverMock.DatastoreMock = c.expectedDsMock
 			if diff := cmp.Diff(c.driverMock, c.expectedDriverMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Driver calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "Driver", diff)
 			}
 			if diff := cmp.Diff(c.dsMock, c.expectedDsMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected Datastore calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "Datastore", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_remove_network_adapter_test.go
+++ b/builder/vsphere/common/step_remove_network_adapter_test.go
@@ -63,20 +63,20 @@ func TestStepRemoveNetworkAdapter_Run(t *testing.T) {
 			state.Put("vm", c.vmMock)
 
 			if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-				t.Fatalf("unexpected action %v", action)
+				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
 			}
 			err, ok := state.Get("error").(error)
 			if ok {
 				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else if c.errMessage != "" {
-				t.Fatalf("expected to fail with %s but it didn't", c.errMessage)
+				t.Fatalf("unexpected success, expected error: '%s'", c.errMessage)
 			}
 
 			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected VirtualMachine calls: %s", diff)
+				t.Fatalf("unexpected '%s' calls: %s", "VirtualMachine", diff)
 			}
 		})
 	}

--- a/builder/vsphere/common/step_run.go
+++ b/builder/vsphere/common/step_run.go
@@ -85,6 +85,6 @@ func (s *StepRun) Cleanup(state multistep.StateBag) {
 
 	err := vm.PowerOff()
 	if err != nil {
-		ui.Error(err.Error())
+		ui.Errorf("%s", err)
 	}
 }

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -110,7 +110,7 @@ func (s *StepWaitForIp) Run(ctx context.Context, state multistep.StateBag) multi
 			}
 			err := fmt.Errorf("timeout waiting for IP address")
 			state.Put("error", err)
-			ui.Error(err.Error())
+			ui.Errorf("%s", err)
 			return multistep.ActionHalt
 		case <-ctx.Done():
 			cancel()

--- a/builder/vsphere/driver/datastore_acc_test.go
+++ b/builder/vsphere/driver/datastore_acc_test.go
@@ -15,14 +15,14 @@ func TestDatastoreAcc(t *testing.T) {
 	d := newTestDriver(t)
 	ds, err := d.FindDatastore("datastore1", "")
 	if err != nil {
-		t.Fatalf("Cannot find the default datastore '%v': %v", "datastore1", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	info, err := ds.Info("name")
 	if err != nil {
-		t.Fatalf("Cannot read datastore properties: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if info.Name != "datastore1" {
-		t.Errorf("Wrong datastore. expected: 'datastore1', got: '%v'", info.Name)
+		t.Errorf("unexpected result: expected '%s', but returned '%s'", "datastore1", info.Name)
 	}
 }
 
@@ -34,31 +34,31 @@ func TestFileUpload(t *testing.T) {
 	fileName := fmt.Sprintf("test-%v", time.Now().Unix())
 	tmpFile, err := os.CreateTemp("", fileName)
 	if err != nil {
-		t.Fatalf("Error creating temp file")
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		t.Fatalf("Error creating temp file")
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	d := newTestDriver(t)
 	ds, err := d.FindDatastore(dsName, hostName)
 	if err != nil {
-		t.Fatalf("Cannot find datastore '%v': %v", dsName, err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	err = ds.UploadFile(tmpFile.Name(), fileName, hostName, true)
 	if err != nil {
-		t.Fatalf("Cannot upload file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	if ds.FileExists(fileName) != true {
-		t.Fatalf("Cannot find file")
+		t.Fatalf("unexpected result: expected 'true', but returned '%t'", ds.FileExists(fileName))
 	}
 
 	err = ds.Delete(fileName)
 	if err != nil {
-		t.Fatalf("Cannot delete file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 }
 
@@ -70,30 +70,30 @@ func TestFileUploadDRS(t *testing.T) {
 	fileName := fmt.Sprintf("test-%v", time.Now().Unix())
 	tmpFile, err := os.CreateTemp("", fileName)
 	if err != nil {
-		t.Fatalf("Error creating temp file")
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		t.Fatalf("Error creating temp file")
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	d := newTestDriver(t)
 	ds, err := d.FindDatastore(dsName, hostName)
 	if err != nil {
-		t.Fatalf("Cannot find datastore '%v': %v", dsName, err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	err = ds.UploadFile(tmpFile.Name(), fileName, hostName, false)
 	if err != nil {
-		t.Fatalf("Cannot upload file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
-	if ds.FileExists(fileName) != true {
-		t.Fatalf("Cannot find file")
+	if ds.FileExists(fileName) != false {
+		t.Fatalf("unexpected error: expected 'true', but returned '%t'", ds.FileExists(fileName))
 	}
 
 	err = ds.Delete(fileName)
 	if err != nil {
-		t.Fatalf("Cannot delete file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 }

--- a/builder/vsphere/driver/datastore_test.go
+++ b/builder/vsphere/driver/datastore_test.go
@@ -83,14 +83,14 @@ func TestDatastoreIsoPath(t *testing.T) {
 	for i, c := range tc {
 		dsIsoPath := &DatastoreIsoPath{path: c.isoPath}
 		if dsIsoPath.Validate() != c.valid {
-			t.Fatalf("%d Expecting %s to be %t but was %t", i, c.isoPath, c.valid, !c.valid)
+			t.Fatalf("%d expected '%s' to be '%t', but returned '%t'", i, c.isoPath, c.valid, !c.valid)
 		}
 		if !c.valid {
 			continue
 		}
 		filePath := dsIsoPath.GetFilePath()
 		if filePath != c.filePath {
-			t.Fatalf("%d Expecting %s but got %s", i, c.filePath, filePath)
+			t.Fatalf("%d expected '%s', but returned '%s'", i, c.filePath, filePath)
 		}
 	}
 }
@@ -98,7 +98,7 @@ func TestDatastoreIsoPath(t *testing.T) {
 func TestVCenterDriver_FindDatastore(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -139,17 +139,17 @@ func TestVCenterDriver_FindDatastore(t *testing.T) {
 			ds, err := sim.driver.FindDatastore(c.datastore, c.host)
 			if c.fail {
 				if err == nil {
-					t.Fatalf("expected to fail")
+					t.Fatal("unexpected success: expected failure")
 				}
 				if c.errMessage != "" && err.Error() != c.errMessage {
-					t.Fatalf("unexpected error message %s", err.Error())
+					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
 				}
 			} else {
 				if err != nil {
-					t.Fatalf("should not fail: %s", err.Error())
+					t.Fatalf("unexpected error: '%s'", err)
 				}
 				if ds == nil {
-					t.Fatalf("expected to find datastore")
+					t.Fatalf("unexpected result: expected '%s', but returned '%s'", c.datastore, ds)
 				}
 			}
 		})
@@ -161,7 +161,7 @@ func TestVCenterDriver_MultipleDatastoreError(t *testing.T) {
 	model.Datastore = 2
 	sim, err := NewCustomVCenterSimulator(model)
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -169,9 +169,9 @@ func TestVCenterDriver_MultipleDatastoreError(t *testing.T) {
 
 	_, err = sim.driver.FindDatastore("", host.Name)
 	if err == nil {
-		t.Fatalf("expected to fail")
+		t.Fatal("unexpected success: expected failure")
 	}
 	if err.Error() != "Host has multiple datastores. Specify it explicitly" {
-		t.Fatalf("unexpected error message %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 }

--- a/builder/vsphere/driver/disk_test.go
+++ b/builder/vsphere/driver/disk_test.go
@@ -29,24 +29,24 @@ func TestAddStorageDevices(t *testing.T) {
 	noExistingDevices := object.VirtualDeviceList{}
 	storageConfigSpec, err := config.AddStorageDevices(noExistingDevices)
 	if err != nil {
-		t.Fatalf("unexpected error: %q", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 	if len(storageConfigSpec) != 3 {
-		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))
+		t.Fatalf("unexpected result: expected '3', but returned '%d'", len(storageConfigSpec))
 	}
 
 	existingDevices := object.VirtualDeviceList{}
 	device, err := existingDevices.CreateNVMEController()
 	if err != nil {
-		t.Fatalf("unexpected error: %q", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 	existingDevices = append(existingDevices, device)
 
 	storageConfigSpec, err = config.AddStorageDevices(existingDevices)
 	if err != nil {
-		t.Fatalf("unexpected error: %q", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 	if len(storageConfigSpec) != 3 {
-		t.Fatalf("Expecting VirtualDeviceList to have 3 storage devices but had %d", len(storageConfigSpec))
+		t.Fatalf("unexpected result: expected '3', but returned '%d'", len(storageConfigSpec))
 	}
 }

--- a/builder/vsphere/driver/driver_test.go
+++ b/builder/vsphere/driver/driver_test.go
@@ -43,7 +43,7 @@ func newTestDriver(t *testing.T) Driver {
 		InsecureConnection: true,
 	})
 	if err != nil {
-		t.Fatalf("Cannot connect: %v", err)
+		t.Fatalf("unexpected error: %s", err)
 	}
 	return d
 }

--- a/builder/vsphere/driver/folder_acc_test.go
+++ b/builder/vsphere/driver/folder_acc_test.go
@@ -10,13 +10,13 @@ func TestFolderAcc(t *testing.T) {
 	d := newTestDriver(t)
 	f, err := d.FindFolder("folder1/folder2")
 	if err != nil {
-		t.Fatalf("Cannot find the default folder '%v': %v", "folder1/folder2", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	path, err := f.Path()
 	if err != nil {
-		t.Fatalf("Cannot read folder name: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if path != "folder1/folder2" {
-		t.Errorf("Wrong folder. expected: 'folder1/folder2', got: '%v'", path)
+		t.Errorf("unexpected result: expected '%s', but returned '%s'", "folder1/folder2", path)
 	}
 }

--- a/builder/vsphere/driver/host_acc_test.go
+++ b/builder/vsphere/driver/host_acc_test.go
@@ -12,14 +12,14 @@ func TestHostAcc(t *testing.T) {
 	d := newTestDriver(t)
 	host, err := d.FindHost(TestHostName)
 	if err != nil {
-		t.Fatalf("Cannot find the default host '%v': %v", "datastore1", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	info, err := host.Info("name")
 	if err != nil {
-		t.Fatalf("Cannot read host properties: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if info.Name != TestHostName {
-		t.Errorf("Wrong host name: expected '%v', got: '%v'", TestHostName, info.Name)
+		t.Errorf("unexpected result: expected '%s', but returned '%s'", TestHostName, info.Name)
 	}
 }

--- a/builder/vsphere/driver/library_test.go
+++ b/builder/vsphere/driver/library_test.go
@@ -45,21 +45,21 @@ func TestLibraryFilePath(t *testing.T) {
 		libraryFilePath := &LibraryFilePath{path: c.filePath}
 		if err := libraryFilePath.Validate(); err != nil {
 			if c.valid {
-				t.Fatalf("Expecting %s to be valid", c.filePath)
+				t.Fatalf("unexpected result: expected '%s' to be valid", c.filePath)
 			}
 			continue
 		}
 		libraryName := libraryFilePath.GetLibraryName()
 		if libraryName != c.libraryName {
-			t.Fatalf("Expecting %s but got %s", c.libraryName, libraryName)
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", c.libraryName, libraryName)
 		}
 		libraryItemName := libraryFilePath.GetLibraryItemName()
 		if libraryItemName != c.libraryItemName {
-			t.Fatalf("Expecting %s but got %s", c.libraryItemName, libraryItemName)
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", c.libraryItemName, libraryItemName)
 		}
 		fileName := libraryFilePath.GetFileName()
 		if fileName != c.fileName {
-			t.Fatalf("Expecting %s but got %s", c.fileName, fileName)
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", c.fileName, fileName)
 		}
 	}
 }

--- a/builder/vsphere/driver/resource_pool_acc_test.go
+++ b/builder/vsphere/driver/resource_pool_acc_test.go
@@ -10,14 +10,14 @@ func TestResourcePoolAcc(t *testing.T) {
 	d := newTestDriver(t)
 	p, err := d.FindResourcePool("", "esxi-01.example.com", "pool1/pool2")
 	if err != nil {
-		t.Fatalf("Cannot find the default resource pool '%v': %v", "pool1/pool2", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	path, err := p.Path()
 	if err != nil {
-		t.Fatalf("Cannot read resource pool name: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if path != "pool1/pool2" {
-		t.Errorf("Wrong folder. expected: 'pool1/pool2', got: '%v'", path)
+		t.Errorf("unexpected result: expected: '%s', but returned: '%s'", "pool1/pool2", path)
 	}
 }

--- a/builder/vsphere/driver/resource_pool_test.go
+++ b/builder/vsphere/driver/resource_pool_test.go
@@ -12,20 +12,20 @@ import (
 func TestVCenterDriver_FindResourcePool(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
 	res, err := sim.driver.FindResourcePool("", "DC0_H0", "")
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if res == nil {
-		t.Fatalf("resource pool should not be nil")
+		t.Fatalf("unexpected result: expected '%v', but returned 'nil'", res)
 	}
 	expectedResourcePool := "Resources"
 	if res.pool.Name() != expectedResourcePool {
-		t.Fatalf("resource name expected %s but was %s", expectedResourcePool, res.pool.Name())
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedResourcePool, res.pool.Name())
 	}
 }
 
@@ -44,31 +44,31 @@ func TestVCenterDriver_FindResourcePoolStandaloneESX(t *testing.T) {
 
 	sim, err := NewCustomVCenterSimulator(model)
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
 	res, err := sim.driver.FindResourcePool("", "localhost.localdomain", "")
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if res == nil {
-		t.Fatalf("resource pool should not be nil")
+		t.Fatalf("unexpected result: expected '%v', but returned 'nil'", res)
 	}
 	expectedResourcePool := "Resources"
 	if res.pool.Name() != expectedResourcePool {
-		t.Fatalf("resource name expected %s but was %s", expectedResourcePool, res.pool.Name())
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedResourcePool, res.pool.Name())
 	}
 
 	// Invalid resource name should look for default resource pool
 	res, err = sim.driver.FindResourcePool("", "localhost.localdomain", "invalid")
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if res == nil {
-		t.Fatalf("resource pool should not be nil")
+		t.Fatalf("unexpected result: expected '%v', but returned 'nil'", res)
 	}
 	if res.pool.Name() != expectedResourcePool {
-		t.Fatalf("resource name expected %s but was %s", expectedResourcePool, res.pool.Name())
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedResourcePool, res.pool.Name())
 	}
 }

--- a/builder/vsphere/driver/vm_cdrom_test.go
+++ b/builder/vsphere/driver/vm_cdrom_test.go
@@ -14,7 +14,7 @@ import (
 func TestVirtualMachineDriver_FindAndAddSATAController(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -22,29 +22,29 @@ func TestVirtualMachineDriver_FindAndAddSATAController(t *testing.T) {
 
 	_, err = vm.FindSATAController()
 	if err != nil && !strings.Contains(err.Error(), "no available SATA controller") {
-		t.Fatalf("unexpected error: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if err == nil {
-		t.Fatalf("vm should not have sata controller")
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	if err := vm.AddSATAController(); err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	sc, err := vm.FindSATAController()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if sc == nil {
-		t.Fatalf("SATA controller wasn't added properly")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "sata controller", sc)
 	}
 }
 
 func TestVirtualMachineDriver_CreateAndRemoveCdrom(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -52,56 +52,56 @@ func TestVirtualMachineDriver_CreateAndRemoveCdrom(t *testing.T) {
 
 	// Add SATA Controller
 	if err := vm.AddSATAController(); err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	// Verify if controller was created
 	sc, err := vm.FindSATAController()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if sc == nil {
-		t.Fatalf("SATA controller wasn't added properly")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "sata controller", sc)
 	}
 
 	// Create CDROM
 	controller := sc.GetVirtualController()
 	cdrom, err := vm.CreateCdrom(controller)
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if cdrom == nil {
-		t.Fatalf("CDrom wasn't created properly")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "cd-rom", cdrom)
 	}
 
 	// Verify if CDROM was created
 	cdroms, err := vm.CdromDevices()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if len(cdroms) != 1 {
-		t.Fatalf("unexpected numbers of cdrom: %d", len(cdroms))
+		t.Fatalf("unexpected result: expected '1', but returned '%d'", len(cdroms))
 	}
 
 	// Remove CDROM
 	err = vm.RemoveCdroms()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	// Verify if CDROM was removed
 	cdroms, err = vm.CdromDevices()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if len(cdroms) != 0 {
-		t.Fatalf("unexpected numbers of cdrom: %d", len(cdroms))
+		t.Fatalf("unexpected result: expected '0', but returned '%d'", len(cdroms))
 	}
 }
 
 func TestVirtualMachineDriver_EjectCdrom(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -109,58 +109,58 @@ func TestVirtualMachineDriver_EjectCdrom(t *testing.T) {
 
 	// Add SATA Controller
 	if err := vm.AddSATAController(); err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	// Verify if controller was created
 	sc, err := vm.FindSATAController()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if sc == nil {
-		t.Fatalf("SATA controller wasn't added properly")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "sata controller", sc)
 	}
 
 	// Create CDROM
 	controller := sc.GetVirtualController()
 	cdrom, err := vm.CreateCdrom(controller)
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if cdrom == nil {
-		t.Fatalf("CDrom wasn't created properly")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "cd-rom", cdrom)
 	}
 
 	// Verify if CDROM was created
 	cdroms, err := vm.CdromDevices()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if len(cdroms) != 1 {
-		t.Fatalf("unexpected numbers of cdrom: %d", len(cdroms))
+		t.Fatalf("unexpected result: expected '1', but returned '%d'", len(cdroms))
 	}
 
 	// Remove CDROM
 	err = vm.EjectCdroms()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	// Verify if CDROM was removed
 	cdroms, err = vm.CdromDevices()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	if len(cdroms) != 1 {
-		t.Fatalf("unexpected numbers of cdrom: %d", len(cdroms))
+		t.Fatalf("unexpected result: expected '1', but returned '%d'", len(cdroms))
 	}
 	cd, ok := cdroms[0].(*types.VirtualCdrom)
 	if !ok {
-		t.Fatalf("Wrong cdrom type")
+		t.Fatalf("unexpected result: expected '%s', but returned '%v'", "cdrom", cd)
 	}
 	if diff := cmp.Diff(cd.Backing, &types.VirtualCdromRemotePassthroughBackingInfo{}); diff != "" {
-		t.Fatalf("Wrong cdrom backing info: %s", diff)
+		t.Fatalf("unexpected result: '%s'", diff)
 	}
 	if diff := cmp.Diff(cd.Connectable, &types.VirtualDeviceConnectInfo{}); diff != "" {
-		t.Fatalf("Wrong cdrom connect info: %s", diff)
+		t.Fatalf("unexpected result: '%s'", diff)
 	}
 }

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -13,7 +13,7 @@ import (
 func TestVirtualMachineDriver_Configure(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -35,14 +35,14 @@ func TestVirtualMachineDriver_Configure(t *testing.T) {
 		VirtualPrecisionClock: "ntp",
 	}
 	if err = vm.Configure(hardwareConfig); err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 }
 
 func TestVirtualMachineDriver_CreateVMWithMultipleDisks(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -77,12 +77,12 @@ func TestVirtualMachineDriver_CreateVMWithMultipleDisks(t *testing.T) {
 
 	vm, err := sim.driver.CreateVM(config)
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	devices, err := vm.Devices()
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	var disks []*types.VirtualDisk
@@ -94,14 +94,14 @@ func TestVirtualMachineDriver_CreateVMWithMultipleDisks(t *testing.T) {
 	}
 
 	if len(disks) != 2 {
-		t.Fatalf("unexpected number of devices")
+		t.Fatalf("unexpected result: expected '2', but returned %d", len(disks))
 	}
 }
 
 func TestVirtualMachineDriver_CloneWithPrimaryDiskResize(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -132,12 +132,12 @@ func TestVirtualMachineDriver_CloneWithPrimaryDiskResize(t *testing.T) {
 
 	clonedVM, err := vm.Clone(context.TODO(), config)
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	devices, err := clonedVM.Devices()
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	var disks []*types.VirtualDisk
@@ -149,24 +149,24 @@ func TestVirtualMachineDriver_CloneWithPrimaryDiskResize(t *testing.T) {
 	}
 
 	if len(disks) != 3 {
-		t.Fatalf("unexpected number of devices")
+		t.Fatalf("unexpected result: expected '3', but returned '%d'", len(disks))
 	}
 
 	if disks[0].CapacityInKB != config.PrimaryDiskSize*1024 {
-		t.Fatalf("unexpected disk size for primary disk: %d", disks[0].CapacityInKB)
+		t.Fatalf("unexpected result: expected '%d', but returned '%d'", config.PrimaryDiskSize*1024, disks[0].CapacityInKB)
 	}
 	if disks[1].CapacityInKB != config.StorageConfig.Storage[0].DiskSize*1024 {
-		t.Fatalf("unexpected disk size for primary disk: %d", disks[1].CapacityInKB)
+		t.Fatalf("unexpected result: expected '%d', but returned '%d'", config.StorageConfig.Storage[0].DiskSize*1024, disks[1].CapacityInKB)
 	}
 	if disks[2].CapacityInKB != config.StorageConfig.Storage[1].DiskSize*1024 {
-		t.Fatalf("unexpected disk size for primary disk: %d", disks[2].CapacityInKB)
+		t.Fatalf("unexpected result: expected '%d', but returned '%d'", config.StorageConfig.Storage[1].DiskSize*1024, disks[2].CapacityInKB)
 	}
 }
 
 func TestVirtualMachineDriver_CloneWithMacAddress(t *testing.T) {
 	sim, err := NewVCenterSimulator()
 	if err != nil {
-		t.Fatalf("should not fail: %s", err.Error())
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	defer sim.Close()
 
@@ -175,12 +175,12 @@ func TestVirtualMachineDriver_CloneWithMacAddress(t *testing.T) {
 
 	devices, err := vm.Devices()
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	adapter, err := findNetworkAdapter(devices)
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	network := adapter.GetVirtualEthernetCard()
@@ -198,26 +198,26 @@ func TestVirtualMachineDriver_CloneWithMacAddress(t *testing.T) {
 	ctx := context.TODO()
 	clonedVM, err := vm.Clone(ctx, config)
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	devices, err = clonedVM.Devices()
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 	adapter, err = findNetworkAdapter(devices)
 	if err != nil {
-		t.Fatalf("unexpected error %s", err.Error())
+		t.Fatalf("unexpected error: %s", err)
 	}
 
 	network = adapter.GetVirtualEthernetCard()
 	if network.AddressType != string(types.VirtualEthernetCardMacTypeManual) {
-		t.Fatalf("unexpected address type")
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", types.VirtualEthernetCardMacTypeManual, network.AddressType)
 	}
 	if network.MacAddress == oldMacAddress {
-		t.Fatalf("expected mac address to be different from old one")
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", newMacAddress, network.MacAddress)
 	}
 	if network.MacAddress != newMacAddress {
-		t.Fatalf("unexpected mac address")
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", newMacAddress, network.MacAddress)
 	}
 }

--- a/builder/vsphere/iso/builder_acc_test.go
+++ b/builder/vsphere/iso/builder_acc_test.go
@@ -485,15 +485,15 @@ func checkNetworkCard(name string) error {
 func TestAccISOBuilderAcc_createFloppy(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "packer-vsphere-iso-test")
 	if err != nil {
-		t.Fatalf("Error creating temp file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	_, err = fmt.Fprint(tmpFile, "Hello, World!")
 	if err != nil {
-		t.Fatalf("Error creating temp file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		t.Fatalf("Error creating temp file: %v", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	config := defaultConfig()
 	config["floppy_files"] = []string{tmpFile.Name()}
@@ -503,7 +503,7 @@ func TestAccISOBuilderAcc_createFloppy(t *testing.T) {
 		Teardown: func() error {
 			d, err := commonT.TestConn()
 			if err != nil {
-				return fmt.Errorf("Cannot connect %v", err)
+				return fmt.Errorf("unexpected error: expected 'nil', but returned '%s'", err)
 			}
 			return commonT.CleanupVM(d, config["vm_name"].(string))
 		},

--- a/builder/vsphere/supervisor/config_test.go
+++ b/builder/vsphere/supervisor/config_test.go
@@ -18,10 +18,10 @@ func TestConfig_Minimal(t *testing.T) {
 	minConfigs := getMinimalConfig()
 	warns, err := c.Prepare(minConfigs)
 	if len(warns) != 0 {
-		t.Errorf("expected no warnings, got: %#v", warns)
+		t.Errorf("unexpected warning: %#v", warns)
 	}
 	if err != nil {
-		t.Errorf("expected no errors, got: %s", err)
+		t.Errorf("unexpected errors: %s", err)
 	}
 }
 
@@ -32,7 +32,7 @@ func TestConfig_Required(t *testing.T) {
 		minConfigs[key] = ""
 		_, err := c.Prepare(minConfigs)
 		if err == nil {
-			t.Errorf("expected an error for the required config: %s", key)
+			t.Errorf("unexpected error: '%s'", err)
 		}
 		minConfigs[key] = val
 	}
@@ -43,10 +43,10 @@ func TestConfig_Complete(t *testing.T) {
 	allConfigs := getCompleteConfig(t)
 	warns, err := c.Prepare(allConfigs)
 	if len(warns) != 0 {
-		t.Errorf("expected no warnings, got: %#v", warns)
+		t.Errorf("unexpected warning: '%#v'", warns)
 	}
 	if err != nil {
-		t.Errorf("expected no errors, got: %s", err)
+		t.Errorf("unexpected error: '%s", err)
 	}
 }
 
@@ -55,62 +55,62 @@ func TestConfig_Values(t *testing.T) {
 	providedConfigs := getCompleteConfig(t)
 	warns, err := c.Prepare(providedConfigs)
 	if len(warns) != 0 {
-		t.Fatalf("expected no warnings, got: %#v", warns)
+		t.Fatalf("unexpected warnings: '%#v'", warns)
 	}
 	if err != nil {
-		t.Fatalf("expected no errors, got: %s", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 
 	if c.ImageName != providedConfigs["image_name"] {
-		t.Errorf("expected image_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'image_name', but returned '%s'",
 			providedConfigs["image_name"], c.ImageName)
 	}
 	if c.ClassName != providedConfigs["class_name"] {
-		t.Errorf("expected class_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'class_name', but returned '%s'",
 			providedConfigs["class_name"], c.ClassName)
 	}
 	if c.StorageClass != providedConfigs["storage_class"] {
-		t.Errorf("expected storage_class to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'storage_class', but returned '%s'",
 			providedConfigs["storage_class"], c.StorageClass)
 	}
 	if c.PublishLocationName != providedConfigs["publish_location_name"] {
-		t.Errorf("expected publish_location_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'publish_location_name', but returned '%s'",
 			providedConfigs["publish_location_name"], c.PublishLocationName)
 	}
 	if c.PublishImageName != providedConfigs["publish_image_name"] {
-		t.Errorf("expected publish_image_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'publish_image_name', but returned '%s'",
 			providedConfigs["publish_image_name"], c.PublishImageName)
 	}
 	if c.KubeconfigPath != providedConfigs["kubeconfig_path"] {
-		t.Errorf("expected kubeconfig_path to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'kubeconfig_path', but returned '%s'",
 			providedConfigs["kubeconfig_path"], c.KubeconfigPath)
 	}
 	if c.SupervisorNamespace != providedConfigs["supervisor_namespace"] {
-		t.Errorf("expected supervisor_namespace to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'supervisor_namespace', but returned '%s'",
 			providedConfigs["supervisor_namespace"], c.SupervisorNamespace)
 	}
 	if c.SourceName != providedConfigs["source_name"] {
-		t.Errorf("expected source_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'source_name', but returned '%s'",
 			providedConfigs["source_name"], c.SourceName)
 	}
 	if c.NetworkType != providedConfigs["network_type"] {
-		t.Errorf("expected network_type to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'network_name', but returned '%s'",
 			providedConfigs["network_type"], c.NetworkType)
 	}
 	if c.NetworkName != providedConfigs["network_name"] {
-		t.Errorf("expected network_name to be: %s, got: %s",
+		t.Errorf("unexpected result: expected '%s' for 'network_name', but returned '%s'",
 			providedConfigs["network_name"], c.NetworkName)
 	}
 	if c.WatchSourceTimeoutSec != providedConfigs["watch_source_timeout_sec"] {
-		t.Errorf("expected watch_source_timeout_sec to be: %d, got: %d",
+		t.Errorf("unexpected result: expected '%d' for 'watch_publish_timeout_sec', but returned '%d'",
 			providedConfigs["watch_source_timeout_sec"], c.WatchSourceTimeoutSec)
 	}
 	if c.WatchPublishTimeoutSec != providedConfigs["watch_publish_timeout_sec"] {
-		t.Errorf("expected watch_publish_timeout_sec to be: %d, got: %d",
+		t.Errorf("unexpected result: expected '%d' for 'watch_publish_timeout_sec', but returned '%d'",
 			providedConfigs["watch_publish_timeout_sec"], c.WatchPublishTimeoutSec)
 	}
 	if c.KeepInputArtifact != providedConfigs["keep_input_artifact"] {
-		t.Errorf("expected keep_input_artifact to be: true, got: false")
+		t.Errorf("unexpected result: expected 'true' for 'keep_input_artifact', but returned 'false'")
 	}
 }
 

--- a/builder/vsphere/supervisor/step_create_source_test.go
+++ b/builder/vsphere/supervisor/step_create_source_test.go
@@ -28,7 +28,7 @@ func TestCreateSource_Prepare(t *testing.T) {
 	config := &supervisor.CreateSourceConfig{}
 	var actualErrs []error
 	if actualErrs = config.Prepare(); len(actualErrs) == 0 {
-		t.Fatalf("Prepare should fail by missing required configs, got empty")
+		t.Fatal("unexpected success: expected failure")
 	}
 
 	expectedErrs := []error{
@@ -37,7 +37,7 @@ func TestCreateSource_Prepare(t *testing.T) {
 		fmt.Errorf("'storage_class' is required for creating the source VM"),
 	}
 	if !reflect.DeepEqual(actualErrs, expectedErrs) {
-		t.Fatalf("Expected errs %v, got %v", expectedErrs, actualErrs)
+		t.Fatalf("unexpected error: expected '%s', but returned '%s'", expectedErrs, actualErrs)
 	}
 
 	// Check error output when providing invalid bootstrap configs.
@@ -52,10 +52,10 @@ func TestCreateSource_Prepare(t *testing.T) {
 		BootstrapProvider: "fake-bootstrap-provider",
 	}
 	if actualErrs = config.Prepare(); len(actualErrs) == 0 {
-		t.Fatalf("Prepare should fail with invalid bootstrap configs, got empty")
+		t.Fatalf("unexpected success: expected failure")
 	}
 	if !reflect.DeepEqual(actualErrs, expectedErrs) {
-		t.Fatalf("Expected errs %v, got %v", expectedErrs, actualErrs)
+		t.Fatalf("unexpected error: expected '%s', but returned '%s'", expectedErrs, actualErrs)
 	}
 
 	expectedErrs = []error{
@@ -63,10 +63,10 @@ func TestCreateSource_Prepare(t *testing.T) {
 	}
 	config.BootstrapProvider = "Sysprep"
 	if actualErrs = config.Prepare(); len(actualErrs) == 0 {
-		t.Fatalf("Prepare should fail with invalid bootstrap configs, got empty")
+		t.Fatalf("unexpected success: expected failure")
 	}
 	if !reflect.DeepEqual(actualErrs, expectedErrs) {
-		t.Fatalf("Expected errs %v, got %v", expectedErrs, actualErrs)
+		t.Fatalf("unexpected error: expected '%s', but returned '%s'", expectedErrs, actualErrs)
 	}
 
 	// Check default values for the optional configs.
@@ -76,14 +76,14 @@ func TestCreateSource_Prepare(t *testing.T) {
 		StorageClass: "fake-storage-class",
 	}
 	if actualErrs = config.Prepare(); len(actualErrs) != 0 {
-		t.Fatalf("Prepare should NOT fail: %v", actualErrs)
+		t.Fatalf("unexpected failure: expected success, but failed: %v", actualErrs)
 	}
 	if !strings.HasPrefix(config.SourceName, supervisor.DefaultSourceNamePrefix) {
-		t.Errorf("Expected default SourceName has prefix %s, got %s",
+		t.Errorf("expected default SourceName has prefix %s, got %s",
 			supervisor.DefaultSourceNamePrefix, config.SourceName)
 	}
 	if config.BootstrapProvider != supervisor.ProviderCloudInit {
-		t.Errorf("Expected default BootstrapProvider %s, got %s",
+		t.Errorf("expected default BootstrapProvider %s, got %s",
 			supervisor.ProviderCloudInit, config.BootstrapProvider)
 	}
 }
@@ -121,9 +121,9 @@ func TestCreateSource_RunDefault(t *testing.T) {
 	action := step.Run(ctx, state)
 	if action == multistep.ActionHalt {
 		if rawErr, ok := state.GetOk("error"); ok {
-			t.Errorf("Error from running the step: %s", rawErr.(error))
+			t.Errorf("unexpected error: %s", rawErr.(error))
 		}
-		t.Fatal("Step should NOT halt")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	// Check if the K8s Secret object is created with expected spec.
@@ -133,7 +133,7 @@ func TestCreateSource_RunDefault(t *testing.T) {
 	}
 	secretObj := &corev1.Secret{}
 	if err := kubeClient.Get(ctx, objKey, secretObj); err != nil {
-		t.Fatalf("Failed to get the expected Secret object, err: %s", err.Error())
+		t.Fatalf("Failed to get the expected Secret object, err: %s", err)
 	}
 	if secretObj.StringData["user-data"] == "" {
 		t.Errorf("Expected the Secret object to be created with user-data, got: %v", secretObj)
@@ -142,7 +142,7 @@ func TestCreateSource_RunDefault(t *testing.T) {
 	// Check if the source VM object is created with expected spec.
 	vmObj := &vmopv1alpha1.VirtualMachine{}
 	if err := kubeClient.Get(ctx, objKey, vmObj); err != nil {
-		t.Fatalf("Failed to get the expected VM object, err: %s", err.Error())
+		t.Fatalf("Failed to get the expected VM object, err: %s", err)
 	}
 	if vmObj.Name != "test-source" {
 		t.Errorf("Expected VM name to be 'test-vm', got %q", vmObj.Name)
@@ -170,7 +170,7 @@ func TestCreateSource_RunDefault(t *testing.T) {
 	// Check if the source VMService object is created with expected spec.
 	vmServiceObj := &vmopv1alpha1.VirtualMachineService{}
 	if err := kubeClient.Get(ctx, objKey, vmServiceObj); err != nil {
-		t.Fatalf("Failed to get the expected VMService object, err: %s", err.Error())
+		t.Fatalf("Failed to get the expected VMService object, err: %s", err)
 	}
 	if vmServiceObj.Name != "test-source" {
 		t.Errorf("Expected VMService name to be 'test-source', got %q", vmServiceObj.Name)
@@ -193,7 +193,7 @@ func TestCreateSource_RunDefault(t *testing.T) {
 	// Check if all the required states are set correctly after the step is run.
 	sourceName := state.Get(supervisor.StateKeySourceName)
 	if sourceName != "test-source" {
-		t.Errorf("State %q should be 'test-source', but got %q", supervisor.StateKeySourceName, sourceName)
+		t.Errorf("State %q should be 'test-source', but returned %q", supervisor.StateKeySourceName, sourceName)
 	}
 	if state.Get(supervisor.StateKeyVMCreated) != true {
 		t.Errorf("State %q should be 'true'", supervisor.StateKeyVMCreated)
@@ -243,7 +243,7 @@ func TestCreateSource_RunCustomBootstrap(t *testing.T) {
 
 	testDataFile, err := os.CreateTemp(t.TempDir(), "test-data-file")
 	if err != nil {
-		t.Fatalf("Failed to create temp test data file, err: %s", err.Error())
+		t.Fatalf("Failed to create temp test data file, err: %s", err)
 	}
 	defer os.Remove(testDataFile.Name())
 	defer testDataFile.Close()
@@ -264,9 +264,9 @@ func TestCreateSource_RunCustomBootstrap(t *testing.T) {
 	ctx := context.TODO()
 	if action := step.Run(ctx, state); action == multistep.ActionHalt {
 		if rawErr, ok := state.GetOk("error"); ok {
-			t.Errorf("Error from running the step: %s", rawErr.(error))
+			t.Errorf("unexpected error: %s", rawErr.(error))
 		}
-		t.Fatal("Step should NOT halt")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	// Check if the K8s Secret object is created with expected bootstrap data.
@@ -276,7 +276,7 @@ func TestCreateSource_RunCustomBootstrap(t *testing.T) {
 	}
 	secretObj := &corev1.Secret{}
 	if err := kubeClient.Get(ctx, objKey, secretObj); err != nil {
-		t.Fatalf("Failed to get the expected Secret object, err: %s", err.Error())
+		t.Fatalf("Failed to get the expected Secret object, err: %s", err)
 	}
 	if secretObj.StringData["unattend"] != "test-unattend-config" {
 		t.Errorf("Expected the Secret object to contain bootstrap data, got: %q", secretObj.StringData)
@@ -285,7 +285,7 @@ func TestCreateSource_RunCustomBootstrap(t *testing.T) {
 	// Check if the source VM object is created with expected bootstrap provider.
 	vmObj := &vmopv1alpha1.VirtualMachine{}
 	if err := kubeClient.Get(ctx, objKey, vmObj); err != nil {
-		t.Fatalf("Failed to get the expected VM object, err: %s", err.Error())
+		t.Fatalf("Failed to get the expected VM object, err: %s", err)
 	}
 	if vmObj.Spec.VmMetadata.Transport != vmopv1alpha1.VirtualMachineMetadataSysprepTransport {
 		t.Errorf("Expected default VM transport to be %q, got %q",
@@ -356,13 +356,13 @@ func TestCreateSource_Cleanup(t *testing.T) {
 		Namespace: "test-namespace",
 	}
 	if err := kubeClient.Get(ctx, objKey, &corev1.Secret{}); !errors.IsNotFound(err) {
-		t.Fatal("Expected the Secret object to be deleted")
+		t.Fatal("expected the Secret object to be deleted")
 	}
 	if err := kubeClient.Get(ctx, objKey, &vmopv1alpha1.VirtualMachine{}); !errors.IsNotFound(err) {
-		t.Fatal("Expected the VirtualMachine object to be deleted")
+		t.Fatal("expected the VirtualMachine object to be deleted")
 	}
 	if err := kubeClient.Get(ctx, objKey, &vmopv1alpha1.VirtualMachineService{}); !errors.IsNotFound(err) {
-		t.Fatal("Expected the VirtualMachineService object to be deleted")
+		t.Fatal("expected the VirtualMachineService object to be deleted")
 	}
 
 	// Check the output lines from the step runs.

--- a/builder/vsphere/supervisor/step_validate_publish_test.go
+++ b/builder/vsphere/supervisor/step_validate_publish_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestValidatePublish_Prepare(t *testing.T) {
 	config := &supervisor.ValidatePublishConfig{}
-	if actualErr := config.Prepare(); len(actualErr) != 0 {
-		t.Fatalf("Prepare should not fail: %v", actualErr)
+	if errs := config.Prepare(); len(errs) != 0 {
+		t.Fatalf("unexpected failure: expected success, but failed: %v", errs[0])
 	}
 }
 
@@ -39,9 +39,9 @@ func TestValidatePublish_Run(t *testing.T) {
 	action := step.Run(ctx, state)
 	if action == multistep.ActionHalt {
 		if rawErr, ok := state.GetOk("error"); ok {
-			t.Errorf("Error from running the step: %s", rawErr.(error))
+			t.Errorf("unexpected error: %s", rawErr.(error))
 		}
-		t.Fatal("Step should NOT halt")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	expectedOutput := []string{
@@ -60,13 +60,13 @@ func TestValidatePublish_Run(t *testing.T) {
 
 	action = step.Run(ctx, state)
 	if action != multistep.ActionHalt {
-		t.Fatal("Step should halt")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionHalt, action)
 	}
 
 	expectedError := fmt.Sprintf("%q not found", testPublishLocationName)
 	if rawErr, ok := state.GetOk("error"); ok {
 		if !strings.Contains(rawErr.(error).Error(), expectedError) {
-			t.Errorf("Expected error contains %v, but got %v", expectedError, rawErr.(error).Error())
+			t.Errorf("Expected error contains '%v', but returned '%v'", expectedError, rawErr.(error).Error())
 		}
 	}
 
@@ -90,13 +90,13 @@ func TestValidatePublish_Run(t *testing.T) {
 
 	action = step.Run(ctx, state)
 	if action != multistep.ActionHalt {
-		t.Fatal("Step should halt")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionHalt, action)
 	}
 
 	expectedError = fmt.Sprintf("publish location %q is not writable", testPublishLocationName)
 	if rawErr, ok := state.GetOk("error"); ok {
 		if rawErr.(error).Error() != expectedError {
-			t.Errorf("Expected error is %v, but got %v", expectedError, rawErr.(error).Error())
+			t.Errorf("unexpected error: expected '%s', but returned '%s'", expectedError, rawErr.(error).Error())
 		}
 	}
 
@@ -112,7 +112,7 @@ func TestValidatePublish_Run(t *testing.T) {
 
 	action = step.Run(ctx, state)
 	if action != multistep.ActionContinue {
-		t.Fatal("Step should continue")
+		t.Fatalf("unexpected result: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
 	expectedOutput = []string{

--- a/builder/vsphere/supervisor/step_watch_source_test.go
+++ b/builder/vsphere/supervisor/step_watch_source_test.go
@@ -22,10 +22,10 @@ import (
 func TestWatchSource_Prepare(t *testing.T) {
 	config := &supervisor.WatchSourceConfig{}
 	if errs := config.Prepare(); len(errs) != 0 {
-		t.Fatalf("Prepare should NOT fail: %v", errs)
+		t.Fatalf("unexpected failure: expected success, but failed: %v", errs[0])
 	}
 	if config.WatchSourceTimeoutSec != supervisor.DefaultWatchTimeoutSec {
-		t.Fatalf("Default timeout should be %d, but got %d", supervisor.DefaultWatchTimeoutSec, config.WatchSourceTimeoutSec)
+		t.Fatalf("Default timeout should be %d, but returned %d", supervisor.DefaultWatchTimeoutSec, config.WatchSourceTimeoutSec)
 	}
 }
 
@@ -62,20 +62,20 @@ func TestWatchSource_Run(t *testing.T) {
 		action := step.Run(context.TODO(), state)
 		if action == multistep.ActionHalt {
 			if rawErr, ok := state.GetOk("error"); ok {
-				t.Errorf("Error from running the step: %s", rawErr.(error))
+				t.Errorf("unexpected error: %s", rawErr.(error))
 			}
-			t.Error("Step should NOT halt")
+			t.Errorf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 			return
 		}
 
 		// Check if all the required states are set correctly after the step is run.
 		vmIP := state.Get(supervisor.StateKeyVMIP)
 		if vmIP != testVMIP {
-			t.Errorf("State %q should be %q, but got %q", supervisor.StateKeyCommunicateIP, testVMIP, vmIP)
+			t.Errorf("State %q should be %q, but returned %q", supervisor.StateKeyCommunicateIP, testVMIP, vmIP)
 		}
 		connectIP := state.Get(supervisor.StateKeyCommunicateIP)
 		if connectIP != testIngressIP {
-			t.Errorf("State %q should be %q, but got %q", supervisor.StateKeyCommunicateIP, testIngressIP, connectIP)
+			t.Errorf("State %q should be %q, but returned %q", supervisor.StateKeyCommunicateIP, testIngressIP, connectIP)
 		}
 
 		// Check the output lines from the step runs.

--- a/builder/vsphere/supervisor/utils_test.go
+++ b/builder/vsphere/supervisor/utils_test.go
@@ -27,19 +27,19 @@ func TestCheckRequiredStates(t *testing.T) {
 	state := newBasicTestState(nil)
 	err := supervisor.CheckRequiredStates(state, "logger")
 	if err != nil {
-		t.Errorf("Expected no error but got: %s", err.Error())
+		t.Errorf("Expected no error but got: %s", err)
 	}
 
 	state.Put("test-key-1", "test-val-1")
 	state.Put("test-key-2", "test-val-2")
 	err = supervisor.CheckRequiredStates(state, "test-key-1", "test-key-2")
 	if err != nil {
-		t.Errorf("Expected no error but got: %s", err.Error())
+		t.Errorf("unexpected error: %s", err)
 	}
 
 	expectErr := supervisor.CheckRequiredStates(state, "test-key-non-exist")
 	if expectErr == nil {
-		t.Errorf("Expected error but got nil")
+		t.Errorf("unexpected result: expected '%s', but returned nil", expectErr)
 	}
 }
 
@@ -58,7 +58,7 @@ func newBasicTestState(writer *bytes.Buffer) *multistep.BasicStateBag {
 func checkOutputLines(t *testing.T, writer *bytes.Buffer, expectedLines []string) {
 	for _, expected := range expectedLines {
 		if actual := readLine(t, writer); actual != expected {
-			t.Fatalf("Expected output %q but got %q", expected, actual)
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", expected, actual)
 		}
 	}
 }
@@ -66,7 +66,7 @@ func checkOutputLines(t *testing.T, writer *bytes.Buffer, expectedLines []string
 func readLine(t *testing.T, writer *bytes.Buffer) string {
 	actual, err := writer.ReadString('\n')
 	if err != nil {
-		t.Fatalf("Failed to read line from writer, err: %s", err.Error())
+		t.Fatalf("Failed to read line from writer, err: %s", err)
 	}
 
 	// Skip "continue checking" line as it can be printed from the retry.

--- a/post-processor/vsphere/artifact_test.go
+++ b/post-processor/vsphere/artifact_test.go
@@ -16,6 +16,6 @@ func TestArtifact_ImplementsArtifact(t *testing.T) {
 func TestArtifact_Id(t *testing.T) {
 	artifact := NewArtifact("datastore", "vmfolder", "vmname", nil)
 	if artifact.Id() != "datastore::vmfolder::vmname" {
-		t.Fatalf("must return datastore, vmfolder, and vmname split by :: as id")
+		t.Fatalf("unexpected result: must return datastore, vmfolder, and vmname split by :: as id")
 	}
 }

--- a/post-processor/vsphere/post-processor_test.go
+++ b/post-processor/vsphere/post-processor_test.go
@@ -57,11 +57,11 @@ func TestGenerateURI_Basic(t *testing.T) {
 
 	uri, err := p.generateURI()
 	if err != nil {
-		t.Fatalf("had error: %s", err)
+		t.Fatalf("unexpected error: '%s'", err)
 	}
 	expectedURI := "vi://me:notpassword@myhost/mydc/host/mycluster"
 	if uri.String() != expectedURI {
-		t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expectedURI)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedURI, uri)
 	}
 }
 
@@ -95,12 +95,12 @@ func TestGenerateURI_PasswordEscapes(t *testing.T) {
 
 		uri, err := p.generateURI()
 		if err != nil {
-			t.Fatalf("had error: %s", err)
+			t.Fatalf("unexpected error: '%s'", err)
 		}
 		expectedURI := fmt.Sprintf("vi://me:%s@myhost/mydc/host/mycluster", escapeCase.Expected)
 
 		if uri.String() != expectedURI {
-			t.Fatalf("URI did not match. Received: %s. Expected: %s", uri, expectedURI)
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedURI, uri)
 		}
 	}
 }
@@ -116,10 +116,10 @@ func TestGetEncodedPassword(t *testing.T) {
 	encoded, isSet := getEncodedPassword(u)
 	expected := "P%40ssW%3Ard"
 	if !isSet {
-		t.Fatalf("Password is set but test said it is not")
+		t.Fatalf("unexpected result: expected 'true', but returned '%t'", isSet)
 	}
 	if encoded != expected {
-		t.Fatalf("Should have successfully gotten encoded password. Expected: %s; received: %s", expected, encoded)
+		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expected, encoded)
 	}
 
 	// There is no password
@@ -127,7 +127,7 @@ func TestGetEncodedPassword(t *testing.T) {
 
 	_, isSet = getEncodedPassword(u)
 	if isSet {
-		t.Fatalf("Should have determined that password was not set")
+		t.Fatalf("unexpected result: expected 'false', but returned '%t'", isSet)
 	}
 
 }


### PR DESCRIPTION
### Description

Standardizes the messages returned in tests.

Examples:

```diff
if err != nil {
-    t.Fatalf("should not fail: %s", err.Error())
+    t.Fatalf("unexpected error: '%s'", err)
}
```

```diff
if action := c.step.Run(context.TODO(), state); action != c.expectedAction {
-    t.Fatalf("unexpected action %v", action)
+    t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
}
```

```diff
if c.fail {
-    t.Fatalf("expected to fail but it didn't")
+    t.Fatal("unexpected success: expected failure")
}
```

```diff
if !driverMock.DatastoreMock.UploadFileCalled {
-    t.Fatalf("datastore.UploadFile should be called.")
+    t.Fatalf("unexpected result: '%s' should be called", "UploadFile")
}
```

### Testing

```console
packer-plugin-vsphere on  refactor(tests)/standardize-messages
➜ go fmt ./...

packer-plugin-vsphere on  refactor(tests)/standardize-messages
➜ make build

packer-plugin-vsphere on  refactor(tests)/standardize-messages
➜ make generate
2024/06/24 10:18:02 Copying "docs" to ".docs/"
2024/06/24 10:18:02 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on  refactor(tests)/standardize-messages
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.360s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       5.195s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.213s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  5.585s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   8.741s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       3.655s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      4.749s

packer-plugin-vsphere on  refactor(tests)/standardize-messages
➜ make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Work/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_amd64
```