### PR TITLE
refactor: time synchronization settings

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -319,8 +319,22 @@ JSON Example:
   are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
   in the vSphere API documentation.
 
-- `tools_sync_time` (bool) - Enable time synchronization with the ESX host where the virtual machine
-  is running. Defaults to `false`.
+- `tools_sync_time` (\*bool) - Enable or disable time synchronization between the guest operating system and the
+  ESX host at startup and after VM operations that may introduce time drift (such
+  as resume from suspend, vMotion, or snapshot restore). If set to `true`, time
+  synchronization is explicitly enabled. If set to `false`, time synchronization is
+  explicitly disabled. If omitted, the builder does not modify the virtual
+  machine's time synchronization settings:
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`true`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
+
+- `tools_sync_time_periodically` (\*bool) - Enable or disable periodic time synchronization between the guest operating
+  system and the ESX host. Use this setting only if the guest operating system does
+  not have native time synchronization.
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`false`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
 
 - `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
   power cycle. Defaults to `false`.

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1641,8 +1641,22 @@ JSON Example:
   are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
   in the vSphere API documentation.
 
-- `tools_sync_time` (bool) - Enable time synchronization with the ESX host where the virtual machine
-  is running. Defaults to `false`.
+- `tools_sync_time` (\*bool) - Enable or disable time synchronization between the guest operating system and the
+  ESX host at startup and after VM operations that may introduce time drift (such
+  as resume from suspend, vMotion, or snapshot restore). If set to `true`, time
+  synchronization is explicitly enabled. If set to `false`, time synchronization is
+  explicitly disabled. If omitted, the builder does not modify the virtual
+  machine's time synchronization settings:
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`true`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
+
+- `tools_sync_time_periodically` (\*bool) - Enable or disable periodic time synchronization between the guest operating
+  system and the ESX host. Use this setting only if the guest operating system does
+  not have native time synchronization.
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`false`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
 
 - `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
   power cycle. Defaults to `false`.

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -88,6 +88,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.CloneConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, c.ConfigParamsConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.FlagConfig.Prepare(&c.HardwareConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig)...)

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -71,6 +71,7 @@ type FlatConfig struct {
 	VirtualPrecisionClock           *string                                     `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
+	ToolsSyncTimePeriodically       *bool                                       `mapstructure:"tools_sync_time_periodically" cty:"tools_sync_time_periodically" hcl:"tools_sync_time_periodically"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
 	VbsEnabled                      *bool                                       `mapstructure:"vbs_enabled" cty:"vbs_enabled" hcl:"vbs_enabled"`
 	VvtdEnabled                     *bool                                       `mapstructure:"vvtd_enabled" cty:"vvtd_enabled" hcl:"vvtd_enabled"`
@@ -224,6 +225,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"precision_clock":                &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
+		"tools_sync_time_periodically":   &hcldec.AttrSpec{Name: "tools_sync_time_periodically", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},
 		"vbs_enabled":                    &hcldec.AttrSpec{Name: "vbs_enabled", Type: cty.Bool, Required: false},
 		"vvtd_enabled":                   &hcldec.AttrSpec{Name: "vvtd_enabled", Type: cty.Bool, Required: false},

--- a/builder/vsphere/common/step_config_params.hcl2spec.go
+++ b/builder/vsphere/common/step_config_params.hcl2spec.go
@@ -10,9 +10,10 @@ import (
 // FlatConfigParamsConfig is an auto-generated flat version of ConfigParamsConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatConfigParamsConfig struct {
-	ConfigParams       map[string]string `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
-	ToolsSyncTime      *bool             `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
-	ToolsUpgradePolicy *bool             `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
+	ConfigParams              map[string]string `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
+	ToolsSyncTime             *bool             `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
+	ToolsSyncTimePeriodically *bool             `mapstructure:"tools_sync_time_periodically" cty:"tools_sync_time_periodically" hcl:"tools_sync_time_periodically"`
+	ToolsUpgradePolicy        *bool             `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
 }
 
 // FlatMapstructure returns a new FlatConfigParamsConfig.
@@ -27,9 +28,10 @@ func (*ConfigParamsConfig) FlatMapstructure() interface{ HCL2Spec() map[string]h
 // The decoded values from this spec will then be applied to a FlatConfigParamsConfig.
 func (*FlatConfigParamsConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"configuration_parameters": &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
-		"tools_sync_time":          &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
-		"tools_upgrade_policy":     &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},
+		"configuration_parameters":     &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
+		"tools_sync_time":              &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
+		"tools_sync_time_periodically": &hcldec.AttrSpec{Name: "tools_sync_time_periodically", Type: cty.Bool, Required: false},
+		"tools_upgrade_policy":         &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -110,6 +110,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, c.ConfigParamsConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.FlagConfig.Prepare(&c.HardwareConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.CDRomConfig.Prepare(&c.ReattachCDRomConfig)...)

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -69,6 +69,7 @@ type FlatConfig struct {
 	VirtualPrecisionClock           *string                                     `mapstructure:"precision_clock" cty:"precision_clock" hcl:"precision_clock"`
 	ConfigParams                    map[string]string                           `mapstructure:"configuration_parameters" cty:"configuration_parameters" hcl:"configuration_parameters"`
 	ToolsSyncTime                   *bool                                       `mapstructure:"tools_sync_time" cty:"tools_sync_time" hcl:"tools_sync_time"`
+	ToolsSyncTimePeriodically       *bool                                       `mapstructure:"tools_sync_time_periodically" cty:"tools_sync_time_periodically" hcl:"tools_sync_time_periodically"`
 	ToolsUpgradePolicy              *bool                                       `mapstructure:"tools_upgrade_policy" cty:"tools_upgrade_policy" hcl:"tools_upgrade_policy"`
 	VbsEnabled                      *bool                                       `mapstructure:"vbs_enabled" cty:"vbs_enabled" hcl:"vbs_enabled"`
 	VvtdEnabled                     *bool                                       `mapstructure:"vvtd_enabled" cty:"vvtd_enabled" hcl:"vvtd_enabled"`
@@ -229,6 +230,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"precision_clock":                &hcldec.AttrSpec{Name: "precision_clock", Type: cty.String, Required: false},
 		"configuration_parameters":       &hcldec.AttrSpec{Name: "configuration_parameters", Type: cty.Map(cty.String), Required: false},
 		"tools_sync_time":                &hcldec.AttrSpec{Name: "tools_sync_time", Type: cty.Bool, Required: false},
+		"tools_sync_time_periodically":   &hcldec.AttrSpec{Name: "tools_sync_time_periodically", Type: cty.Bool, Required: false},
 		"tools_upgrade_policy":           &hcldec.AttrSpec{Name: "tools_upgrade_policy", Type: cty.Bool, Required: false},
 		"vbs_enabled":                    &hcldec.AttrSpec{Name: "vbs_enabled", Type: cty.Bool, Required: false},
 		"vvtd_enabled":                   &hcldec.AttrSpec{Name: "vvtd_enabled", Type: cty.Bool, Required: false},

--- a/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ConfigParamsConfig-not-required.mdx
@@ -28,8 +28,22 @@
   are silently ignored. Refer to the [`VirtualMachineConfigSpec`](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.ConfigSpec.html)
   in the vSphere API documentation.
 
-- `tools_sync_time` (bool) - Enable time synchronization with the ESX host where the virtual machine
-  is running. Defaults to `false`.
+- `tools_sync_time` (\*bool) - Enable or disable time synchronization between the guest operating system and the
+  ESX host at startup and after VM operations that may introduce time drift (such
+  as resume from suspend, vMotion, or snapshot restore). If set to `true`, time
+  synchronization is explicitly enabled. If set to `false`, time synchronization is
+  explicitly disabled. If omitted, the builder does not modify the virtual
+  machine's time synchronization settings:
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`true`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
+
+- `tools_sync_time_periodically` (\*bool) - Enable or disable periodic time synchronization between the guest operating
+  system and the ESX host. Use this setting only if the guest operating system does
+  not have native time synchronization.
+    - `vsphere-iso` builder uses the vSphere default for new virtual machines
+       (`false`).
+    - `vsphere-clone` builder inherits the setting from the source virtual machine.
 
 - `tools_upgrade_policy` (bool) - Automatically check for and upgrade VMware Tools after a virtual machine
   power cycle. Defaults to `false`.


### PR DESCRIPTION
### Description

Refactored `tools_sync_time` from `bool` to `*bool` in `ConfigParamsConfig` to distinguish explicit `true/false` from omission, and adjust logic to handle `nil` values. The change makes `tools_sync_time` optional and clarifies its behavior when omitted, ensuring more flexible and accurate time synchronization settings for virtual machines. 

Added `tools_sync_time_periodically` configuration option for periodic time synchronization between the guest operating system and the ESX host.

**Configuration and Validation Updates:**

* Added the `tools_sync_time_periodically` option to both `vsphere-iso` and `vsphere-clone` builders, allowing users to enable or disable periodic time synchronization. This is only recommended if the guest OS does not have native time sync. [[1]](diffhunk://#diff-993ef7c30ee0e141b8c77fa17935929e1b9e12af6607b3bc7fe526dbff9a4921R74) [[2]](diffhunk://#diff-2fd27dfc0b7ffb82b2fce57af1eb5d95c320069e1625bef83964d01c76b57d63R72) [[3]](diffhunk://#diff-e782b5e5d7e4b31fe094b93cfe92519141435a287271c17439d5dbd16e72d395R15)
* Updated the `tools_sync_time` option to accept a pointer (`*bool`), clarifying its meaning and inheritance: if omitted, the builder uses defaults or inherits from the source VM.
* Implemented validation logic so that `tools_sync_time_periodically` can only be enabled if `tools_sync_time` is also set to `true`.

**Documentation Improvements:**

* Revised documentation in Markdown and MDX files to explain the new and updated options, their defaults, and inheritance behavior for both builders. [[1]](diffhunk://#diff-6752170ad5617582d4773e4abc3c9a943a0685112b0b5591bd80239ee6aa08deL1644-R1659) [[2]](diffhunk://#diff-259290b43a88f7ba6c250e0f0cd285a8c6b0c063643e34aa78de285d3ef29445L322-R337) [[3]](diffhunk://#diff-5449599e1f9a54cee110019d0e1565057bb150a6fc5d06dfe395bd242594f6c9L31-R46)

**Internal Code Changes:**

* Updated configuration structs and HCL2 specs to support the new option and pointer types. [[1]](diffhunk://#diff-993ef7c30ee0e141b8c77fa17935929e1b9e12af6607b3bc7fe526dbff9a4921R228) [[2]](diffhunk://#diff-2fd27dfc0b7ffb82b2fce57af1eb5d95c320069e1625bef83964d01c76b57d63R233) [[3]](diffhunk://#diff-e782b5e5d7e4b31fe094b93cfe92519141435a287271c17439d5dbd16e72d395R33)
* Modified the step logic to correctly set vSphere API fields for both time synchronization options.
* Ensured the new validation is called during config preparation for both builders. [[1]](diffhunk://#diff-d1e700a7f09dbbdf999d3f58122336912f3f1be8e31c0af8f692b9b7605d2396R91) [[2]](diffhunk://#diff-e40ca17e878479f036653932155b88ee79efde031f6f7e6ff25d602a0944a9f3R113)

### Resolved Issues

Closes #547
Closes #499 

### Rollback Plan

Revert commit.

### Changes to Security Controls

None.
