### PR TITLE
fix: remove ovftool commands from logs

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/url"
 	"os/exec"
 	"regexp"
@@ -238,10 +237,8 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	}
 
 	ui.Message(fmt.Sprintf("Uploading %s to %s", source, p.config.Host))
-
-	log.Printf("Starting ovftool with parameters: %s", strings.Join(args, " "))
-
 	ui.Message("Validating username and password...")
+
 	err = p.ValidateOvfTool(args, ovftool, ui)
 	if err != nil {
 		return nil, false, false, err
@@ -263,7 +260,6 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
 		cmd := &packersdk.RemoteCmd{Command: flattenedCmd}
-		log.Printf("Starting ovfttool command: %s", flattenedCmd)
 		err = cmd.RunWithUi(ctx, comm, ui)
 		if err != nil || cmd.ExitStatus() != 0 {
 			return fmt.Errorf("error uploading virtual machine")


### PR DESCRIPTION
### Summary

Removes the joined commands which would contain credentials, if logged.

### Testing

```console
packer-plugin-vsphere on  fix/remove-ovftool-commands-from-logs via 🐹 v1.23.0 
➜ go fmt ./...

packer-plugin-vsphere on  fix/remove-ovftool-commands-from-logs via 🐹 v1.23.0 
➜ make test   
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.606s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       4.567s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       9.782s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  5.977s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   11.874s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       4.912s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      6.166s
```

### Reference

- [x] https://github.com/hashicorp/packer-plugin-vsphere/security/code-scanning/1
- [x] https://github.com/hashicorp/packer-plugin-vsphere/security/code-scanning/2