### PR TITLE
chore: bump to v2.0.0-dev

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	Version           = "1.4.3"
+	Version           = "2.0.0"
 	VersionPrerelease = "dev"
 	VersionMetadata   = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)


### PR DESCRIPTION
Updates to v2.0.0-dev.

Ref: #501

```shell
packer-plugin-vsphere on  chore/prepare-v2.0.0-dev via 🐹 v1.23.8 
➜ make build

packer-plugin-vsphere on  chore/prepare-v2.0.0-dev via 🐹 v1.23.8 took 27.5s 
➜ make dev
packer plugins install --path packer-plugin-vsphere "github.com/hashicorp/vsphere"
Successfully installed plugin github.com/hashicorp/vsphere from /Users/johnsonryan/Downloads/packer-plugin-vsphere/packer-plugin-vsphere to /Users/johnsonryan/.packer.d/plugins/github.com/hashicorp/vsphere/packer-plugin-vsphere_v2.0.0-dev_x5.0_darwin_amd64

```