### PR TITLE
fix: configuration parameters

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -291,14 +291,39 @@ JSON Example:
 
 <!-- Code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; DO NOT EDIT MANUALLY -->
 
-- `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the vSphere API's
-  [VirtualMachineConfigSpec](https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/8.0.2.0/data-structures/VirtualMachineConfigSpec/)
+- `configuration_parameters` (map[string]string) - A map of key-value pairs to sent to the [`extraConfig`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html#extraConfig).
+  in the vSphere API's `VirtualMachineConfigSpec`.
+  
+  HCL Example:
+  
+  ```hcl
+    configuration_parameters = {
+      "disk.EnableUUID" = "TRUE"
+      "svga.autodetect" = "TRUE"
+      "log.keepOld"     = "15"
+    }
+  ```
+  
+  JSON Example:
+  
+  ```json
+    "configuration_parameters": {
+      "disk.EnableUUID": "TRUE",
+      "svga.autodetect": "TRUE",
+      "log.keepOld": "15"
+    }
+  ```
+  
+  ~> **Note:** Configuration keys that would conflict with parameters that
+  are explicitly configurable through other fields in the `ConfigSpec`` object
+  are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
+  in the vSphere API documentation.
 
 - `tools_sync_time` (bool) - Enable time synchronization with the ESXi host where the virtual machine
   is running. Defaults to `false`.
 
-- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual
-  machine power cycle. Defaults to `false`.
+- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
+  power cycle. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1396,14 +1396,39 @@ JSON Example:
 
 <!-- Code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; DO NOT EDIT MANUALLY -->
 
-- `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the vSphere API's
-  [VirtualMachineConfigSpec](https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/8.0.2.0/data-structures/VirtualMachineConfigSpec/)
+- `configuration_parameters` (map[string]string) - A map of key-value pairs to sent to the [`extraConfig`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html#extraConfig).
+  in the vSphere API's `VirtualMachineConfigSpec`.
+  
+  HCL Example:
+  
+  ```hcl
+    configuration_parameters = {
+      "disk.EnableUUID" = "TRUE"
+      "svga.autodetect" = "TRUE"
+      "log.keepOld"     = "15"
+    }
+  ```
+  
+  JSON Example:
+  
+  ```json
+    "configuration_parameters": {
+      "disk.EnableUUID": "TRUE",
+      "svga.autodetect": "TRUE",
+      "log.keepOld": "15"
+    }
+  ```
+  
+  ~> **Note:** Configuration keys that would conflict with parameters that
+  are explicitly configurable through other fields in the `ConfigSpec`` object
+  are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
+  in the vSphere API documentation.
 
 - `tools_sync_time` (bool) - Enable time synchronization with the ESXi host where the virtual machine
   is running. Defaults to `false`.
 
-- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual
-  machine power cycle. Defaults to `false`.
+- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
+  power cycle. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; -->
 

--- a/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -1,12 +1,37 @@
 <!-- Code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; DO NOT EDIT MANUALLY -->
 
-- `configuration_parameters` (map[string]string) - configuration_parameters is a direct passthrough to the vSphere API's
-  [VirtualMachineConfigSpec](https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/8.0.2.0/data-structures/VirtualMachineConfigSpec/)
+- `configuration_parameters` (map[string]string) - A map of key-value pairs to sent to the [`extraConfig`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html#extraConfig).
+  in the vSphere API's `VirtualMachineConfigSpec`.
+  
+  HCL Example:
+  
+  ```hcl
+    configuration_parameters = {
+      "disk.EnableUUID" = "TRUE"
+      "svga.autodetect" = "TRUE"
+      "log.keepOld"     = "15"
+    }
+  ```
+  
+  JSON Example:
+  
+  ```json
+    "configuration_parameters": {
+      "disk.EnableUUID": "TRUE",
+      "svga.autodetect": "TRUE",
+      "log.keepOld": "15"
+    }
+  ```
+  
+  ~> **Note:** Configuration keys that would conflict with parameters that
+  are explicitly configurable through other fields in the `ConfigSpec`` object
+  are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
+  in the vSphere API documentation.
 
 - `tools_sync_time` (bool) - Enable time synchronization with the ESXi host where the virtual machine
   is running. Defaults to `false`.
 
-- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual
-  machine power cycle. Defaults to `false`.
+- `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
+  power cycle. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ConfigParamsConfig struct in builder/vsphere/common/step_config_params.go; -->


### PR DESCRIPTION
### Summary

Updates to the documentation, improvements to logging, and enhancements to error handling in the `vsphere` builder components. The most important changes include adding examples to the documentation, improving logging for configuration parameters, and enhancing error handling during VM reconfiguration.

Documentation Updates:
* [`.web-docs/components/builder/vsphere-clone/README.md`](diffhunk://#diff-259290b43a88f7ba6c250e0f0cd285a8c6b0c063643e34aa78de285d3ef29445L294-R326): Added HCL and JSON examples for `configuration_parameters` and notes on ignored keys.
* [`.web-docs/components/builder/vsphere-iso/README.md`](diffhunk://#diff-6752170ad5617582d4773e4abc3c9a943a0685112b0b5591bd80239ee6aa08deL1399-R1431): Added HCL and JSON examples for `configuration_parameters` and notes on ignored keys.
* [`docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx`](diffhunk://#diff-5449599e1f9a54cee110019d0e1565057bb150a6fc5d06dfe395bd242594f6c9L3-R35): Added HCL and JSON examples for `configuration_parameters` and notes on ignored keys.

Logging Enhancements:
* [`builder/vsphere/common/step_config_params.go`](diffhunk://#diff-70f2c03a7ee2709fd1b221fbb524b93d7e6b91c76d0941089ee01509862e0078R85-R90): Added logging for each key-value pair in `configuration_parameters`.

Error Handling Improvements:
* [`builder/vsphere/driver/vm.go`](diffhunk://#diff-f81447593c9b389c1718a91e14307807b280b36f7c76f64a150637d6faba312bL1301-R1342): Enhanced error messages and added logging for ignored configuration parameters during VM reconfiguration.

### Testing

Configuration:

```hcl
  configuration_parameters = {
    "svga.autodetect"        = "TRUE"
    "logging"                = "FALSE"
    "disk.EnableUUID"        = "TRUE"
    "log.keepOld"            = "15"
    "migrate.encryptionMode" = "required"
  }
```

Log:

```console
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Adding: svga.autodetect = TRUE
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Adding: logging = FALSE
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Adding: disk.EnableUUID = TRUE
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Adding: log.keepOld = 15
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Adding: migrate.encryptionMode = required
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Reconfiguration task completed successfully.
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Ignored the following parameters: [migrate.encryptionMode = required , logging = FALSE]
2024/09/25 19:51:52 packer-plugin-vsphere_v1.4.1-dev_x5.0_darwin_arm64 plugin: 2024/09/25 19:51:52 [INFO] Some configuration keys were ignored due to conflicts with other fields in the ConfigSpec. Refer to VirtualMachineConfigSpec in the vSphere API documentation.
```

### Reference

Ref: #467 
