### PR TITLE
fix: `http_ip` warn vs err

### DIFF
--- a/builder/vsphere/common/http_address.go
+++ b/builder/vsphere/common/http_address.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"fmt"
+	"log"
 	"net"
 )
 
@@ -24,7 +25,7 @@ func ValidateHTTPAddress(httpAddress string) error {
 		return fmt.Errorf("invalid IP address format: %s", httpAddress)
 	}
 	if !IsIPInInterfaces(httpAddress) {
-		return fmt.Errorf("%s is not assigned to an interface", httpAddress)
+		log.Printf("[WARN] %s is not assigned to an interface", httpAddress)
 	}
 	return nil
 }


### PR DESCRIPTION
Updates `ValidateHTTPAddress` to simply log a warning if the `http_ip` is not bound to an interface instead of error.

Closes #474