### PR TITLE
fix: `vsphere-clone`: rearrange build steps to ensure source VM exists before deleting target

### DIFF
--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -135,19 +135,20 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 	d := state.Get("driver").(driver.Driver)
 	vmPath := path.Join(s.Location.Folder, s.Location.VMName)
 
-	err := d.PreCleanVM(ui, vmPath, s.Force, s.Location.Cluster, s.Location.Host, s.Location.ResourcePool)
-	if err != nil {
-		state.Put("error", err)
-		return multistep.ActionHalt
-	}
-
-	ui.Say("Cloning virtual machine...")
+	ui.Say("Finding virtual machine to clone...")
 	template, err := d.FindVM(s.Config.Template)
 	if err != nil {
 		state.Put("error", fmt.Errorf("error finding virtual machine to clone: %s", err))
 		return multistep.ActionHalt
 	}
 
+	err = d.PreCleanVM(ui, vmPath, s.Force, s.Location.Cluster, s.Location.Host, s.Location.ResourcePool)
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+
+	ui.Say("Cloning virtual machine...")
 	var disks []driver.Disk
 	for _, disk := range s.Config.StorageConfig.Storage {
 		disks = append(disks, driver.Disk{

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -159,6 +159,11 @@ func TestStepCreateVM_Run(t *testing.T) {
 		t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", multistep.ActionContinue, action)
 	}
 
+	// Find VM
+	if !driverMock.FindVMCalled {
+		t.Fatalf("unexpected result: expected '%s' to be called", "FindVM")
+	}
+
 	// Pre clean VM
 	if !driverMock.PreCleanVMCalled {
 		t.Fatalf("unexpected result: expected '%s' to be called", "PreCleanVM")
@@ -170,13 +175,10 @@ func TestStepCreateVM_Run(t *testing.T) {
 		t.Fatalf("unexpected result: expected '%s', but returned '%s'", vmPath, driverMock.PreCleanVMPath)
 	}
 
-	if !driverMock.FindVMCalled {
-		t.Fatalf("unexpected result: expected '%s' to be called", "FindVM")
-	}
+	// Clone VM
 	if !vmMock.CloneCalled {
 		t.Fatalf("unexpected result: expected '%s' to be called", "Clone")
 	}
-
 	if diff := cmp.Diff(vmMock.CloneConfig, driverCreateConfig(step.Config, step.Location)); diff != "" {
 		t.Fatalf("unexpected result: '%s'", diff)
 	}


### PR DESCRIPTION
### Summary
This PR addresses an issue in the `vsphere-clone` builder where using the `-force` flag can lead to unintentional deletion of the target VM, which may result in the loss of critical data if the target VM is the only copy of a virtual machine. 

### Issue description
Currently, when the `-force` flag is specified, the `vsphere-clone` builder first deletes the target VM before verifying that the source VM to be cloned exists. If the source VM is missing, this process leaves users without a VM to clone and potentially results in data loss.

### Use case
In our environment, Packer is used to perform regular updates on legacy virtual machine templates. These templates are unique, lack proper build configurations, and cannot be easily replicated. If, for any reason, human intervention results in running `packer build` with the `-force` flag, there is a significant risk of losing irreplaceable data.

### Testing
Testing was performed to confirm:
1. Source VM existence is verified before any deletion action on the target VM.
2. With the `-force` flag, the target VM is only deleted if a source VM exists.

### Related issues

- Closes #490