### PR TITLE
chore(xfer): remove `.copywrite.hcl`

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,9 +1,0 @@
-project {
-  license = "MPL-2.0"
-  copyright_year = 2021
-  header_ignore = [
-    "*.hcl2spec.go", # generated code specs, since they'll be wiped out until we support adding headers to generated files.
-    "**/test-fixtures/**",
-    "**/examples/**",
-  ]
-}


### PR DESCRIPTION
### Description

Post-transfer removal of `.copywrite.hcl`.

