### PR TITLE
[wip] refactor: simplify access to methods/fields via direct calls

### DIFF
--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -45,9 +45,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config: &b.config.ConnectConfig,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -57,7 +57,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&StepCloneVM{
 			Config:   &b.config.CloneConfig,
 			Location: &b.config.LocationConfig,
-			Force:    b.config.PackerConfig.PackerForce,
+			Force:    b.config.PackerForce,
 		},
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,
@@ -97,7 +97,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 		// Set the address for the HTTP server based on the configuration
 		// provided by the user.
-		if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
+		if addrs := b.config.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
 			// Use the specified HTTPAddress, if valid.
 			err := common.ValidateHTTPAddress(addrs)
 			if err != nil {
@@ -105,14 +105,14 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 				return nil, err
 			}
 			state.Put("http_bind_address", addrs)
-		} else if intf := b.config.HTTPConfig.HTTPInterface; intf != "" {
+		} else if intf := b.config.HTTPInterface; intf != "" {
 			// Use the specified HTTPInterface, if valid.
 			state.Put("http_interface", intf)
 		} else {
 			// Use IP discovery if neither is specified.
 			steps = append(steps, &common.StepHTTPIPDiscover{
-				HTTPIP:  b.config.BootConfig.HTTPIP,
-				Network: b.config.WaitIpConfig.GetIPNet(),
+				HTTPIP:  b.config.HTTPIP,
+				Network: b.config.GetIPNet(),
 			})
 		}
 

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -31,8 +31,8 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	conf := new(Config)
 	warns, err := conf.Prepare(raw)
 	testConfigOk(t, warns, err)
-	if conf.ShutdownConfig.Timeout != 3*time.Minute {
-		t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.ShutdownConfig.Timeout)
+	if conf.Timeout != 3*time.Minute {
+		t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.Timeout)
 	}
 }
 

--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -17,7 +17,7 @@ func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
 		WindowsSysPrepFile: "path-to-file",
 		WindowsSysPrepText: "text",
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 
@@ -44,7 +44,7 @@ func TestWindowsSysprepFilePrintsWarning(t *testing.T) {
 	config := &CustomizeConfig{
 		WindowsSysPrepFile: "path-to-file",
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 
@@ -81,7 +81,7 @@ func TestWindowsSysprepTextSetsContent(t *testing.T) {
 	config := &CustomizeConfig{
 		WindowsSysPrepText: text,
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -492,7 +492,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 	vmRef, ok := info.Result.(types.ManagedObjectReference)
 	if !ok {
 		log.Printf("[ERROR] unexpected result during cloning operation: %s", info.Result)
-		return nil, fmt.Errorf("error occured while cloning the virtual machine")
+		return nil, fmt.Errorf("error occurred while cloning the virtual machine")
 	}
 
 	created := vm.driver.NewVM(&vmRef)

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -67,9 +67,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoteCachePath:      b.config.RemoteCachePath,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -83,7 +83,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&StepCreateVM{
 			Config:   &b.config.CreateConfig,
 			Location: &b.config.LocationConfig,
-			Force:    b.config.PackerConfig.PackerForce,
+			Force:    b.config.PackerForce,
 		},
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,
@@ -113,7 +113,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	// Set the address for the HTTP server based on the configuration
 	// provided by the user.
-	if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
+	if addrs := b.config.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
 		// Validate and use the specified HTTPAddress.
 		err := common.ValidateHTTPAddress(addrs)
 		if err != nil {
@@ -121,15 +121,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			return nil, err
 		}
 		state.Put("http_bind_address", addrs)
-	} else if intf := b.config.HTTPConfig.HTTPInterface; intf != "" {
+	} else if intf := b.config.HTTPInterface; intf != "" {
 		// Use the specified HTTPInterface.
 		state.Put("http_interface", intf)
 	} else {
 		// Use IP discovery if neither HTTPAddress nor HTTPInterface
 		// is specified.
 		steps = append(steps, &common.StepHTTPIPDiscover{
-			HTTPIP:  b.config.BootConfig.HTTPIP,
-			Network: b.config.WaitIpConfig.GetIPNet(),
+			HTTPIP:  b.config.HTTPIP,
+			Network: b.config.GetIPNet(),
 		})
 	}
 

--- a/builder/vsphere/supervisor/builder.go
+++ b/builder/vsphere/supervisor/builder.go
@@ -60,7 +60,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	)
 
 	// conditionally add steps to validate import spec and import images from source URL as VM image.
-	if b.config.ImportImageConfig.ImportSourceURL != "" {
+	if b.config.ImportSourceURL != "" {
 		steps = append(steps,
 			&StepImportImage{
 				ImportImageConfig: &b.config.ImportImageConfig,


### PR DESCRIPTION
Refactored multiple instances where methods or fields were accessed through an intermediate field. These have been simplified to use direct access where applicable.

Interestingly there is an linting error only with the CI but it's running an older version of `golangci-lint`.

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/simplify-intermediate-access]
golangci-lint run
0 issues.

~/Downloads/packer-plugin-vsphere git:[refactor/simplify-intermediate-access]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/simplify-intermediate-access]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/simplify-intermediate-access]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.660s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.840s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.159s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.468s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   6.277s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.730s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.321s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```