### PR TITLE
refactor: set firmware configuration during create

### DIFF
--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -84,6 +84,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Config:   &b.config.CreateConfig,
 			Location: &b.config.LocationConfig,
 			Force:    b.config.PackerForce,
+			Firmware: b.config.Firmware,
 		},
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -170,6 +170,7 @@ type StepCreateVM struct {
 	Config        *CreateConfig
 	Location      *common.LocationConfig
 	Force         bool
+	Firmware      string
 	GeneratedData *packerbuilderdata.GeneratedData
 }
 
@@ -228,6 +229,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		NICs:          networkCards,
 		USBController: s.Config.USBController,
 		Version:       s.Config.Version,
+		Firmware:      s.Firmware,
 	})
 	if err != nil {
 		state.Put("error", fmt.Errorf("error creating virtual machine: %v", err))


### PR DESCRIPTION
### Description

Refactors to support for specifying the firmware type when creating and configuring the virtual machines. This will ensure that the APCI layout for virtual machines created with virtual hardware 20 or later with EFI (and EFI with Secure Boot) have the correct APCI motherboard layout upon creation.

Reference: 

- https://knowledge.broadcom.com/external/article/313466/
- https://williamlam.com/2023/01/acpi-motherboard-layout-requires-efi-considerations-for-switching-vm-firmware-in-vsphere-8.html

### Resolved Issues

Closes #472 

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.

