### PR TITLE
refactor: exported functions with unexported return types

### DIFF
--- a/post-processor/vsphere-template/step_create_snapshot.go
+++ b/post-processor/vsphere-template/step_create_snapshot.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vmware/govmomi"
 )
 
-type stepCreateSnapshot struct {
+type StepCreateSnapshot struct {
 	VMName              string
 	RemoteFolder        string
 	SnapshotName        string
@@ -21,7 +21,7 @@ type stepCreateSnapshot struct {
 	SnapshotEnable      bool
 }
 
-func NewStepCreateSnapshot(artifact packersdk.Artifact, p *PostProcessor) *stepCreateSnapshot {
+func NewStepCreateSnapshot(artifact packersdk.Artifact, p *PostProcessor) *StepCreateSnapshot {
 	// Set the default folder.
 	remoteFolder := "Discovered virtual machine"
 	vmname := artifact.Id()
@@ -32,7 +32,7 @@ func NewStepCreateSnapshot(artifact packersdk.Artifact, p *PostProcessor) *stepC
 		vmname = id[2]
 	}
 
-	return &stepCreateSnapshot{
+	return &StepCreateSnapshot{
 		VMName:              vmname,
 		RemoteFolder:        remoteFolder,
 		SnapshotEnable:      p.config.SnapshotEnable,
@@ -41,7 +41,7 @@ func NewStepCreateSnapshot(artifact packersdk.Artifact, p *PostProcessor) *stepC
 	}
 }
 
-func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	cli := state.Get("client").(*govmomi.Client)
 	dcPath := state.Get("dcPath").(string)
@@ -75,4 +75,4 @@ func (s *stepCreateSnapshot) Run(ctx context.Context, state multistep.StateBag) 
 	return multistep.ActionContinue
 }
 
-func (s *stepCreateSnapshot) Cleanup(multistep.StateBag) {}
+func (s *StepCreateSnapshot) Cleanup(multistep.StateBag) {}

--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -19,14 +19,14 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 )
 
-type stepMarkAsTemplate struct {
+type StepMarkAsTemplate struct {
 	VMName       string
 	TemplateName string
 	RemoteFolder string
 	ReregisterVM config.Trilean
 }
 
-func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepMarkAsTemplate {
+func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *StepMarkAsTemplate {
 	// Set the default folder.
 	remoteFolder := "Discovered virtual machine"
 
@@ -43,7 +43,7 @@ func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepM
 		vmname = id[2]
 	}
 
-	return &stepMarkAsTemplate{
+	return &StepMarkAsTemplate{
 		VMName:       vmname,
 		TemplateName: p.config.TemplateName,
 		RemoteFolder: remoteFolder,
@@ -51,7 +51,7 @@ func NewStepMarkAsTemplate(artifact packersdk.Artifact, p *PostProcessor) *stepM
 	}
 }
 
-func (s *stepMarkAsTemplate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepMarkAsTemplate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	cli := state.Get("client").(*govmomi.Client)
 	folder := state.Get("folder").(*object.Folder)
@@ -193,4 +193,4 @@ func unregisterPreviousVM(cli *govmomi.Client, folder *object.Folder, name strin
 	return nil
 }
 
-func (s *stepMarkAsTemplate) Cleanup(multistep.StateBag) {}
+func (s *StepMarkAsTemplate) Cleanup(multistep.StateBag) {}


### PR DESCRIPTION
TL;DR: Export the return type for exported functions.

Refactors the naming conventions for struct types and their associated methods in the `post-processor/vsphere-template` package to improve consistency and align with Go naming standards. The changes involve renaming private struct types to exported ones and updating all related method signatures accordingly.

* The `stepCreateSnapshot` struct has been renamed to `StepCreateSnapshot`, making it an exported type. All associated methods (`NewStepCreateSnapshot`, `Run`, and `Cleanup`) have been updated to reflect this change. [[1]](diffhunk://#diff-96ba201a7b3dc867f393bfeb954034b5e257131b0d2b737e5a741d96dd877219L16-R24) [[2]](diffhunk://#diff-96ba201a7b3dc867f393bfeb954034b5e257131b0d2b737e5a741d96dd877219L35-R35) [[3]](diffhunk://#diff-96ba201a7b3dc867f393bfeb954034b5e257131b0d2b737e5a741d96dd877219L44-R44) [[4]](diffhunk://#diff-96ba201a7b3dc867f393bfeb954034b5e257131b0d2b737e5a741d96dd877219L78-R78)
* The `stepMarkAsTemplate` struct has been renamed to `StepMarkAsTemplate`, making it an exported type. All associated methods (`NewStepMarkAsTemplate`, `Run`, and `Cleanup`) have been updated to reflect this change. [[1]](diffhunk://#diff-90daccde26d091676affc4a2d9fb7904e389a9c8f0989c31e8d1951a20034db6L22-R29) [[2]](diffhunk://#diff-90daccde26d091676affc4a2d9fb7904e389a9c8f0989c31e8d1951a20034db6L46-R54) [[3]](diffhunk://#diff-90daccde26d091676affc4a2d9fb7904e389a9c8f0989c31e8d1951a20034db6L196-R196)

```shell
~/Downloads/packer-plugin-vsphere git:[fix/export-return-types]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[fix/export-return-types]
make build

~/Downloads/packer-plugin-vsphere git:[fix/export-return-types]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.670s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.602s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.059s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.206s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   7.246s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.668s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      3.229s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```