### PR TITLE
chore: resolve supervisor-builder lint issue

### DIFF
--- a/builder/vsphere/supervisor/step_create_source.go
+++ b/builder/vsphere/supervisor/step_create_source.go
@@ -216,8 +216,8 @@ func (s *StepCreateSource) initStep(state multistep.StateBag, logger *PackerLogg
 		}
 	} else if importedImageName != "" {
 		// If both are set, the image name specified in the config will be used for the source image.
-		logger.Info(fmt.Sprintf("The configured image with name %s will be used to create the source VirtualMachine object instead of the imported image %s",
-			s.Config.ImageName, importedImageName))
+		logger.Info("The configured image with name %s will be used to create the source VirtualMachine object instead of the imported image %s",
+			s.Config.ImageName, importedImageName)
 	}
 
 	if namespace, ok = state.Get(StateKeySupervisorNamespace).(string); !ok {

--- a/builder/vsphere/supervisor/step_import_image.go
+++ b/builder/vsphere/supervisor/step_import_image.go
@@ -176,8 +176,8 @@ func (s *StepImportImage) Cleanup(state multistep.StateBag) {
 	}
 
 	if !s.ImportImageConfig.KeepImportRequest {
-		logger.Info(fmt.Sprintf("Deleting the ContentLibraryItemImportRequest object %s in namespace %s.",
-			s.ImportImageConfig.ImportRequestName, s.Namespace))
+		logger.Info("Deleting the ContentLibraryItemImportRequest object %s in namespace %s.",
+			s.ImportImageConfig.ImportRequestName, s.Namespace)
 		ctx := context.Background()
 		itemImportReqObj := &imgregv1.ContentLibraryItemImportRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -199,8 +199,8 @@ func (s *StepImportImage) Cleanup(state multistep.StateBag) {
 		}
 
 		// Clean imported image if the image is imported and clean image is set as true.
-		logger.Info(fmt.Sprintf("Deleting the imported ContentLibraryItem object %s in namespace %s.",
-			s.ImportItemResourceName, s.Namespace))
+		logger.Info("Deleting the imported ContentLibraryItem object %s in namespace %s.",
+			s.ImportItemResourceName, s.Namespace)
 		importedImage := &imgregv1.ContentLibraryItem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      s.ImportItemResourceName,


### PR DESCRIPTION
This PR resolves supervisor-builder lint issues reported from the current golangci-lint-action version.