### PR TITLE
refactor: use nil slice declaration

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -1371,7 +1371,7 @@ func (vm *VirtualMachineDriver) AddConfigParams(params map[string]string, info *
 		}
 
 		// Check for ignored parameters.
-		ignoredParams := []string{}
+		var ignoredParams []string
 		for k, v := range params {
 			found := false
 			for _, option := range moVM.Config.ExtraConfig {
@@ -1500,7 +1500,7 @@ func (vm *VirtualMachineDriver) FindContentLibraryTemplateDatastoreName(library 
 		vm.logout()
 		return nil, err
 	}
-	datastores := []string{}
+	var datastores []string
 	for _, storage := range l.library.Storage {
 		name, err := vm.driver.GetDatastoreName(storage.DatastoreID)
 		if err != nil {


### PR DESCRIPTION
Replaces empty slice declaration with nil slice declaration.

An empty slice can be represented by nil or an empty slice literal. They are functionally equivalent — their len and cap are both zero — but the nil slice is the preferred style. 

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/use-nil-slice-declaration]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/use-nil-slice-declaration]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/use-nil-slice-declaration]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.772s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.930s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.366s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.566s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   7.545s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.964s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      3.561s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```