### PR TITLE
chore(gh): bump golangci-lint to v1.60.1

### DIFF
--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -51,7 +51,7 @@ jobs:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b # v5.0.0
         with:
-          version: v1.54.2
+          version: v1.60.1
           only-new-issues: true
   check-fmt:
     needs:


### PR DESCRIPTION
Bumps golangci-lint to v1.60.1.
