### PR TITLE
chore: update version

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,15 +6,8 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	// Version is the main version number that is being run at the moment.
-	Version = "1.3.1"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	Version           = "1.3.1"
 	VersionPrerelease = "dev"
-
-	// PluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	VersionMetadata   = ""
+	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
### Summary

- Replaces the deprecated `InitializePluginVersion` with `NewPluginVersion` from `packer-plugin-sdk`, which is the recommended approach in `version/version.go`.
- Removed superfluous comments that are already included in the SDK.

### Testing

```console
packer-plugin-vsphere on  chore/update-version via 🐹 v1.22.6 
➜ make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Library/Mobile Documents/com~apple~CloudDocs/Code/Work/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.3.1-dev_x5.0_darwin_amd64
```