### PR TITLE
refactor: replace type assertion on errors

### DIFF
--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -4,6 +4,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"regexp"
@@ -117,7 +118,8 @@ func (ds *DatastoreDriver) Info(params ...string) (*mo.Datastore, error) {
 // DirExists checks if a directory exists in a datastore.
 func (ds *DatastoreDriver) DirExists(filepath string) bool {
 	_, err := ds.ds.Stat(ds.driver.ctx, filepath)
-	if _, ok := err.(object.DatastoreNoSuchDirectoryError); ok {
+	var datastoreNoSuchDirectoryError object.DatastoreNoSuchDirectoryError
+	if errors.As(err, &datastoreNoSuchDirectoryError) {
 		return false
 	}
 	return true

--- a/builder/vsphere/driver/folder.go
+++ b/builder/vsphere/driver/folder.go
@@ -4,6 +4,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -41,7 +42,8 @@ func (d *VCenterDriver) FindFolder(name string) (*Folder, error) {
 		for _, folder := range folders {
 			parent = path.Join(parent, folder)
 			f, err := d.finder.Folder(d.ctx, path.Join(d.datacenter.InventoryPath, "vm", parent))
-			if _, ok := err.(*find.NotFoundError); ok {
+			var notFoundError *find.NotFoundError
+			if errors.As(err, &notFoundError) {
 				f, err = parentFolder.CreateFolder(d.ctx, folder)
 			}
 			if err != nil {

--- a/builder/vsphere/driver/resource_pool.go
+++ b/builder/vsphere/driver/resource_pool.go
@@ -4,6 +4,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -44,14 +45,13 @@ func (d *VCenterDriver) FindResourcePool(cluster string, host string, name strin
 	if err != nil {
 		log.Printf("[WARN] %s not found. Looking for default resource pool.", resourcePath)
 		dp, dperr := d.finder.DefaultResourcePool(d.ctx)
-		if _, ok := dperr.(*find.NotFoundError); ok {
+		var notFoundError *find.NotFoundError
+		if errors.As(dperr, &notFoundError) {
 			vapp, verr := d.finder.VirtualApp(d.ctx, name)
 			if verr != nil {
 				return nil, err
 			}
 			dp = vapp.ResourcePool
-		} else if dperr != nil {
-			return nil, err
 		}
 		p = dp
 	}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -170,7 +170,8 @@ func (d *VCenterDriver) FindVM(name string) (VirtualMachine, error) {
 func (d *VCenterDriver) PreCleanVM(ui packersdk.Ui, vmPath string, force bool, vsphereCluster string, vsphereHost string, vsphereResourcePool string) error {
 	vm, err := d.FindVM(vmPath)
 	if err != nil {
-		if _, ok := err.(*find.NotFoundError); !ok {
+		var notFoundError *find.NotFoundError
+		if !errors.As(err, &notFoundError) {
 			return fmt.Errorf("error looking up existing virtual machine: %v", err)
 		}
 	}


### PR DESCRIPTION
Replaces type assertion on errors with a call to `errors.As`.

The preferred way for checking for a specific error type is to use the `errors.As` function from the standard library as this function traverses the chain of the wrapped errors while checking for a specific error type.

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/replaces-type-assertion]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/replaces-type-assertion]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/replaces-type-assertion]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.702s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       3.275s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.996s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.439s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   6.217s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.157s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      1.675s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```