### PR TITLE
fix: omit comparison to bool constant

### DIFF
--- a/builder/vsphere/supervisor/step_import_image.go
+++ b/builder/vsphere/supervisor/step_import_image.go
@@ -163,7 +163,7 @@ func (s *StepImportImage) validate(ctx context.Context, logger *PackerLogger) er
 }
 
 func (s *StepImportImage) Cleanup(state multistep.StateBag) {
-	if v, ok := state.GetOk(StateKeyImageImportRequestCreated); !ok || v.(bool) == false {
+	if v, ok := state.GetOk(StateKeyImageImportRequestCreated); !ok || !v.(bool) {
 		// Either the image import step was skipped or the object was not created successfully.
 		// Skip deleting the ContentLibraryItemImportRequest object.
 		return


### PR DESCRIPTION
### Summary

Simplifies the condition for checking if the image import request was created.

```shell
➜ staticcheck builder/vsphere/supervisor/step_import_image.go                                             
builder/vsphere/supervisor/step_import_image.go:166:69: should omit comparison to bool constant, can be simplified to !v.(bool) (S1002)
```

```shell
➜ staticcheck builder/vsphere/supervisor/step_import_image.go                                             
➜
```
