### PR TITLE
fix: use pointer handle null values

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1641,7 +1641,7 @@ The above configuration would create the following files:
   created, must be empty prior to running the builder. By default, this is
   "output-<buildName>" where "buildName" is the name of the build.
 
-- `directory_permission` (os.FileMode) - The permissions to apply to the "output_directory", and to any parent
+- `directory_permission` (\*os.FileMode) - The permissions to apply to the "output_directory", and to any parent
   directories that get created for output_directory.  By default, this is
   "0750". You should express the permission as quoted string with a
   leading zero such as "0755" in JSON file, because JSON does not support

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1489,7 +1489,7 @@ The above configuration would create the following files:
   created, must be empty prior to running the builder. By default, this is
   "output-<buildName>" where "buildName" is the name of the build.
 
-- `directory_permission` (os.FileMode) - The permissions to apply to the "output_directory", and to any parent
+- `directory_permission` (\*os.FileMode) - The permissions to apply to the "output_directory", and to any parent
   directories that get created for output_directory.  By default, this is
   "0750". You should express the permission as quoted string with a
   leading zero such as "0755" in JSON file, because JSON does not support

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ testacc: dev
 
 generate: install-packer-sdc
 	@go generate ./...
+	# Patch the generated files to use *os.FileMode so null values are handled correctly.
+	@for f in builder/vsphere/common/output_config.hcl2spec.go builder/vsphere/common/step_export.hcl2spec.go; do \
+		awk '/DirPerm/{gsub(/ os\.FileMode/, " *os.FileMode")} {print}' "$$f" > "$$f.tmp" && mv "$$f.tmp" "$$f"; \
+	done
+	@go fmt ./...
 	@rm -rf .docs
 	@packer-sdc renderdocs -src "docs" -partials docs-partials/ -dst ".docs/"
 	@./.web-docs/scripts/compile-to-webdocs.sh "." ".docs" ".web-docs" "hashicorp"

--- a/builder/vsphere/common/output_config.go
+++ b/builder/vsphere/common/output_config.go
@@ -31,7 +31,7 @@ type OutputConfig struct {
 	// leading zero such as "0755" in JSON file, because JSON does not support
 	// octal value. In Unix-like OS, the actual permission may differ from
 	// this value because of umask.
-	DirPerm os.FileMode `mapstructure:"directory_permission" required:"false"`
+	DirPerm *os.FileMode `mapstructure:"directory_permission" required:"false"`
 }
 
 func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {
@@ -39,8 +39,9 @@ func (c *OutputConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		c.OutputDir = fmt.Sprintf("output-%s", pc.PackerBuildName)
 	}
 
-	if runtime.GOOS != "windows" && c.DirPerm == 0 {
-		c.DirPerm = 0750
+	if runtime.GOOS != "windows" && (c.DirPerm == nil || *c.DirPerm == 0) {
+		perm := os.FileMode(0750)
+		c.DirPerm = &perm
 	}
 
 	return nil

--- a/builder/vsphere/common/output_config.hcl2spec.go
+++ b/builder/vsphere/common/output_config.hcl2spec.go
@@ -12,8 +12,8 @@ import (
 // FlatOutputConfig is an auto-generated flat version of OutputConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOutputConfig struct {
-	OutputDir *string     `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm   os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	OutputDir *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	DirPerm   *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
 }
 
 // FlatMapstructure returns a new FlatOutputConfig.

--- a/builder/vsphere/common/step_export.go
+++ b/builder/vsphere/common/step_export.go
@@ -159,7 +159,7 @@ func (c *ExportConfig) Prepare(ctx *interpolate.Context, lc *LocationConfig, pc 
 	}
 
 	// Check if the output directory exists.
-	if err := os.MkdirAll(c.OutputDir.OutputDir, c.OutputDir.DirPerm); err != nil {
+	if err := os.MkdirAll(c.OutputDir.OutputDir, *c.OutputDir.DirPerm); err != nil {
 		errs = packersdk.MultiErrorAppend(errs, errors.Wrap(err, "unable to make directory for export"))
 	}
 

--- a/builder/vsphere/common/step_export.hcl2spec.go
+++ b/builder/vsphere/common/step_export.hcl2spec.go
@@ -12,14 +12,14 @@ import (
 // FlatExportConfig is an auto-generated flat version of ExportConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatExportConfig struct {
-	Name       *string     `mapstructure:"name" cty:"name" hcl:"name"`
-	Force      *bool       `mapstructure:"force" cty:"force" hcl:"force"`
-	ImageFiles *bool       `mapstructure:"image_files" cty:"image_files" hcl:"image_files"`
-	Manifest   *string     `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
-	OutputDir  *string     `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
-	DirPerm    os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
-	Options    []string    `mapstructure:"options" cty:"options" hcl:"options"`
-	Format     *string     `mapstructure:"output_format" cty:"output_format" hcl:"output_format"`
+	Name       *string      `mapstructure:"name" cty:"name" hcl:"name"`
+	Force      *bool        `mapstructure:"force" cty:"force" hcl:"force"`
+	ImageFiles *bool        `mapstructure:"image_files" cty:"image_files" hcl:"image_files"`
+	Manifest   *string      `mapstructure:"manifest" cty:"manifest" hcl:"manifest"`
+	OutputDir  *string      `mapstructure:"output_directory" required:"false" cty:"output_directory" hcl:"output_directory"`
+	DirPerm    *os.FileMode `mapstructure:"directory_permission" required:"false" cty:"directory_permission" hcl:"directory_permission"`
+	Options    []string     `mapstructure:"options" cty:"options" hcl:"options"`
+	Format     *string      `mapstructure:"output_format" cty:"output_format" hcl:"output_format"`
 }
 
 // FlatMapstructure returns a new FlatExportConfig.

--- a/docs-partials/builder/vsphere/common/OutputConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/OutputConfig-not-required.mdx
@@ -7,7 +7,7 @@
   created, must be empty prior to running the builder. By default, this is
   "output-<buildName>" where "buildName" is the name of the build.
 
-- `directory_permission` (os.FileMode) - The permissions to apply to the "output_directory", and to any parent
+- `directory_permission` (\*os.FileMode) - The permissions to apply to the "output_directory", and to any parent
   directories that get created for output_directory.  By default, this is
   "0750". You should express the permission as quoted string with a
   leading zero such as "0755" in JSON file, because JSON does not support


### PR DESCRIPTION

<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

> [!IMPORTANT]
> Required after the update to `hashicorp/packer-plugin-sdk` v0.6.6 in #675.

Change `DirPerm` in `OutputConfig` from `os.FileMode` to `*os.FileMode` so that HCL2 can correctly represent the field as optional/nullable.

When `directory_permission` is not set in a onfiguration, the packer-sdc generated flat struct receives a cty null value for the field. Assigning a cty null to a non-pointer `os.FileMode` causes a runtime panic: "null value is not allowed". Using a pointer type allows the field to be nil when omitted, which is handled in `Prepare()` by falling back to the default permission of `0750`.

The corresponding generated `hcl2spec.go` files (`output_config` and `step_export`) are updated to mirror the pointer type. Because the pointer is now declared in the source struct, future runs of `make generate` will regenerate these files with `*os.FileMode`.

Fixes:
- Runtime error: null value is not allowed [directory_permission]
- Build error: cannot use DirPerm (type *os.FileMode) as os.FileMode

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Ref: #675

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->