### PR TITLE
fix: remove nil check

### DIFF
--- a/builder/vsphere/clone/step_customize.go
+++ b/builder/vsphere/clone/step_customize.go
@@ -440,7 +440,7 @@ func (w *WindowsOptions) sysprep() *types.CustomizationSysprep {
 }
 
 func (w *WindowsOptions) guiRunOnce() *types.CustomizationGuiRunOnce {
-	if w.RunOnceCommandList == nil || len(w.RunOnceCommandList) == 0 {
+	if len(w.RunOnceCommandList) == 0 {
 		return &types.CustomizationGuiRunOnce{
 			CommandList: []string{""},
 		}


### PR DESCRIPTION
### Summary

This pull request includes a small change to the `builder/vsphere/clone/step_customize.go` file that removes the nil check for `w.RunOnceCommandList` since `len()` for a `nil` slice is defined as zero. The change simplifies the conditional check

```shell
packer-plugin-vsphere on fix/remove-nil-check  via 🐹 v1.23.2 
➜ staticcheck builder/vsphere/clone/step_customize.go 
builder/vsphere/clone/step_customize.go:443:5: should omit nil check; len() for []string is defined as zero (S1009)
```

```shell
packer-plugin-vsphere on fix/remove-nil-check  via 🐹 v1.23.2 
➜ staticcheck builder/vsphere/clone/step_customize.go

packer-plugin-vsphere on fix/remove-nil-check  [!] via 🐹 v1.23.2 
➜       
```                 
