### PR TITLE
chore: update golangci-lint to v2

### DIFF
--- a/.github/workflows/go-validate.yml
+++ b/.github/workflows/go-validate.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Determine Go version'
         id: get-go-version
         run: |
@@ -34,8 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Go Mod Tidy
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: go mod tidy
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-      - uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b # v5.0.0
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.60.1
+          version: latest
           only-new-issues: true
   check-fmt:
     needs:
@@ -59,8 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Gofmt check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |
@@ -77,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate check
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
       - run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,42 +1,43 @@
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-# For more information about the golangci-lint configuration file, refer to:
-# https://golangci-lint.run/usage/configuration/
-
-issues:
-  exclude-rules:
-    # Exclude staticcheck for some rules.
-    - linters: [staticcheck]
-      text: "SA1006|SA1019|SA4006|SA4010|SA4017|SA5007|SA6005|SA9004"
-    # Exclude line length linter for generated files.
-    - linters: [lll]
-      source: "^//go:generate "
-
+---
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unconvert
     - unused
-
-run:
-  concurrency: 4
-  timeout: 10m
-  exclude-files:
-    - ".*\\.hcl2spec\\.go$"
-
-output:
-  formats:
-    - format: colored-line-number
-
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - "fmt:.*"
-      - "io:Close"
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt:.*
+        - io:Close
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: SA1006|SA1019|SA4006|SA4010|SA4017|SA5007|SA6005|SA9004
+      - linters:
+          - lll
+        source: '^//go:generate '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -45,9 +45,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config: &b.config.ConnectConfig,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -57,7 +57,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&StepCloneVM{
 			Config:   &b.config.CloneConfig,
 			Location: &b.config.LocationConfig,
-			Force:    b.config.PackerConfig.PackerForce,
+			Force:    b.config.PackerForce,
 		},
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,
@@ -97,7 +97,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 		// Set the address for the HTTP server based on the configuration
 		// provided by the user.
-		if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
+		if addrs := b.config.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
 			// Use the specified HTTPAddress, if valid.
 			err := common.ValidateHTTPAddress(addrs)
 			if err != nil {
@@ -105,14 +105,14 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 				return nil, err
 			}
 			state.Put("http_bind_address", addrs)
-		} else if intf := b.config.HTTPConfig.HTTPInterface; intf != "" {
+		} else if intf := b.config.HTTPInterface; intf != "" {
 			// Use the specified HTTPInterface, if valid.
 			state.Put("http_interface", intf)
 		} else {
 			// Use IP discovery if neither is specified.
 			steps = append(steps, &common.StepHTTPIPDiscover{
-				HTTPIP:  b.config.BootConfig.HTTPIP,
-				Network: b.config.WaitIpConfig.GetIPNet(),
+				HTTPIP:  b.config.HTTPIP,
+				Network: b.config.GetIPNet(),
 			})
 		}
 

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -31,8 +31,8 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	conf := new(Config)
 	warns, err := conf.Prepare(raw)
 	testConfigOk(t, warns, err)
-	if conf.ShutdownConfig.Timeout != 3*time.Minute {
-		t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.ShutdownConfig.Timeout)
+	if conf.Timeout != 3*time.Minute {
+		t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.Timeout)
 	}
 }
 

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -115,14 +115,10 @@ func (ds *DatastoreDriver) Info(params ...string) (*mo.Datastore, error) {
 	return &info, nil
 }
 
