### PR TITLE
refactor: use `log.Fatal` for fatal error handling in `main`

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone"
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso"
@@ -27,7 +25,6 @@ func main() {
 	pps.SetVersion(version.PluginVersion)
 	err := pps.Run()
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Refactor fatal error handling in the main function to use `log.Fatal`.

Previously, fatal errors were handled by printing to os.Stderr using `fmt.Fprintln` followed by an explicit `os.Exit(1)`.This change replaces that pattern with a single call to `log.Fatal(err)`. This is more idiomatic Go, makes the code more concise, and leverages the standard log package's capabilities, such as automatic timestamping of the error message. The program's exit behavior (exiting with status 1 on fatal error) remains the same.

```shell
~/Downloads/packer-plugin-vsphere git:[refactor/standardize-fatal-error-handling]
go fmt ./...

~/Downloads/packer-plugin-vsphere git:[refactor/standardize-fatal-error-handling]
make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Downloads/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v1.4.3-dev_x5.0_darwin_amd64

~/Downloads/packer-plugin-vsphere git:[refactor/standardize-fatal-error-handling]
make build

~/Downloads/packer-plugin-vsphere git:[refactor/standardize-fatal-error-handling]
make test
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        2.518s
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       7.563s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       12.648s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  4.505s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   11.146s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       3.065s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      6.042s
```