### PR TITLE
refactor: set `NestedHVEnabled` only when requested or `true`

### DIFF
--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -608,7 +608,9 @@ func (vm *VirtualMachineDriver) Configure(config *HardwareConfig) error {
 	confSpec.MemoryAllocation = &ramSpec
 
 	confSpec.MemoryReservationLockedToMax = &config.RAMReserveAll
-	confSpec.NestedHVEnabled = &config.NestedHV
+	if config.NestedHV {
+		confSpec.NestedHVEnabled = &config.NestedHV
+	}
 
 	confSpec.CpuHotAddEnabled = &config.CpuHotAddEnabled
 	confSpec.MemoryHotAddEnabled = &config.MemoryHotAddEnabled


### PR DESCRIPTION
### Description

Currently, the vsphere-iso builder always sets the NestedHVEnabled ConfSpec on the modify request when
building a VM. This increases required permissions for building image due to the server rejecting with missing permissions. (I have not had time yet to determine the exact required additional permission grant.)

Determining this was excessively difficult, please consider adding the equivalent of the 'client_debug' option that exists in the terraform vsphere provider to dump the actual requests that are submitted.

### Resolved Issues

NA

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

This reduces required permissions in vcenter to perform a build as a side effect, but otherwise no change.