-// DirExists checks if a directory exists in a datastore.
 func (ds *DatastoreDriver) DirExists(filepath string) bool {
 	_, err := ds.ds.Stat(ds.driver.ctx, filepath)
 	var datastoreNoSuchDirectoryError object.DatastoreNoSuchDirectoryError
-	if errors.As(err, &datastoreNoSuchDirectoryError) {
-		return false
-	}
-	return true
+	return !errors.As(err, &datastoreNoSuchDirectoryError)
 }
 
 // FileExists checks if a file exists in a datastore.

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -67,9 +67,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			RemoteCachePath:      b.config.RemoteCachePath,
 		},
 		&commonsteps.StepCreateCD{
-			Files:   b.config.CDConfig.CDFiles,
-			Content: b.config.CDConfig.CDContent,
-			Label:   b.config.CDConfig.CDLabel,
+			Files:   b.config.CDFiles,
+			Content: b.config.CDContent,
+			Label:   b.config.CDLabel,
 		},
 		&common.StepRemoteUpload{
 			Datastore:                  b.config.Datastore,
@@ -83,7 +83,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&StepCreateVM{
 			Config:   &b.config.CreateConfig,
 			Location: &b.config.LocationConfig,
-			Force:    b.config.PackerConfig.PackerForce,
+			Force:    b.config.PackerForce,
 		},
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,
@@ -113,7 +113,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	// Set the address for the HTTP server based on the configuration
 	// provided by the user.
-	if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
+	if addrs := b.config.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
 		// Validate and use the specified HTTPAddress.
 		err := common.ValidateHTTPAddress(addrs)
 		if err != nil {
@@ -121,15 +121,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			return nil, err
 		}
 		state.Put("http_bind_address", addrs)
-	} else if intf := b.config.HTTPConfig.HTTPInterface; intf != "" {
+	} else if intf := b.config.HTTPInterface; intf != "" {
 		// Use the specified HTTPInterface.
 		state.Put("http_interface", intf)
 	} else {
 		// Use IP discovery if neither HTTPAddress nor HTTPInterface
 		// is specified.
 		steps = append(steps, &common.StepHTTPIPDiscover{
-			HTTPIP:  b.config.BootConfig.HTTPIP,
-			Network: b.config.WaitIpConfig.GetIPNet(),
+			HTTPIP:  b.config.HTTPIP,
+			Network: b.config.GetIPNet(),
 		})
 	}
 

--- a/builder/vsphere/supervisor/builder.go
+++ b/builder/vsphere/supervisor/builder.go
@@ -60,7 +60,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	)
 
 	// conditionally add steps to validate import spec and import images from source URL as VM image.
