### PR TITLE
[wip] feat: add iso path validation

### DIFF
--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -90,7 +90,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.FlagConfig.Prepare(&c.HardwareConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
-	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig)...)
+	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig, nil)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CDConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)

--- a/builder/vsphere/common/step_add_cdrom.go
+++ b/builder/vsphere/common/step_add_cdrom.go
@@ -10,10 +10,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver"
+	"github.com/vmware/govmomi/object"
 )
 
 type CDRomConfig struct {
@@ -59,8 +61,133 @@ type StepAddCDRom struct {
 	Config *CDRomConfig
 }
 
-func (c *CDRomConfig) Prepare(k *ReattachCDRomConfig) []error {
+// validateISOPaths validates that all ISO files specified in ISOPaths exist on their respective datastores.
+func (c *CDRomConfig) validateISOPaths(d driver.Driver) []error {
 	var errs []error
+
+	if len(c.ISOPaths) == 0 {
+		return errs
+	}
+
+	if d == nil {
+		errs = append(errs, fmt.Errorf("driver is not available for ISO validation"))
+		return errs
+	}
+
+	for _, isoPath := range c.ISOPaths {
+		if strings.TrimSpace(isoPath) == "" {
+			errs = append(errs, fmt.Errorf("ISO path cannot be empty or whitespace-only"))
+			continue
+		}
+
+		if err := c.validateContentLibraryPath(isoPath, d); err == nil {
+			continue
+		} else {
+			if strings.Contains(err.Error(), "content library") && !strings.Contains(err.Error(), "not a content library path format") {
+				errs = append(errs, err)
+				continue
+			}
+		}
+
+		if err := c.validateDatastorePath(isoPath, d); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+// validateDatastorePath validates a datastore ISO path format and file existence.
+func (c *CDRomConfig) validateDatastorePath(isoPath string, d driver.Driver) error {
+	dsIsoPath := driver.NewDatastoreIsoPath(isoPath)
+
+	if !dsIsoPath.Validate() {
+		return fmt.Errorf("invalid datastore path format: '%s'", isoPath)
+	}
+
+	dsPath := object.DatastorePath{}
+	if !dsPath.FromString(isoPath) {
+		return fmt.Errorf("unable to parse datastore path: '%s'", isoPath)
+	}
+
+	datastore, err := d.FindDatastore(dsPath.Datastore, "")
+	if err != nil {
+		return fmt.Errorf("unable to access datastore '%s' for ISO validation: %s", dsPath.Datastore, err)
+	}
+
+	if datastore == nil {
+		return fmt.Errorf("datastore '%s' returned nil reference during ISO validation", dsPath.Datastore)
+	}
+
+	filePath := dsIsoPath.GetFilePath()
+	if !datastore.FileExists(filePath) {
+		return fmt.Errorf("ISO file not found: '%s'", isoPath)
+	}
+
+	return nil
+}
+
+// validateContentLibraryPath validates a content library ISO path format and file existence.
+func (c *CDRomConfig) validateContentLibraryPath(isoPath string, d driver.Driver) error {
+	pathParts := strings.Split(strings.TrimLeft(isoPath, "/"), "/")
+	if len(pathParts) != 3 {
+		return fmt.Errorf("not a content library path format")
+	}
+	for i, part := range pathParts {
+		if strings.TrimSpace(part) == "" {
+			switch i {
+			case 0:
+				return fmt.Errorf("content library name cannot be empty in path: '%s'", isoPath)
+			case 1:
+				return fmt.Errorf("content library item name cannot be empty in path: '%s'", isoPath)
+			case 2:
+				return fmt.Errorf("content library file name cannot be empty in path: '%s'", isoPath)
+			}
+		}
+	}
+
+	datastorePath, err := d.FindContentLibraryFileDatastorePath(isoPath)
+	if err != nil {
+		errorMsg := err.Error()
+		if strings.Contains(errorMsg, "not found") {
+			if strings.Contains(errorMsg, "library") {
+				return fmt.Errorf("content library not found: '%s'", pathParts[0])
+			}
+			if strings.Contains(errorMsg, "item") {
+				return fmt.Errorf("content library item not found: '%s' in library '%s'", pathParts[1], pathParts[0])
+			}
+		}
+		if strings.Contains(errorMsg, "not identified as a Content Library path") {
+			return fmt.Errorf("invalid content library path format: '%s'", isoPath)
+		}
+		if strings.Contains(errorMsg, "connection") || strings.Contains(errorMsg, "timeout") || strings.Contains(errorMsg, "network") {
+			return fmt.Errorf("unable to connect to vCenter for content library validation: %s", err)
+		}
+		return fmt.Errorf("content library path resolution failed for '%s': %s", isoPath, err)
+	}
+
+	if strings.TrimSpace(datastorePath) == "" {
+		return fmt.Errorf("content library path resolution returned empty datastore path for '%s'", isoPath)
+	}
+
+	if datastorePath != isoPath {
+		if err := c.validateDatastorePath(datastorePath, d); err != nil {
+			return fmt.Errorf("content library file validation failed for '%s' (resolved to '%s'): %s", isoPath, datastorePath, err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("content library path resolution did not return a datastore path for '%s'", isoPath)
+}
+
+func (c *CDRomConfig) Prepare(k *ReattachCDRomConfig, d driver.Driver) []error {
+	var errs []error
+
+	if len(c.ISOPaths) > 0 && d != nil {
+		if validationErrs := c.validateISOPaths(d); len(validationErrs) > 0 {
+			errs = append(errs, validationErrs...)
+		}
+	}
 
 	// `cdrom_type` must be either 'ide' or 'sata'.
 	if c.CdromType != "" && c.CdromType != "ide" && c.CdromType != "sata" {
@@ -80,6 +207,21 @@ func (c *CDRomConfig) Prepare(k *ReattachCDRomConfig) []error {
 func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	vm := state.Get("vm").(driver.VirtualMachine)
+	if d, ok := state.GetOk("driver"); ok && len(s.Config.ISOPaths) > 0 {
+		if driver, driverOk := d.(driver.Driver); driverOk {
+			if validationErrs := s.Config.validateISOPaths(driver); len(validationErrs) > 0 {
+				var errMsg string
+				for i, err := range validationErrs {
+					if i > 0 {
+						errMsg += "; "
+					}
+					errMsg += err.Error()
+				}
+				state.Put("error", fmt.Errorf("ISO validation failed: %s", errMsg))
+				return multistep.ActionHalt
+			}
+		}
+	}
 
 	if s.Config.CdromType == "sata" {
 		if _, err := vm.FindSATAController(); err != nil {
@@ -97,12 +239,9 @@ func (s *StepAddCDRom) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	if path, ok := state.GetOk("iso_remote_path"); ok {
-		// The order matters: docs say "iso_url" should go first, so make sure
-		// to prepend it.
 		s.Config.ISOPaths = append([]string{path.(string)}, s.Config.ISOPaths...)
 	}
 
-	// Add our custom CD, if it exists.
 	if cdPath, _ := state.Get("cd_path").(string); cdPath != "" {
 		s.Config.ISOPaths = append(s.Config.ISOPaths, cdPath)
 	}

--- a/builder/vsphere/common/step_add_cdrom_test.go
+++ b/builder/vsphere/common/step_add_cdrom_test.go
@@ -6,6 +6,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,8 +17,7 @@ import (
 )
 
 func TestCDRomConfig_Prepare(t *testing.T) {
-	// Data validation
-	tc := []struct {
+	tests := []struct {
 		name           string
 		config         *CDRomConfig
 		keepConfig     *ReattachCDRomConfig
@@ -25,7 +25,7 @@ func TestCDRomConfig_Prepare(t *testing.T) {
 		expectedErrMsg string
 	}{
 		{
-			name:           "Should not fail for empty config",
+			name:           "Empty config",
 			config:         new(CDRomConfig),
 			keepConfig:     new(ReattachCDRomConfig),
 			fail:           false,
@@ -54,25 +54,27 @@ func TestCDRomConfig_Prepare(t *testing.T) {
 		},
 	}
 
-	for _, c := range tc {
-		errs := c.config.Prepare(c.keepConfig)
-		if c.fail {
-			if len(errs) == 0 {
-				t.Fatal("unexpected success: expected failure")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.config.Prepare(tt.keepConfig, nil)
+			if tt.fail {
+				if len(errs) == 0 {
+					t.Fatal("Expected error but got none")
+				}
+				if errs[0].Error() != tt.expectedErrMsg {
+					t.Fatalf("Expected error '%s', got '%s'", tt.expectedErrMsg, errs[0])
+				}
+			} else {
+				if len(errs) != 0 {
+					t.Fatalf("Expected no error but got: %s", errs[0])
+				}
 			}
-			if errs[0].Error() != c.expectedErrMsg {
-				t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
-			}
-		} else {
-			if len(errs) != 0 {
-				t.Fatalf("unexpected failure: expected success, but failed: %s", errs[0])
-			}
-		}
+		})
 	}
 }
 
 func TestStepAddCDRom_Run(t *testing.T) {
-	tc := []struct {
+	tests := []struct {
 		name           string
 		state          *multistep.BasicStateBag
 		step           *StepAddCDRom
@@ -205,26 +207,26 @@ func TestStepAddCDRom_Run(t *testing.T) {
 		},
 	}
 
-	for _, c := range tc {
-		t.Run(c.name, func(t *testing.T) {
-			c.state.Put("vm", c.vmMock)
-			if action := c.step.Run(context.TODO(), c.state); action != c.expectedAction {
-				t.Fatalf("unexpected action: expected '%#v', but returned '%#v'", c.expectedAction, action)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.state.Put("vm", tt.vmMock)
+			if action := tt.step.Run(context.TODO(), tt.state); action != tt.expectedAction {
+				t.Fatalf("Expected action '%#v', got '%#v'", tt.expectedAction, action)
 			}
-			err, ok := c.state.Get("error").(error)
+			err, ok := tt.state.Get("error").(error)
 			if ok {
-				if err.Error() != c.errMessage {
-					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.errMessage, err)
+				if err.Error() != tt.errMessage {
+					t.Fatalf("Expected error '%s', got '%s'", tt.errMessage, err)
 				}
 			} else {
-				if c.fail {
-					t.Fatal("unexpected success: expected failure")
+				if tt.fail {
+					t.Fatal("Expected error but got none")
 				}
 			}
 
-			if diff := cmp.Diff(c.vmMock, c.expectedVmMock,
+			if diff := cmp.Diff(tt.vmMock, tt.expectedVmMock,
 				cmpopts.IgnoreInterfaces(struct{ error }{})); diff != "" {
-				t.Fatalf("unexpected result: %s", diff)
+				t.Fatalf("Unexpected VM mock state: %s", diff)
 			}
 		})
 	}
@@ -241,4 +243,1338 @@ func isoRemotePathStateBag() *multistep.BasicStateBag {
 	state := basicStateBag(nil)
 	state.Put("iso_remote_path", "remote/path")
 	return state
+}
+
+func TestCDRomConfig_ValidateISOPaths(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *CDRomConfig
+		driverMock     *driver.DriverMock
+		expectedErrors []string
+	}{
+		{
+			name: "Empty ISO paths",
+			config: &CDRomConfig{
+				ISOPaths: []string{},
+			},
+			driverMock:     driver.NewDriverMock(),
+			expectedErrors: []string{},
+		},
+		{
+			name: "Valid datastore path - file exists",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[datastore1] iso/ubuntu.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "Valid datastore path - file does not exist",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[datastore1] iso/ubuntu.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{"ISO file not found: '[datastore1] iso/ubuntu.iso'"},
+		},
+		{
+			name: "Invalid datastore path format",
+			config: &CDRomConfig{
+				ISOPaths: []string{"invalid-path-format"},
+			},
+			driverMock:     driver.NewDriverMock(),
+			expectedErrors: []string{"unable to parse datastore path: 'invalid-path-format'"},
+		},
+		{
+			name: "Datastore not found",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[nonexistent] iso/ubuntu.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore not found"),
+			},
+			expectedErrors: []string{"unable to access datastore 'nonexistent' for ISO validation: datastore not found"},
+		},
+		{
+			name: "Valid content library path - resolves successfully",
+			config: &CDRomConfig{
+				ISOPaths: []string{"Library/Item/file.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{},
+		},
+		{
+			name: "Content library path - library not found",
+			config: &CDRomConfig{
+				ISOPaths: []string{"NonexistentLibrary/Item/file.iso"},
+			},
+			driverMock:     &driver.DriverMock{},
+			expectedErrors: []string{"content library not found: 'NonexistentLibrary'"},
+		},
+		{
+			name: "Empty or whitespace-only path",
+			config: &CDRomConfig{
+				ISOPaths: []string{"", "   ", "\t\n"},
+			},
+			driverMock: driver.NewDriverMock(),
+			expectedErrors: []string{
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+			},
+		},
+		{
+			name: "Multiple paths with mixed results",
+			config: &CDRomConfig{
+				ISOPaths: []string{
+					"[datastore1] iso/valid.iso",
+					"[datastore1] iso/missing.iso",
+					"",
+					"invalid-format",
+				},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false, // Will be used for both paths
+				},
+			},
+			expectedErrors: []string{
+				"ISO file not found: '[datastore1] iso/valid.iso'",
+				"ISO file not found: '[datastore1] iso/missing.iso'",
+				"ISO path cannot be empty or whitespace-only",
+				"unable to parse datastore path: 'invalid-format'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.driverMock != nil {
+				for _, isoPath := range tt.config.ISOPaths {
+					parts := strings.Split(strings.TrimLeft(isoPath, "/"), "/")
+					if len(parts) == 3 {
+						if parts[0] == "NonexistentLibrary" {
+							tt.driverMock.FindContentLibraryFileDatastorePathErr = fmt.Errorf("library not found")
+						} else {
+							tt.driverMock.FindContentLibraryFileDatastorePathReturn = "[datastore1] resolved/path.iso"
+						}
+					}
+				}
+			}
+
+			errors := tt.config.validateISOPaths(tt.driverMock)
+
+			if len(errors) != len(tt.expectedErrors) {
+				t.Fatalf("Expected %d errors, got %d: %v", len(tt.expectedErrors), len(errors), errors)
+			}
+
+			for i, expectedErr := range tt.expectedErrors {
+				if i >= len(errors) {
+					t.Fatalf("Expected error %d: '%s', but got no error", i, expectedErr)
+				}
+				if !strings.Contains(errors[i].Error(), expectedErr) {
+					t.Errorf("Expected error %d to contain '%s', got '%s'", i, expectedErr, errors[i].Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ValidateDatastorePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *CDRomConfig
+		isoPath     string
+		driverMock  *driver.DriverMock
+		expectedErr string
+		shouldFail  bool
+	}{
+		{
+			name:    "Valid datastore path with existing file",
+			config:  &CDRomConfig{},
+			isoPath: "[datastore1] iso/ubuntu.iso",
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			shouldFail: false,
+		},
+		{
+			name:    "Valid datastore path with missing file",
+			config:  &CDRomConfig{},
+			isoPath: "[datastore1] iso/missing.iso",
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErr: "ISO file not found: '[datastore1] iso/missing.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Invalid datastore path format",
+			config:      &CDRomConfig{},
+			isoPath:     "invalid-format",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "unable to parse datastore path: 'invalid-format'",
+			shouldFail:  true,
+		},
+		{
+			name:    "Datastore not found",
+			config:  &CDRomConfig{},
+			isoPath: "[nonexistent] iso/file.iso",
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore 'nonexistent' not found"),
+			},
+			expectedErr: "unable to access datastore 'nonexistent' for ISO validation",
+			shouldFail:  true,
+		},
+		{
+			name:        "Datastore path without brackets",
+			config:      &CDRomConfig{},
+			isoPath:     "iso/ubuntu.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "unable to parse datastore path: 'iso/ubuntu.iso'",
+			shouldFail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validateDatastorePath(tt.isoPath, tt.driverMock)
+
+			if tt.shouldFail {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error to contain '%s', got '%s'", tt.expectedErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ValidateContentLibraryPath(t *testing.T) {
+	tests := []struct {
+		name                string
+		config              *CDRomConfig
+		isoPath             string
+		driverMock          *driver.DriverMock
+		mockResolvedPath    string
+		mockResolutionError error
+		mockFileExists      bool
+		expectedErr         string
+		shouldFail          bool
+	}{
+		{
+			name:             "Valid content library path - successful resolution and file exists",
+			config:           &CDRomConfig{},
+			isoPath:          "MyLibrary/UbuntuItem/ubuntu.iso",
+			mockResolvedPath: "[datastore1] resolved/ubuntu.iso",
+			mockFileExists:   true,
+			shouldFail:       false,
+		},
+		{
+			name:                "Content library not found",
+			config:              &CDRomConfig{},
+			isoPath:             "NonexistentLibrary/Item/file.iso",
+			mockResolutionError: fmt.Errorf("library not found"),
+			expectedErr:         "content library not found: 'NonexistentLibrary'",
+			shouldFail:          true,
+		},
+		{
+			name:                "Content library item not found",
+			config:              &CDRomConfig{},
+			isoPath:             "MyLibrary/NonexistentItem/file.iso",
+			mockResolutionError: fmt.Errorf("item not found"),
+			expectedErr:         "content library item not found: 'NonexistentItem' in library 'MyLibrary'",
+			shouldFail:          true,
+		},
+		{
+			name:        "Invalid content library path format - too few parts",
+			config:      &CDRomConfig{},
+			isoPath:     "Library/Item",
+			expectedErr: "not a content library path format",
+			shouldFail:  true,
+		},
+		{
+			name:        "Invalid content library path format - too many parts",
+			config:      &CDRomConfig{},
+			isoPath:     "Library/Item/File/Extra",
+			expectedErr: "not a content library path format",
+			shouldFail:  true,
+		},
+		{
+			name:             "Content library path resolves but file doesn't exist",
+			config:           &CDRomConfig{},
+			isoPath:          "MyLibrary/Item/missing.iso",
+			mockResolvedPath: "[datastore1] resolved/missing.iso",
+			mockFileExists:   false,
+			expectedErr:      "content library file validation failed",
+			shouldFail:       true,
+		},
+		{
+			name:             "Content library path resolution returns same path",
+			config:           &CDRomConfig{},
+			isoPath:          "MyLibrary/Item/file.iso",
+			mockResolvedPath: "MyLibrary/Item/file.iso", // Same as input
+			expectedErr:      "content library path resolution did not return a datastore path",
+			shouldFail:       true,
+		},
+		{
+			name:                "Generic content library resolution error",
+			config:              &CDRomConfig{},
+			isoPath:             "MyLibrary/Item/file.iso",
+			mockResolutionError: fmt.Errorf("generic resolution error"),
+			expectedErr:         "content library path resolution failed",
+			shouldFail:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driverMock := driver.NewDriverMock()
+			if tt.driverMock != nil {
+				driverMock = tt.driverMock
+			}
+
+			if driverMock.DatastoreMock == nil {
+				driverMock.DatastoreMock = &driver.DatastoreMock{}
+			}
+			driverMock.DatastoreMock.FileExistsReturn = tt.mockFileExists
+			if tt.mockResolutionError != nil {
+				driverMock.FindContentLibraryFileDatastorePathErr = tt.mockResolutionError
+			} else if tt.mockResolvedPath != "" {
+				driverMock.FindContentLibraryFileDatastorePathReturn = tt.mockResolvedPath
+			} else {
+				driverMock.FindContentLibraryFileDatastorePathErr = fmt.Errorf("not identified as a Content Library path")
+			}
+
+			err := tt.config.validateContentLibraryPath(tt.isoPath, driverMock)
+
+			if tt.shouldFail {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error to contain '%s', got '%s'", tt.expectedErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ValidateContentLibraryPath_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *CDRomConfig
+		isoPath     string
+		driverMock  *driver.DriverMock
+		expectedErr string
+		shouldFail  bool
+	}{
+		{
+			name:    "Connection timeout",
+			config:  &CDRomConfig{},
+			isoPath: "Library/Item/file.iso",
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathErr: fmt.Errorf("connection timeout"),
+			},
+			expectedErr: "unable to connect to vCenter for content library validation: connection timeout",
+			shouldFail:  true,
+		},
+		{
+			name:    "Network error",
+			config:  &CDRomConfig{},
+			isoPath: "Library/Item/file.iso",
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathErr: fmt.Errorf("network unreachable"),
+			},
+			expectedErr: "unable to connect to vCenter for content library validation: network unreachable",
+			shouldFail:  true,
+		},
+		{
+			name:    "Returns empty string",
+			config:  &CDRomConfig{},
+			isoPath: "Library/Item/file.iso",
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathReturn: "",
+			},
+			expectedErr: "content library path resolution returned empty datastore path for 'Library/Item/file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:    "Returns whitespace only string",
+			config:  &CDRomConfig{},
+			isoPath: "Library/Item/file.iso",
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathReturn: "   \t\n   ",
+			},
+			expectedErr: "content library path resolution returned empty datastore path for 'Library/Item/file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Empty item name",
+			config:      &CDRomConfig{},
+			isoPath:     "Library//file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "content library item name cannot be empty in path: 'Library//file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Empty file name",
+			config:      &CDRomConfig{},
+			isoPath:     "Library/Item/",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "content library file name cannot be empty in path: 'Library/Item/'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Whitespace only library name",
+			config:      &CDRomConfig{},
+			isoPath:     "   /Item/file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "content library name cannot be empty in path: '   /Item/file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Whitespace only item name",
+			config:      &CDRomConfig{},
+			isoPath:     "Library/   /file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "content library item name cannot be empty in path: 'Library/   /file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Whitespace only file name",
+			config:      &CDRomConfig{},
+			isoPath:     "Library/Item/   ",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "content library file name cannot be empty in path: 'Library/Item/   '",
+			shouldFail:  true,
+		},
+		{
+			name:        "Not content library format",
+			config:      &CDRomConfig{},
+			isoPath:     "/Item/file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "not a content library path format",
+			shouldFail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validateContentLibraryPath(tt.isoPath, tt.driverMock)
+
+			if tt.shouldFail {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error to contain '%s', got '%s'", tt.expectedErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ErrorMessageFormatting(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *CDRomConfig
+		driverMock     *driver.DriverMock
+		expectedFormat string
+	}{
+		{
+			name: "Datastore file not found error format",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[datastore1] iso/ubuntu.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedFormat: "ISO file not found: '[datastore1] iso/ubuntu.iso'",
+		},
+		{
+			name: "Datastore access error format",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[nonexistent] iso/ubuntu.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore not found"),
+			},
+			expectedFormat: "unable to access datastore 'nonexistent' for ISO validation: datastore not found",
+		},
+		{
+			name: "Invalid path format error",
+			config: &CDRomConfig{
+				ISOPaths: []string{"invalid-format"},
+			},
+			driverMock:     driver.NewDriverMock(),
+			expectedFormat: "unable to parse datastore path: 'invalid-format'",
+		},
+		{
+			name: "Empty path error format",
+			config: &CDRomConfig{
+				ISOPaths: []string{""},
+			},
+			driverMock:     driver.NewDriverMock(),
+			expectedFormat: "ISO path cannot be empty or whitespace-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := tt.config.validateISOPaths(tt.driverMock)
+
+			if len(errors) == 0 {
+				t.Fatal("Expected at least one error")
+			}
+
+			if errors[0].Error() != tt.expectedFormat {
+				t.Errorf("Expected error format '%s', got '%s'", tt.expectedFormat, errors[0].Error())
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ErrorAggregation(t *testing.T) {
+	config := &CDRomConfig{
+		ISOPaths: []string{
+			"",
+			"   ",
+			"invalid-format",
+			"[datastore1] iso/missing1.iso",
+			"[datastore1] iso/missing2.iso",
+		},
+	}
+
+	driverMock := &driver.DriverMock{
+		DatastoreMock: &driver.DatastoreMock{
+			FileExistsReturn: false,
+		},
+	}
+
+	errors := config.validateISOPaths(driverMock)
+
+	expectedErrorCount := 5
+	if len(errors) != expectedErrorCount {
+		t.Fatalf("Expected %d errors, got %d: %v", expectedErrorCount, len(errors), errors)
+	}
+
+	expectedSubstrings := []string{
+		"ISO path cannot be empty or whitespace-only",
+		"ISO path cannot be empty or whitespace-only",
+		"unable to parse datastore path: 'invalid-format'",
+		"ISO file not found: '[datastore1] iso/missing1.iso'",
+		"ISO file not found: '[datastore1] iso/missing2.iso'",
+	}
+
+	for i, expectedSubstring := range expectedSubstrings {
+		if !strings.Contains(errors[i].Error(), expectedSubstring) {
+			t.Errorf("Error %d should contain '%s', got '%s'", i, expectedSubstring, errors[i].Error())
+		}
+	}
+}
+
+func TestCDRomConfig_ValidateISOPaths_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *CDRomConfig
+		driverMock     *driver.DriverMock
+		expectedErrors []string
+	}{
+		{
+			name: "Nil driver - should handle gracefully",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[datastore1] iso/test.iso"},
+			},
+			driverMock:     nil,
+			expectedErrors: []string{"driver is not available for ISO validation"},
+		},
+		{
+			name: "Empty and whitespace-only paths",
+			config: &CDRomConfig{
+				ISOPaths: []string{"", "   ", "\t", "\n", "  \t\n  "},
+			},
+			driverMock: driver.NewDriverMock(),
+			expectedErrors: []string{
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+				"ISO path cannot be empty or whitespace-only",
+			},
+		},
+		{
+			name: "Malformed datastore paths",
+			config: &CDRomConfig{
+				ISOPaths: []string{
+					"[incomplete",
+					"incomplete]",
+					"[datastore1",
+					"datastore1] file.iso",
+					"[datastore][] /file.iso",
+					"[data/store] /file.iso",
+				},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{
+				"invalid datastore path format: '[incomplete'",
+				"invalid datastore path format: 'incomplete]'",
+				"invalid datastore path format: '[datastore1'",
+				"invalid datastore path format: 'datastore1] file.iso'",
+				"invalid datastore path format: '[datastore][] /file.iso'",
+				"content library path resolution returned empty datastore path for '[data/store] /file.iso'",
+			},
+		},
+		{
+			name: "Datastore access error",
+			config: &CDRomConfig{
+				ISOPaths: []string{"[datastore1] iso/test.iso"},
+			},
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore not found"),
+			},
+			expectedErrors: []string{"unable to access datastore 'datastore1' for ISO validation: datastore not found"},
+		},
+
+		{
+			name: "Mixed edge cases",
+			config: &CDRomConfig{
+				ISOPaths: []string{
+					"",
+					"[datastore][] /file.iso",
+					"Library//file.iso",
+					"[datastore1] valid.iso",
+				},
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{
+				"ISO path cannot be empty or whitespace-only",
+				"invalid datastore path format: '[datastore][] /file.iso'",
+				"content library item name cannot be empty in path: 'Library//file.iso'",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var errors []error
+			if tt.driverMock == nil {
+				errors = tt.config.validateISOPaths(nil)
+			} else {
+				errors = tt.config.validateISOPaths(tt.driverMock)
+			}
+
+			if len(errors) != len(tt.expectedErrors) {
+				t.Fatalf("Expected %d errors, got %d: %v", len(tt.expectedErrors), len(errors), errors)
+			}
+
+			for i, expectedErr := range tt.expectedErrors {
+				if i >= len(errors) {
+					t.Fatalf("Expected error %d: '%s', but got no error", i, expectedErr)
+				}
+				if !strings.Contains(errors[i].Error(), expectedErr) {
+					t.Errorf("Expected error %d to contain '%s', got '%s'", i, expectedErr, errors[i].Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_ValidateDatastorePath_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *CDRomConfig
+		isoPath     string
+		driverMock  *driver.DriverMock
+		expectedErr string
+		shouldFail  bool
+	}{
+		{
+			name:    "Datastore access error",
+			config:  &CDRomConfig{},
+			isoPath: "[datastore1] iso/test.iso",
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore not accessible"),
+			},
+			expectedErr: "unable to access datastore 'datastore1' for ISO validation: datastore not accessible",
+			shouldFail:  true,
+		},
+		{
+			name:    "Datastore connection timeout",
+			config:  &CDRomConfig{},
+			isoPath: "[datastore1] iso/test.iso",
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("connection timeout to datastore"),
+			},
+			expectedErr: "unable to access datastore 'datastore1' for ISO validation: connection timeout to datastore",
+			shouldFail:  true,
+		},
+		{
+			name:    "Datastore network error",
+			config:  &CDRomConfig{},
+			isoPath: "[datastore1] iso/test.iso",
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("network unreachable"),
+			},
+			expectedErr: "unable to access datastore 'datastore1' for ISO validation: network unreachable",
+			shouldFail:  true,
+		},
+		{
+			name:        "Completely malformed path - no brackets",
+			config:      &CDRomConfig{},
+			isoPath:     "just-a-filename.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "unable to parse datastore path: 'just-a-filename.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Path with only opening bracket",
+			config:      &CDRomConfig{},
+			isoPath:     "[datastore1 file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "invalid datastore path format: '[datastore1 file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:        "Path with only closing bracket",
+			config:      &CDRomConfig{},
+			isoPath:     "datastore1] file.iso",
+			driverMock:  driver.NewDriverMock(),
+			expectedErr: "invalid datastore path format: 'datastore1] file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:    "Empty datastore name - valid format but file doesn't exist",
+			config:  &CDRomConfig{},
+			isoPath: "[] file.iso",
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErr: "ISO file not found: '[] file.iso'",
+			shouldFail:  true,
+		},
+		{
+			name:    "Whitespace-only datastore name - valid format but file doesn't exist",
+			config:  &CDRomConfig{},
+			isoPath: "[   ] file.iso",
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErr: "ISO file not found: '[   ] file.iso'",
+			shouldFail:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validateDatastorePath(tt.isoPath, tt.driverMock)
+
+			if tt.shouldFail {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("Expected error to contain '%s', got '%s'", tt.expectedErr, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_PrepareWithMockDriver(t *testing.T) {
+	tests := []struct {
+		name                    string
+		config                  *CDRomConfig
+		keepConfig              *ReattachCDRomConfig
+		driverMock              *driver.DriverMock
+		expectedErrors          []string
+		expectedDriverCalls     map[string]bool
+		expectedDatastoreCalls  map[string]interface{}
+		expectedContentLibCalls map[string]interface{}
+	}{
+		{
+			name: "No ISO paths configured",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{},
+			},
+			keepConfig:     &ReattachCDRomConfig{ReattachCDRom: 2},
+			driverMock:     driver.NewDriverMock(),
+			expectedErrors: []string{},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": false,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": false,
+			},
+		},
+		{
+			name: "Valid datastore ISO path",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{"[datastore1] iso/ubuntu.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 2},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": true,
+			},
+		},
+		{
+			name: "Missing datastore ISO file",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{"[datastore1] iso/missing.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 2},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{"ISO file not found: '[datastore1] iso/missing.iso'"},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": true,
+			},
+		},
+		{
+			name: "Datastore not found",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{"[nonexistent] iso/file.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 2},
+			driverMock: &driver.DriverMock{
+				FindDatastoreErr: fmt.Errorf("datastore 'nonexistent' not found"),
+			},
+			expectedErrors: []string{"unable to access datastore 'nonexistent' for ISO validation: datastore 'nonexistent' not found"},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": false,
+			},
+		},
+		{
+			name: "Valid content library path",
+			config: &CDRomConfig{
+				CdromType: "sata",
+				ISOPaths:  []string{"MyLibrary/UbuntuItem/ubuntu.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 1},
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathReturn: "[datastore1] resolved/ubuntu.iso",
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": true,
+			},
+			expectedContentLibCalls: map[string]interface{}{
+				"FindContentLibraryFileDatastorePathCalled": true,
+			},
+		},
+		{
+			name: "Content library not found",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{"NonexistentLibrary/Item/file.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 3},
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathErr: fmt.Errorf("library not found"),
+			},
+			expectedErrors: []string{"content library not found: 'NonexistentLibrary'"},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": false,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": false,
+			},
+			expectedContentLibCalls: map[string]interface{}{
+				"FindContentLibraryFileDatastorePathCalled": true,
+			},
+		},
+		{
+			name: "Multiple ISO validation errors with cdrom_type error",
+			config: &CDRomConfig{
+				CdromType: "invalid",
+				ISOPaths: []string{
+					"",
+					"[datastore1] iso/missing.iso",
+					"invalid-format",
+				},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 5},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{
+				"ISO path cannot be empty or whitespace-only",
+				"ISO file not found: '[datastore1] iso/missing.iso'",
+				"unable to parse datastore path: 'invalid-format'",
+				"'cdrom_type' must be 'ide' or 'sata'",
+				"'reattach_cdroms' should be between 1 and 4",
+			},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": true,
+			},
+		},
+		{
+			name: "Mixed datastore and content library paths with some missing",
+			config: &CDRomConfig{
+				CdromType: "sata",
+				ISOPaths: []string{
+					"[datastore1] iso/missing.iso",
+				},
+			},
+			keepConfig: &ReattachCDRomConfig{ReattachCDRom: 2},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{"ISO file not found: '[datastore1] iso/missing.iso'"},
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+			expectedDatastoreCalls: map[string]interface{}{
+				"FileExistsCalled": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := tt.config.Prepare(tt.keepConfig, tt.driverMock)
+
+			if len(errors) != len(tt.expectedErrors) {
+				t.Fatalf("Expected %d errors, got %d: %v", len(tt.expectedErrors), len(errors), errors)
+			}
+
+			for i, expectedErr := range tt.expectedErrors {
+				if i >= len(errors) {
+					t.Fatalf("Expected error %d: '%s', but got no error", i, expectedErr)
+				}
+				if !strings.Contains(errors[i].Error(), expectedErr) {
+					t.Errorf("Expected error %d to contain '%s', got '%s'", i, expectedErr, errors[i].Error())
+				}
+			}
+
+			for method, expectedCalled := range tt.expectedDriverCalls {
+				switch method {
+				case "FindDatastore":
+					if tt.driverMock.FindDatastoreCalled != expectedCalled {
+						t.Errorf("Expected FindDatastore called: %v, got: %v", expectedCalled, tt.driverMock.FindDatastoreCalled)
+					}
+				}
+			}
+
+			if tt.driverMock.DatastoreMock != nil {
+				for method, expectedValue := range tt.expectedDatastoreCalls {
+					switch method {
+					case "FileExistsCalled":
+						if tt.driverMock.DatastoreMock.FileExistsCalled != expectedValue.(bool) {
+							t.Errorf("Expected DatastoreMock.FileExistsCalled: %v, got: %v", expectedValue, tt.driverMock.DatastoreMock.FileExistsCalled)
+						}
+					}
+				}
+			}
+
+			for method, expectedValue := range tt.expectedContentLibCalls {
+				switch method {
+				case "FindContentLibraryFileDatastorePathCalled":
+					if tt.driverMock.FindContentLibraryFileDatastorePathCalled != expectedValue.(bool) {
+						t.Errorf("Expected FindContentLibraryFileDatastorePathCalled: %v, got: %v", expectedValue, tt.driverMock.FindContentLibraryFileDatastorePathCalled)
+					}
+				}
+			}
+
+		})
+	}
+}
+
+func TestStepAddCDRom_RunWithISOValidation(t *testing.T) {
+	tests := []struct {
+		name                string
+		step                *StepAddCDRom
+		state               *multistep.BasicStateBag
+		driverMock          *driver.DriverMock
+		vmMock              *driver.VirtualMachineMock
+		expectedAction      multistep.StepAction
+		expectedError       string
+		shouldHaveError     bool
+		expectedDriverCalls map[string]bool
+	}{
+		{
+			name: "ISO validation passes, step continues normally",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "ide",
+					ISOPaths:  []string{"[datastore1] iso/ubuntu.iso"},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			vmMock:          new(driver.VirtualMachineMock),
+			expectedAction:  multistep.ActionContinue,
+			shouldHaveError: false,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+		},
+		{
+			name: "ISO validation fails, step halts",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "ide",
+					ISOPaths:  []string{"[datastore1] iso/missing.iso"},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			vmMock:          new(driver.VirtualMachineMock),
+			expectedAction:  multistep.ActionHalt,
+			expectedError:   "ISO validation failed: ISO file not found: '[datastore1] iso/missing.iso'",
+			shouldHaveError: true,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+		},
+		{
+			name: "Multiple ISO validation errors aggregated",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths: []string{
+						"",
+						"[datastore1] iso/missing1.iso",
+						"[datastore1] iso/missing2.iso",
+					},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			vmMock:          new(driver.VirtualMachineMock),
+			expectedAction:  multistep.ActionHalt,
+			expectedError:   "ISO validation failed:",
+			shouldHaveError: true,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+		},
+		{
+			name: "No driver in state, validation skipped",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "ide",
+					ISOPaths:  []string{"[datastore1] iso/any.iso"},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock:      nil, // No driver
+			vmMock:          new(driver.VirtualMachineMock),
+			expectedAction:  multistep.ActionContinue,
+			shouldHaveError: false,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": false,
+			},
+		},
+		{
+			name: "Content library path validation in runtime",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "sata",
+					ISOPaths:  []string{"MyLibrary/Item/file.iso"},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathReturn: "[datastore1] resolved/file.iso",
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			vmMock:          &driver.VirtualMachineMock{},
+			expectedAction:  multistep.ActionContinue,
+			shouldHaveError: false,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": true,
+			},
+		},
+		{
+			name: "Content library path fails validation in runtime",
+			step: &StepAddCDRom{
+				Config: &CDRomConfig{
+					CdromType: "ide",
+					ISOPaths:  []string{"NonexistentLibrary/Item/file.iso"},
+				},
+			},
+			state: func() *multistep.BasicStateBag {
+				state := basicStateBag(nil)
+				return state
+			}(),
+			driverMock: &driver.DriverMock{
+				FindContentLibraryFileDatastorePathErr: fmt.Errorf("library not found"),
+			},
+			vmMock:          new(driver.VirtualMachineMock),
+			expectedAction:  multistep.ActionHalt,
+			expectedError:   "ISO validation failed: content library not found: 'NonexistentLibrary'",
+			shouldHaveError: true,
+			expectedDriverCalls: map[string]bool{
+				"FindDatastore": false, // Won't be called due to content library error
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.state.Put("vm", tt.vmMock)
+			if tt.driverMock != nil {
+				tt.state.Put("driver", tt.driverMock)
+			}
+
+			action := tt.step.Run(context.TODO(), tt.state)
+
+			if action != tt.expectedAction {
+				t.Fatalf("Expected action %v, got %v", tt.expectedAction, action)
+			}
+			err, hasError := tt.state.Get("error").(error)
+			if tt.shouldHaveError {
+				if !hasError {
+					t.Fatal("Expected error but got none")
+				}
+				if !strings.Contains(err.Error(), tt.expectedError) {
+					t.Errorf("Expected error to contain '%s', got '%s'", tt.expectedError, err.Error())
+				}
+			} else {
+				if hasError {
+					t.Errorf("Expected no error but got: %s", err.Error())
+				}
+			}
+
+			if tt.driverMock != nil {
+				for method, expectedCalled := range tt.expectedDriverCalls {
+					switch method {
+					case "FindDatastore":
+						if tt.driverMock.FindDatastoreCalled != expectedCalled {
+							t.Errorf("Expected FindDatastore called: %v, got: %v", expectedCalled, tt.driverMock.FindDatastoreCalled)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCDRomConfig_PrepareErrorCollection(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *CDRomConfig
+		keepConfig     *ReattachCDRomConfig
+		driverMock     *driver.DriverMock
+		expectedErrors []string
+		description    string
+	}{
+		{
+			name: "ISO validation errors combined with existing validation errors",
+			config: &CDRomConfig{
+				CdromType: "invalid", // This will cause a cdrom_type validation error
+				ISOPaths: []string{
+					"[datastore1] iso/missing.iso", // This will cause an ISO validation error
+				},
+			},
+			keepConfig: &ReattachCDRomConfig{
+				ReattachCDRom: 5, // This will cause a reattach_cdroms validation error
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{
+				"ISO file not found: '[datastore1] iso/missing.iso'",
+				"'cdrom_type' must be 'ide' or 'sata'",
+				"'reattach_cdroms' should be between 1 and 4",
+			},
+			description: "Verifies that ISO validation errors are properly integrated with existing validation",
+		},
+		{
+			name: "ISO validation passes, other validations fail",
+			config: &CDRomConfig{
+				CdromType: "invalid",
+				ISOPaths:  []string{"[datastore1] iso/valid.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{
+				ReattachCDRom: -1,
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{
+				"'cdrom_type' must be 'ide' or 'sata'",
+				"'reattach_cdroms' should be between 1 and 4",
+			},
+			description: "Verifies that when ISO validation passes, other validation errors are still reported",
+		},
+		{
+			name: "All validations pass",
+			config: &CDRomConfig{
+				CdromType: "ide",
+				ISOPaths:  []string{"[datastore1] iso/valid.iso"},
+			},
+			keepConfig: &ReattachCDRomConfig{
+				ReattachCDRom: 2,
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: true,
+				},
+			},
+			expectedErrors: []string{},
+			description:    "Verifies that when all validations pass, no errors are returned",
+		},
+		{
+			name: "Multiple ISO validation errors with valid other config",
+			config: &CDRomConfig{
+				CdromType: "sata",
+				ISOPaths: []string{
+					"",
+					"[datastore1] iso/missing1.iso",
+					"invalid-format",
+					"[datastore1] iso/missing2.iso",
+				},
+			},
+			keepConfig: &ReattachCDRomConfig{
+				ReattachCDRom: 3,
+			},
+			driverMock: &driver.DriverMock{
+				DatastoreMock: &driver.DatastoreMock{
+					FileExistsReturn: false,
+				},
+			},
+			expectedErrors: []string{
+				"ISO path cannot be empty or whitespace-only",
+				"ISO file not found: '[datastore1] iso/missing1.iso'",
+				"unable to parse datastore path: 'invalid-format'",
+				"ISO file not found: '[datastore1] iso/missing2.iso'",
+			},
+			description: "Verifies that multiple ISO validation errors are all collected and reported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errors := tt.config.Prepare(tt.keepConfig, tt.driverMock)
+
+			if len(errors) != len(tt.expectedErrors) {
+				t.Fatalf("%s: Expected %d errors, got %d: %v", tt.description, len(tt.expectedErrors), len(errors), errors)
+			}
+			for i, expectedErr := range tt.expectedErrors {
+				if i >= len(errors) {
+					t.Fatalf("%s: Expected error %d: '%s', but got no error", tt.description, i, expectedErr)
+				}
+				if !strings.Contains(errors[i].Error(), expectedErr) {
+					t.Errorf("%s: Expected error %d to contain '%s', got '%s'", tt.description, i, expectedErr, errors[i].Error())
+				}
+			}
+		})
+	}
 }

--- a/builder/vsphere/driver/datastore.go
+++ b/builder/vsphere/driver/datastore.go
@@ -229,6 +229,11 @@ type DatastoreIsoPath struct {
 	path string
 }
 
+// NewDatastoreIsoPath creates a new DatastoreIsoPath with the given path
+func NewDatastoreIsoPath(path string) *DatastoreIsoPath {
+	return &DatastoreIsoPath{path: path}
+}
+
 // Validate checks if the path matches the expected datastore ISO path format.
 // Returns true if valid, otherwise false.
 func (d *DatastoreIsoPath) Validate() bool {

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -30,6 +30,10 @@ type DriverMock struct {
 
 	FindVMCalled bool
 	FindVMName   string
+
+	FindContentLibraryFileDatastorePathCalled bool
+	FindContentLibraryFileDatastorePathReturn string
+	FindContentLibraryFileDatastorePathErr    error
 }
 
 func NewDriverMock() *DriverMock {
@@ -118,7 +122,8 @@ func (d *DriverMock) FindContentLibraryItem(libraryId string, name string) (*lib
 }
 
 func (d *DriverMock) FindContentLibraryFileDatastorePath(isoPath string) (string, error) {
-	return "", nil
+	d.FindContentLibraryFileDatastorePathCalled = true
+	return d.FindContentLibraryFileDatastorePathReturn, d.FindContentLibraryFileDatastorePathErr
 }
 
 func (d *DriverMock) UpdateContentLibraryItem(item *library.Item, name string, description string) error {

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -112,7 +112,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.FlagConfig.Prepare(&c.HardwareConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
-	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig)...)
+	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig, nil)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CDConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)


### PR DESCRIPTION
### Description

🚧 Pending e2e Tests. 🚧

This pull request introduces enhanced validation for ISO paths used in builder configurations, ensuring that ISO files specified for CD-ROM devices exist and are accessible on their respective datastores or content libraries. It also adds better error handling and updates the driver mock for improved testability.

**ISO Path Validation Improvements:**

* Added a comprehensive `validateISOPaths` method in `CDRomConfig` to check that each ISO path exists, is correctly formatted, and is accessible either as a datastore path or a content library path. This includes detailed error messages for various failure scenarios.
* Updated the `Prepare` method in `CDRomConfig` to accept a `driver.Driver` parameter and invoke `validateISOPaths` when ISO paths are provided, ensuring validation occurs during configuration preparation.
* Modified the `Run` method in `StepAddCDRom` to perform ISO path validation at runtime, halting the step and reporting errors if validation fails.

**API and Mock Enhancements:**

* Added a `NewDatastoreIsoPath` constructor to simplify creation and validation of datastore ISO paths.
* Extended the `DriverMock` with support for simulating content library file datastore path lookups and associated errors, improving test coverage for the new validation logic. [[1]](diffhunk://#diff-822252cf8e80e25d0bf4a5d4987e0c2fd9306c7757b986f7e56e4fd7e6d203d5R33-R36) [[2]](diffhunk://#diff-822252cf8e80e25d0bf4a5d4987e0c2fd9306c7757b986f7e56e4fd7e6d203d5L121-R126)

**Integration and Compatibility Updates:**

* Updated calls to `CDRomConfig.Prepare` in both `clone/config.go` and `iso/config.go` to pass the new `driver.Driver` parameter, maintaining compatibility with the revised method signature. [[1]](diffhunk://#diff-d1e700a7f09dbbdf999d3f58122336912f3f1be8e31c0af8f692b9b7605d2396L93-R93) [[2]](diffhunk://#diff-e40ca17e878479f036653932155b88ee79efde031f6f7e6ff25d602a0944a9f3L115-R115)

**Imports and Code Cleanup:**

* Added necessary imports (e.g., `strings`, `object`) to support the new validation logic in `step_add_cdrom.go`.
* Minor code cleanup and reordering to streamline ISO path handling in the CD-ROM step.

```shell
packer-plugin-vsphere on  feat/add-iso-path-validation [$?] via 🐹 v1.23.11 
➜ make test                                                                 
?       github.com/hashicorp/packer-plugin-vsphere      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/testing       [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common/utils [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/examples/driver      [no test files]
?       github.com/hashicorp/packer-plugin-vsphere/version      [no test files]
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/clone        1.799s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/common       2.336s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/driver       7.060s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/iso  2.144s
ok      github.com/hashicorp/packer-plugin-vsphere/builder/vsphere/supervisor   7.060s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere       1.424s
ok      github.com/hashicorp/packer-plugin-vsphere/post-processor/vsphere-template      2.302s
```

### Resolved Issues

Closes #453

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
