### PR TITLE
refactor: remove redundant type

### DIFF
--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -17,7 +17,7 @@ func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
 		WindowsSysPrepFile: "path-to-file",
 		WindowsSysPrepText: "text",
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 
@@ -44,7 +44,7 @@ func TestWindowsSysprepFilePrintsWarning(t *testing.T) {
 	config := &CustomizeConfig{
 		WindowsSysPrepFile: "path-to-file",
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 
@@ -81,7 +81,7 @@ func TestWindowsSysprepTextSetsContent(t *testing.T) {
 	config := &CustomizeConfig{
 		WindowsSysPrepText: text,
 		NetworkInterfaces: []NetworkInterface{
-			NetworkInterface{},
+			{},
 		},
 	}
 


### PR DESCRIPTION
Removes redundant type.

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/remove-redundant-type]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/remove-redundant-type]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/remove-redundant-type]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.770s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.931s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.469s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.513s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   6.534s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.449s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      1.994s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```