-	if b.config.ImportImageConfig.ImportSourceURL != "" {
+	if b.config.ImportSourceURL != "" {
 		steps = append(steps,
 			&StepImportImage{
 				ImportImageConfig: &b.config.ImportImageConfig,


### PR DESCRIPTION
Updates `golangci-lint` to v2 (`latest`).

- Migrated the configuration.
- Updates the `golangci/golangci-lint-action` to v7 for interoperability.
- Addresses existing linting issues.

```shell
~/Downloads/packer-plugin-vsphere git:[main]
golangci-lint migrate
WARN The configuration comments are not migrated. 
WARN Details about the migration: https://golangci-lint.run/product/migration-guide/ 
╭───────────────────────────────────────────────────────────────────────────╮
│                                                                           │
│                               We need you!                                │
│                                                                           │
│ Donations help fund the ongoing development and maintenance of this tool. │
│  If golangci-lint has been useful to you, please consider contributing.   │
│                                                                           │
│                  Donate now: https://donate.golangci.org                  │
│                                                                           │
╰───────────────────────────────────────────────────────────────────────────╯
~/Downloads/packer-plugin-vsphere git:[main]
golangci-lint run
builder/vsphere/clone/builder.go:48:22: QF1008: could remove embedded field "CDConfig" from selector (staticcheck)
                        Files:   b.config.CDConfig.CDFiles,
                                          ^
builder/vsphere/clone/builder.go:49:22: QF1008: could remove embedded field "CDConfig" from selector (staticcheck)
                        Content: b.config.CDConfig.CDContent,
                                          ^
builder/vsphere/clone/builder.go:50:22: QF1008: could remove embedded field "CDConfig" from selector (staticcheck)
                        Label:   b.config.CDConfig.CDLabel,
                                          ^
builder/vsphere/clone/builder.go:60:23: QF1008: could remove embedded field "PackerConfig" from selector (staticcheck)
                        Force:    b.config.PackerConfig.PackerForce,
                                           ^
builder/vsphere/clone/builder.go:100:24: QF1008: could remove embedded field "HTTPConfig" from selector (staticcheck)
                if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
                                     ^
builder/vsphere/clone/builder.go:108:30: QF1008: could remove embedded field "HTTPConfig" from selector (staticcheck)
                } else if intf := b.config.HTTPConfig.HTTPInterface; intf != "" {
                                           ^
builder/vsphere/clone/builder.go:114:23: QF1008: could remove embedded field "BootConfig" from selector (staticcheck)
                                HTTPIP:  b.config.BootConfig.HTTPIP,
                                                  ^
builder/vsphere/clone/builder.go:115:23: QF1008: could remove embedded field "WaitIpConfig" from selector (staticcheck)
                                Network: b.config.WaitIpConfig.GetIPNet(),
                                                  ^
builder/vsphere/clone/config_test.go:34:10: QF1008: could remove embedded field "ShutdownConfig" from selector (staticcheck)
        if conf.ShutdownConfig.Timeout != 3*time.Minute {
                ^
builder/vsphere/clone/config_test.go:35:72: QF1008: could remove embedded field "ShutdownConfig" from selector (staticcheck)
                t.Fatalf("unexpected result: expected '3m', but returned '%v'", conf.ShutdownConfig.Timeout)
                                                                                     ^
builder/vsphere/driver/datastore.go:122:2: S1008: should use 'return !errors.As(err, &datastoreNoSuchDirectoryError)' instead of 'if errors.As(err, &datastoreNoSuchDirectoryError) { return false }; return true' (staticcheck)
        if errors.As(err, &datastoreNoSuchDirectoryError) {
        ^
builder/vsphere/iso/builder.go:86:23: QF1008: could remove embedded field "PackerConfig" from selector (staticcheck)
                        Force:    b.config.PackerConfig.PackerForce,
                                           ^
builder/vsphere/iso/builder.go:116:23: QF1008: could remove embedded field "HTTPConfig" from selector (staticcheck)
        if addrs := b.config.HTTPConfig.HTTPAddress; addrs != "" && addrs != common.DefaultHttpBindAddress {
                             ^
builder/vsphere/iso/builder.go:131:22: QF1008: could remove embedded field "BootConfig" from selector (staticcheck)
                        HTTPIP:  b.config.BootConfig.HTTPIP,
                                          ^
builder/vsphere/iso/builder.go:132:22: QF1008: could remove embedded field "WaitIpConfig" from selector (staticcheck)
                        Network: b.config.WaitIpConfig.GetIPNet(),
                                          ^
builder/vsphere/supervisor/builder.go:63:14: QF1008: could remove embedded field "ImportImageConfig" from selector (staticcheck)
        if b.config.ImportImageConfig.ImportSourceURL != "" {
                    ^
16 issues:
* staticcheck: 16

~/Downloads/packer-plugin-vsphere git:[main]
golangci-lint run --fix
builder/vsphere/driver/datastore.go:122:2: S1008: should use 'return !errors.As(err, &datastoreNoSuchDirectoryError)' instead of 'if errors.As(err, &datastoreNoSuchDirectoryError) { return false }; return true' (staticcheck)
        if errors.As(err, &datastoreNoSuchDirectoryError) {
        ^
1 issues:
* staticcheck: 1

~/Downloads/packer-plugin-vsphere git:[main]
golangci-lint run
0 issues.

~/Downloads/packer-plugin-vsphere git:[main]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[main]
make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Downloads/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.4.3-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vsphere git:[main]
make build

~/Downloads/packer-plugin-vsphere git:[main]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.709s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       4.467s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       8.048s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.331s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   6.200s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.561s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.171s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
```