### PR TITLE
refactor: omit type declaration

### DIFF
--- a/post-processor/vsphere/post-processor.go
+++ b/post-processor/vsphere/post-processor.go
@@ -30,7 +30,7 @@ const DefaultMaxRetries = 5
 const DefaultDiskMode = "thick"
 const OvftoolWindows = "ovftool.exe"
 
-var ovftool string = "ovftool"
+var ovftool = "ovftool"
 
 var (
 	// Regular expression to validate RFC1035 hostnames from full fqdn or simple hostname.


### PR DESCRIPTION
Removed variable type declaration inferred by the compiler.

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/omit-type-declaration]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/omit-type-declaration]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/omit-type-declaration]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.721s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.885s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.483s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.503s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   6.291s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.790s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.323s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]

~/Downloads/packer-plugin-vsphere git:[refactor/omit-type-declaration]
golangci-lint run           
0 issues:
```