### PR TITLE
refactor: enhance resource pool handling

### DIFF
--- a/builder/vsphere/driver/resource_pool.go
+++ b/builder/vsphere/driver/resource_pool.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -34,6 +35,8 @@ func (d *VCenterDriver) NewResourcePool(ref *types.ManagedObjectReference) *Reso
 // pool or a vApp if the specified pool is not found. Returns a ResourcePool
 // object or an error if neither the specified nor default pool is accessible.
 func (d *VCenterDriver) FindResourcePool(cluster string, host string, name string) (*ResourcePool, error) {
+	name = strings.TrimSpace(name)
+
 	var res string
 	if cluster != "" {
 		res = cluster
@@ -41,20 +44,36 @@ func (d *VCenterDriver) FindResourcePool(cluster string, host string, name strin
 		res = host
 	}
 
-	resourcePath := fmt.Sprintf("%v/Resources/%v", res, name)
+	var resourcePath string
+	switch {
+	case name == "":
+		resourcePath = fmt.Sprintf("%v/Resources", res)
+	case strings.HasPrefix(name, "/"):
+		resourcePath = name
+	default:
+		resourcePath = fmt.Sprintf("%v/Resources/%v", res, name)
+	}
+
 	p, err := d.Finder.ResourcePool(d.Ctx, resourcePath)
 	if err != nil {
-		log.Printf("[WARN] %s not found. Looking for default resource pool.", resourcePath)
+		log.Printf("[WARN] %s not found. Attempting to use default resource pool.", resourcePath)
+
 		dp, dperr := d.Finder.DefaultResourcePool(d.Ctx)
 		var notFoundError *find.NotFoundError
 		if errors.As(dperr, &notFoundError) {
 			vapp, verr := d.Finder.VirtualApp(d.Ctx, name)
 			if verr != nil {
-				return nil, err
+				return nil, fmt.Errorf("could not resolve '%s': %w", name, verr)
 			}
 			dp = vapp.ResourcePool
+		} else if dperr != nil {
+			return nil, fmt.Errorf("error finding default resource pool: %w", dperr)
 		}
 		p = dp
+	}
+
+	if p == nil {
+		return nil, fmt.Errorf("resource pool '%s' resolved to nil", resourcePath)
 	}
 
 	return &ResourcePool{

--- a/builder/vsphere/driver/resource_pool_test.go
+++ b/builder/vsphere/driver/resource_pool_test.go
@@ -17,17 +17,63 @@ func TestVCenterDriver_FindResourcePool(t *testing.T) {
 	}
 	defer sim.Close()
 
-	res, err := sim.driver.FindResourcePool("", "DC0_H0", "")
-	if err != nil {
-		t.Fatalf("unexpected error: '%s'", err)
-	}
-	if res == nil {
-		t.Fatalf("unexpected result: expected '%v', but returned 'nil'", res)
-	}
-	expectedResourcePool := "Resources"
-	if res.pool.Name() != expectedResourcePool {
-		t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedResourcePool, res.pool.Name())
-	}
+	t.Run("empty name with host", func(t *testing.T) {
+		res, err := sim.driver.FindResourcePool("", "DC0_H0", "")
+		if err != nil {
+			t.Fatalf("unexpected error: '%s'", err)
+		}
+		if res == nil {
+			t.Fatalf("unexpected result: expected resource pool, but returned 'nil'")
+		}
+		expectedResourcePool := "Resources"
+		if res.pool.Name() != expectedResourcePool {
+			t.Fatalf("unexpected result: expected '%s', but returned '%s'", expectedResourcePool, res.pool.Name())
+		}
+	})
+
+	t.Run("empty name with cluster", func(t *testing.T) {
+		res, err := sim.driver.FindResourcePool("DC0_C0", "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: '%s'", err)
+		}
+		if res == nil {
+			t.Fatalf("unexpected result: expected resource pool, but returned 'nil'")
+		}
+		if res.pool.Name() != "Resources" {
+			t.Fatalf("unexpected result: expected 'Resources', but returned '%s'", res.pool.Name())
+		}
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		res, err := sim.driver.FindResourcePool("DC0_C0", "", "foo")
+
+		if err == nil {
+			t.Fatalf("expected error when using unknown relative resource pool path 'foo', but got none")
+		}
+		if res != nil {
+			t.Fatalf("unexpected result: expected no resource pool for unknown path 'foo', but got one")
+		}
+	})
+
+	t.Run("absolute path", func(t *testing.T) {
+		res, err := sim.driver.FindResourcePool("", "", "/DC0/host/DC0_H0/Resources")
+		if err != nil {
+			t.Fatalf("unexpected error: '%s'", err)
+		}
+		if res == nil || res.pool == nil {
+			t.Fatalf("unexpected result: expected resource pool, but returned 'nil'")
+		}
+	})
+
+	t.Run("whitespace trimming", func(t *testing.T) {
+		res, err := sim.driver.FindResourcePool("", "DC0_H0", "  ")
+		if err != nil {
+			t.Fatalf("unexpected error: '%s'", err)
+		}
+		if res == nil {
+			t.Fatalf("unexpected result: expected resource pool, but returned 'nil'")
+		}
+	})
 }
 
 func TestVCenterDriver_FindResourcePoolStandaloneESX(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Enhances the `FindResourcePool` method to handle resource pool name input more robustly and adds comprehensive tests for these scenarios. The changes improve how resource pool paths are resolved, handle errors more gracefully, and ensure whitespace in names is managed correctly.

* Updated `FindResourcePool` in `resource_pool.go` to trim whitespace from the `name` parameter and handle absolute, relative, and empty resource pool names, improving flexibility and correctness when resolving resource pool paths.
* Added handling for cases where the resolved resource pool is `nil` and improved error messages for better debugging.
* Improved error handling when failing to find the default resource pool or virtual app, returning more informative errors.
* Added new test cases in `resource_pool_test.go` to cover empty names with host or cluster, relative and absolute paths, and whitespace trimming, ensuring the new logic is thoroughly validated.
* Imported the `strings` package in `resource_pool.go` to support whitespace trimming and path processing.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [x] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Resolves #657

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->