### PR TITLE
fix: type assertion on errors

### DIFF
--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -117,8 +117,8 @@ func (ds *DatastoreDriver) Info(params ...string) (*mo.Datastore, error) {
 
 func (ds *DatastoreDriver) DirExists(filepath string) bool {
 	_, err := ds.ds.Stat(ds.driver.ctx, filepath)
-	var datastoreNoSuchDirectoryError object.DatastoreNoSuchDirectoryError
-	return !errors.As(err, &datastoreNoSuchDirectoryError)
+	var notFoundError *object.DatastoreNoSuchDirectoryError
+	return !errors.As(err, &notFoundError)
 }
 
 // FileExists checks if a file exists in a datastore.


### PR DESCRIPTION
Fix the type assertion on errors to use the `*object.DatastoreNoSuchDirectoryError` pointer.

Follow-up to #530.

```shell
~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Downloads/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.4.3-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
make build

~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.479s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       5.289s
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       10.115s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  3.462s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   8.429s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       2.988s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      3.777s
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]

~/Downloads/packer-plugin-vsphere git:[fix/type-assertion-on-errors]
golangci-lint run
0 issues.
```