### PR TITLE
chore: driver godoc

### DIFF
--- a/builder/vsphere/driver/cluster.go
+++ b/builder/vsphere/driver/cluster.go
@@ -10,6 +10,9 @@ type Cluster struct {
 	cluster *object.ClusterComputeResource
 }
 
+// FindCluster locates a cluster within the vCenter environment by its name.
+// Returns a Cluster object or an error if not found or if the retrieval
+// process fails.
 func (d *VCenterDriver) FindCluster(name string) (*Cluster, error) {
 	c, err := d.finder.ClusterComputeResource(d.ctx, name)
 	if err != nil {

--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -22,10 +22,12 @@ type StorageConfig struct {
 	Storage            []Disk
 }
 
+// AddStorageDevices adds virtual storage devices to an existing device list
+// based on the configuration. Adds a new controller for each controller type
+// specified in the configuration and adds virtual disks to the controller.
 func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	newDevices := object.VirtualDeviceList{}
 
-	// Create new controller based on existing devices list and add it to the new devices list.
 	var controllers []types.BaseVirtualController
 	for _, controllerType := range c.DiskControllerType {
 		var device types.BaseVirtualDevice
@@ -71,7 +73,8 @@ func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceLi
 	return newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
 }
 
-// Returns the first virtual disk found in the devices list.
+// findDisk scans a list of virtual devices and retrieves a single virtual disk
+// if exactly one is found.  Returns an error if no disk or multiple disks are found.
 // TODO: Add support for multiple disks.
 func findDisk(devices object.VirtualDeviceList) (*types.VirtualDisk, error) {
 	var disks []*types.VirtualDisk
@@ -90,6 +93,6 @@ func findDisk(devices object.VirtualDeviceList) (*types.VirtualDisk, error) {
 		// Single disk found.
 		return disks[0], nil
 	}
-	// More than one disk found.
+	// Multiple disks found.
 	return nil, errors.New("more than one virtual disk found, only a single disk is allowed")
 }

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -134,10 +134,7 @@ func (d *VCenterDriver) Cleanup() (error, error) {
 	return d.restClient.client.Logout(d.ctx), d.client.SessionManager.Logout(d.ctx)
 }
 
-// The rest.Client requires vCenter.
-// RestClient is to modularize the rest.Client session and use it only when is necessary.
-// This will allow users without vCenter Server to use the other features that do not use the rest.Client.
-// To use the client login/logout must be done to create an authenticated session.
+// RestClient manages RESTful interactions with vCenter, handling client initialization and credential storage.
 type RestClient struct {
 	client      *rest.Client
 	credentials *url.Userinfo

--- a/builder/vsphere/driver/folder.go
+++ b/builder/vsphere/driver/folder.go
@@ -26,9 +26,12 @@ func (d *VCenterDriver) NewFolder(ref *types.ManagedObjectReference) *Folder {
 	}
 }
 
+// FindFolder locates or creates a folder structure within a datastore based
+// on the provided folder name. Returns a pointer to the Folder object or an
+// error if the operation fails.
 func (d *VCenterDriver) FindFolder(name string) (*Folder, error) {
 	if name != "" {
-		// create folders if they don't exist
+		// If the folder does not exist, create it.
 		parent := ""
 		parentFolder, err := d.finder.Folder(d.ctx, path.Join(d.datacenter.InventoryPath, "vm"))
 		if err != nil {
@@ -59,6 +62,8 @@ func (d *VCenterDriver) FindFolder(name string) (*Folder, error) {
 	}, nil
 }
 
+// Info retrieves properties of the folder object with optional filters specified
+// as parameters. If no parameters are provided, all properties are returned.
 func (f *Folder) Info(params ...string) (*mo.Folder, error) {
 	var p []string
 	if len(params) == 0 {
@@ -74,6 +79,8 @@ func (f *Folder) Info(params ...string) (*mo.Folder, error) {
 	return &info, nil
 }
 
+// Path constructs and returns the full hierarchical path of the folder,
+// starting from the datacenter level or an error.
 func (f *Folder) Path() (string, error) {
 	info, err := f.Info("name", "parent")
 	if err != nil {

--- a/builder/vsphere/driver/host.go
+++ b/builder/vsphere/driver/host.go
@@ -14,6 +14,8 @@ type Host struct {
 	host   *object.HostSystem
 }
 
+// NewHost creates and initializes a new Host object using a
+// ManagedObjectReference and the VCenterDriver instance.
 func (d *VCenterDriver) NewHost(ref *types.ManagedObjectReference) *Host {
 	return &Host{
 		host:   object.NewHostSystem(d.client.Client, *ref),
@@ -21,6 +23,8 @@ func (d *VCenterDriver) NewHost(ref *types.ManagedObjectReference) *Host {
 	}
 }
 
+// FindHost locates a host within the vCenter environment by its name. Returns
+// a Host object or an error if not found or if the retrieval process fails.
 func (d *VCenterDriver) FindHost(name string) (*Host, error) {
 	h, err := d.finder.HostSystem(d.ctx, name)
 	if err != nil {
@@ -32,6 +36,8 @@ func (d *VCenterDriver) FindHost(name string) (*Host, error) {
 	}, nil
 }
 
+// Info retrieves properties of the host object with optional filters specified
+// as parameters. If no parameters are provided, all properties are returned.
 func (h *Host) Info(params ...string) (*mo.HostSystem, error) {
 	var p []string
 	if len(params) == 0 {

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -17,6 +17,8 @@ type Library struct {
 	library *library.Library
 }
 
+// FindContentLibraryByName retrieves a content library by its name. Returns a
+// Library object or an error if the library is not found.
 func (d *VCenterDriver) FindContentLibraryByName(name string) (*Library, error) {
 	lm := library.NewManager(d.restClient.client)
 	l, err := lm.GetLibraryByName(d.ctx, name)
@@ -29,6 +31,9 @@ func (d *VCenterDriver) FindContentLibraryByName(name string) (*Library, error) 
 	}, nil
 }
 
+// FindContentLibraryItem retrieves a content library item by its name within
+// the specified library ID.  Returns the library item if found or an error if
+// the item is not found or the retrieval process fails.
 func (d *VCenterDriver) FindContentLibraryItem(libraryId string, name string) (*library.Item, error) {
 	lm := library.NewManager(d.restClient.client)
 	items, err := lm.GetLibraryItems(d.ctx, libraryId)
@@ -43,6 +48,10 @@ func (d *VCenterDriver) FindContentLibraryItem(libraryId string, name string) (*
 	return nil, fmt.Errorf("content library item %s not found", name)
 }
 
+// FindContentLibraryItemUUID retrieves the UUID of a content library item
+//
+//	based on the given library ID and item name. Returns the UUID if found or
+//	an error if the item is not found or the retrieval process fails.
 func (d *VCenterDriver) FindContentLibraryItemUUID(libraryId string, name string) (string, error) {
 	item, err := d.FindContentLibraryItem(libraryId, name)
 	if err != nil {
@@ -51,6 +60,10 @@ func (d *VCenterDriver) FindContentLibraryItemUUID(libraryId string, name string
 	return item.ID, nil
 }
 
+// FindContentLibraryFileDatastorePath checks if the provided ISO path belongs
+// to a content library and retrieves its datastore path. Returns the datastore
+// path if the ISO path is a content library path or an error if the path is
+// not identified as a content library path or if the retrieval process fails.
 func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (string, error) {
 	log.Printf("Check if ISO path is a Content Library path")
 	err := d.restClient.Login(d.ctx)
@@ -98,6 +111,8 @@ func (d *VCenterDriver) FindContentLibraryFileDatastorePath(isoPath string) (str
 	return path.Join(libItemDir, isoFilePath), nil
 }
 
+// UpdateContentLibraryItem updates the metadata of a content library item,
+// such as its name and description. Returns an error if the update fails.
 func (d *VCenterDriver) UpdateContentLibraryItem(item *library.Item, name string, description string) error {
 	lm := library.NewManager(d.restClient.client)
 	item.Patch(&library.Item{
@@ -112,6 +127,8 @@ type LibraryFilePath struct {
 	path string
 }
 
+// Validate checks the format of the LibraryFilePath and returns an error if
+// the path is not in the expected format.
 func (l *LibraryFilePath) Validate() error {
 	l.path = strings.TrimLeft(l.path, "/")
 	parts := strings.Split(l.path, "/")
@@ -121,14 +138,17 @@ func (l *LibraryFilePath) Validate() error {
 	return nil
 }
 
+// GetLibraryName retrieves the library name from the content library file path.
 func (l *LibraryFilePath) GetLibraryName() string {
 	return strings.Split(l.path, "/")[0]
 }
 
+// GetLibraryItemName retrieves the library item name from the content library file path.
 func (l *LibraryFilePath) GetLibraryItemName() string {
 	return strings.Split(l.path, "/")[1]
 }
 
+// GetFileName retrieves the file name from the content library file path.
 func (l *LibraryFilePath) GetFileName() string {
 	return strings.Split(l.path, "/")[2]
 }

--- a/builder/vsphere/driver/network.go
+++ b/builder/vsphere/driver/network.go
@@ -16,6 +16,8 @@ type Network struct {
 	network object.NetworkReference
 }
 
+// NewNetwork creates and initializes a new Network object using the provided
+// ManagedObjectReference.
 func (d *VCenterDriver) NewNetwork(ref *types.ManagedObjectReference) *Network {
 	return &Network{
 		network: object.NewNetwork(d.client.Client, *ref),
@@ -23,6 +25,8 @@ func (d *VCenterDriver) NewNetwork(ref *types.ManagedObjectReference) *Network {
 	}
 }
 
+// FindNetwork locates a network by its name within the vCenter context.
+// Returns a Network object or an error if the network is not found.
 func (d *VCenterDriver) FindNetwork(name string) (*Network, error) {
 	n, err := d.finder.Network(d.ctx, name)
 	if err != nil {
@@ -34,6 +38,8 @@ func (d *VCenterDriver) FindNetwork(name string) (*Network, error) {
 	}, nil
 }
 
+// FindNetworks retrieves a list of networks in the vCenter matching the
+// provided name and returns them as Network objects.
 func (d *VCenterDriver) FindNetworks(name string) ([]*Network, error) {
 	ns, err := d.finder.NetworkList(d.ctx, name)
 	if err != nil {
@@ -49,6 +55,9 @@ func (d *VCenterDriver) FindNetworks(name string) ([]*Network, error) {
 	return networks, nil
 }
 
+// Info retrieves the properties of the network object with optional filters
+// specified as parameters. If no parameters are provided, all properties are
+// returned.
 func (n *Network) Info(params ...string) (*mo.Network, error) {
 	var p []string
 	if len(params) == 0 {
@@ -75,6 +84,7 @@ type MultipleNetworkFoundError struct {
 	append string
 }
 
+// Error returns a formatted error message for the MultipleNetworkFoundError.
 func (e *MultipleNetworkFoundError) Error() string {
 	return fmt.Sprintf("'%s' resolves to more than one network name; %s", e.path, e.append)
 }

--- a/builder/vsphere/driver/resource_pool.go
+++ b/builder/vsphere/driver/resource_pool.go
@@ -18,6 +18,8 @@ type ResourcePool struct {
 	driver *VCenterDriver
 }
 
+// NewResourcePool creates and returns a new ResourcePool object using the
+// provided ManagedObjectReference.
 func (d *VCenterDriver) NewResourcePool(ref *types.ManagedObjectReference) *ResourcePool {
 	return &ResourcePool{
 		pool:   object.NewResourcePool(d.client.Client, *ref),
@@ -25,6 +27,10 @@ func (d *VCenterDriver) NewResourcePool(ref *types.ManagedObjectReference) *Reso
 	}
 }
 
+// FindResourcePool locates a resource pool by its name within a specified
+// cluster or host context in vCenter. It falls back to the default resource
+// pool or a vApp if the specified pool is not found. Returns a ResourcePool
+// object or an error if neither the specified nor default pool is accessible.
 func (d *VCenterDriver) FindResourcePool(cluster string, host string, name string) (*ResourcePool, error) {
 	var res string
 	if cluster != "" {
@@ -39,7 +45,6 @@ func (d *VCenterDriver) FindResourcePool(cluster string, host string, name strin
 		log.Printf("[WARN] %s not found. Looking for default resource pool.", resourcePath)
 		dp, dperr := d.finder.DefaultResourcePool(d.ctx)
 		if _, ok := dperr.(*find.NotFoundError); ok {
-			// VirtualApp extends ResourcePool, so it should support VirtualApp types.
 			vapp, verr := d.finder.VirtualApp(d.ctx, name)
 			if verr != nil {
 				return nil, err
@@ -57,6 +62,9 @@ func (d *VCenterDriver) FindResourcePool(cluster string, host string, name strin
 	}, nil
 }
 
+// Info retrieves the properties of the ResourcePool object with optional
+// filters specified as parameters. If no parameters are provided, all
+// properties are returned.
 func (p *ResourcePool) Info(params ...string) (*mo.ResourcePool, error) {
 	var params2 []string
 	if len(params) == 0 {
@@ -72,6 +80,9 @@ func (p *ResourcePool) Info(params ...string) (*mo.ResourcePool, error) {
 	return &info, nil
 }
 
+// Path returns the full hierarchical path of the ResourcePool or an empty
+// string if it's a top-level entity. It recursively resolves the parent's
+// path until reaching the root or a top-level parent.
 func (p *ResourcePool) Path() (string, error) {
 	poolInfo, err := p.Info("name", "parent")
 	if err != nil {

--- a/builder/vsphere/driver/vm_cdrom.go
+++ b/builder/vsphere/driver/vm_cdrom.go
@@ -14,11 +14,16 @@ var (
 	ErrNoSataController = errors.New("no available SATA controller")
 )
 
+// AddSATAController adds a new SATA controller to the virtual machine configuration.
+// Returns an error if the operation fails.
 func (vm *VirtualMachineDriver) AddSATAController() error {
 	sata := &types.VirtualAHCIController{}
 	return vm.addDevice(sata)
 }
 
+// FindSATAController searches and returns the first available SATA controller
+// for the virtual machine. Returns an error if no SATA controller is found or
+// if there is an issue obtaining the devices.
 func (vm *VirtualMachineDriver) FindSATAController() (*types.VirtualAHCIController, error) {
 	l, err := vm.Devices()
 	if err != nil {
@@ -33,6 +38,11 @@ func (vm *VirtualMachineDriver) FindSATAController() (*types.VirtualAHCIControll
 	return c.(*types.VirtualAHCIController), nil
 }
 
+// CreateCdrom creates a new virtual CD-ROM device and attaches it to the
+// specified virtual controller. It initializes the CD-ROM with default
+// connectable settings, allowing guest control and automatic connection.
+// Returns the created VirtualCdrom object or an error if the devices cannot
+// be retrieved or assigned.
 func (vm *VirtualMachineDriver) CreateCdrom(c *types.VirtualController) (*types.VirtualCdrom, error) {
 	l, err := vm.Devices()
 	if err != nil {
@@ -56,6 +66,8 @@ func (vm *VirtualMachineDriver) CreateCdrom(c *types.VirtualController) (*types.
 	return device, nil
 }
 
+// RemoveCdroms removes all virtual CD-ROM drives and associated SATA
+// controllers from the virtual machine configuration.
 func (vm *VirtualMachineDriver) RemoveCdroms() error {
 	devices, err := vm.Devices()
 	if err != nil {
@@ -96,6 +108,8 @@ func (vm *VirtualMachineDriver) RemoveNCdroms(n int) error {
 	return nil
 }
 
+// EjectCdroms removes all attached CD-ROM devices from the virtual machine by
+// resetting their backing and connection information.
 func (vm *VirtualMachineDriver) EjectCdroms() error {
 	cdroms, err := vm.CdromDevices()
 	if err != nil {

--- a/builder/vsphere/driver/vm_keyboard.go
+++ b/builder/vsphere/driver/vm_keyboard.go
@@ -16,6 +16,9 @@ type KeyInput struct {
 	Shift    bool
 }
 
+// TypeOnKeyboard sends a sequence of USB scan code events to simulate keyboard
+// typing on a virtual machine. The input parameter specifies the USB HID
+// scancode and key modifiers like Ctrl, Alt, and Shift.
 func (vm *VirtualMachineDriver) TypeOnKeyboard(input KeyInput) (int32, error) {
 	var spec types.UsbScanCodeSpec
 


### PR DESCRIPTION
### Description

Adds or updates the Go Doc comments for the driver functions.

```shell
packer-plugin-vsphere on  chore/driver-godoc [!] via 🐹 v1.23.5 
➜ go fmt ./...

packer-plugin-vsphere on  chore/driver-godoc [!] via 🐹 v1.23.5 took 33.2s 
➜ make generate
2025/01/26 14:22:21 Copying "docs" to ".docs/"
2025/01/26 14:22:21 Replacing @include '...' calls in .docs/
Compiling MDX docs in '.docs' to Markdown in '.web-docs'...

packer-plugin-vsphere on  chore/driver-godoc [!] via 🐹 v1.23.5 
➜ make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils[no test files]
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone       1.521s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common      3.187s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.178s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.710s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   5.762s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.602s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.018s
```