### PR TITLE
feat: add `overwrite` option for vm template imports

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1678,17 +1678,19 @@ The template is stored in an existing or newly created library item.
   must be of type Local to allow deploying virtual machines.
 
 - `name` (string) - The name of the content library item that will be created or updated.
-  For VM templates, the name of the item should be different from
-  [vm_name](#vm_name) and the default is [vm_name](#vm_name) + timestamp
-  when not set. VM templates will always be imported to a new library item.
-  For OVF templates, the name defaults to [vm_name](#vm_name) when not set,
-  and if an item with the same name already exists it will be then updated
-  with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note:** It's not possible to update existing content library items
-  with a new VM template. If updating an existing content library item is
-  necessary, use an OVF template instead by setting the [ovf](#ovf) option
-  as `true`.
+  For VM templates, the default is [vm_name](#vm_name) + timestamp when not set.
+  VM templates are always imported as new library items. If an item with the
+  specified name already exists, the import will fail unless [overwrite](#overwrite)
+  is set to `true`.
+  
+  For OVF templates, the name defaults to [vm_name](#vm_name) when not set.
+  If an item with the same name already exists, it will be updated with the
+  new OVF template, otherwise a new item will be created.
+  
+  ~> **Note:** VM templates cannot update existing content library items in-place
+  like OVF templates. When [overwrite](#overwrite) is enabled, the existing item
+  will be deleted before creating the new one.
 
 - `description` (string) - A description for the content library item that will be created.
   Defaults to "Packer imported [vm_name](#vm_name) VM template".
@@ -1729,6 +1731,11 @@ The template is stored in an existing or newly created library item.
 - `ovf_flags` ([]string) - Flags to use for OVF package creation. The supported flags can be
   obtained using ExportFlag.list. If unset, no flags will be used.
   Known values: `EXTRA_CONFIG`, `PRESERVE_MAC`.
+
+- `overwrite` (bool) - Overwrite the content library item if it already exists. This only applies
+  to VM templates. For OVF templates, existing items are always updated.
+  When enabled for VM templates, the existing item will be deleted before
+  creating the new one. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1526,17 +1526,19 @@ The template is stored in an existing or newly created library item.
   must be of type Local to allow deploying virtual machines.
 
 - `name` (string) - The name of the content library item that will be created or updated.
-  For VM templates, the name of the item should be different from
-  [vm_name](#vm_name) and the default is [vm_name](#vm_name) + timestamp
-  when not set. VM templates will always be imported to a new library item.
-  For OVF templates, the name defaults to [vm_name](#vm_name) when not set,
-  and if an item with the same name already exists it will be then updated
-  with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note:** It's not possible to update existing content library items
-  with a new VM template. If updating an existing content library item is
-  necessary, use an OVF template instead by setting the [ovf](#ovf) option
-  as `true`.
+  For VM templates, the default is [vm_name](#vm_name) + timestamp when not set.
+  VM templates are always imported as new library items. If an item with the
+  specified name already exists, the import will fail unless [overwrite](#overwrite)
+  is set to `true`.
+  
+  For OVF templates, the name defaults to [vm_name](#vm_name) when not set.
+  If an item with the same name already exists, it will be updated with the
+  new OVF template, otherwise a new item will be created.
+  
+  ~> **Note:** VM templates cannot update existing content library items in-place
+  like OVF templates. When [overwrite](#overwrite) is enabled, the existing item
+  will be deleted before creating the new one.
 
 - `description` (string) - A description for the content library item that will be created.
   Defaults to "Packer imported [vm_name](#vm_name) VM template".
@@ -1577,6 +1579,11 @@ The template is stored in an existing or newly created library item.
 - `ovf_flags` ([]string) - Flags to use for OVF package creation. The supported flags can be
   obtained using ExportFlag.list. If unset, no flags will be used.
   Known values: `EXTRA_CONFIG`, `PRESERVE_MAC`.
+
+- `overwrite` (bool) - Overwrite the content library item if it already exists. This only applies
+  to VM templates. For OVF templates, existing items are always updated.
+  When enabled for VM templates, the existing item will be deleted before
+  creating the new one. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->
 

--- a/builder/vsphere/common/step_import_to_content_library.go
+++ b/builder/vsphere/common/step_import_to_content_library.go
@@ -9,6 +9,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -28,17 +29,19 @@ type ContentLibraryDestinationConfig struct {
 	// must be of type Local to allow deploying virtual machines.
 	Library string `mapstructure:"library"`
 	// The name of the content library item that will be created or updated.
-	// For VM templates, the name of the item should be different from
-	// [vm_name](#vm_name) and the default is [vm_name](#vm_name) + timestamp
-	// when not set. VM templates will always be imported to a new library item.
-	// For OVF templates, the name defaults to [vm_name](#vm_name) when not set,
-	// and if an item with the same name already exists it will be then updated
-	// with the new OVF template, otherwise a new item will be created.
 	//
-	// ~> **Note:** It's not possible to update existing content library items
-	// with a new VM template. If updating an existing content library item is
-	// necessary, use an OVF template instead by setting the [ovf](#ovf) option
-	// as `true`.
+	// For VM templates, the default is [vm_name](#vm_name) + timestamp when not set.
+	// VM templates are always imported as new library items. If an item with the
+	// specified name already exists, the import will fail unless [overwrite](#overwrite)
+	// is set to `true`.
+	//
+	// For OVF templates, the name defaults to [vm_name](#vm_name) when not set.
+	// If an item with the same name already exists, it will be updated with the
+	// new OVF template, otherwise a new item will be created.
+	//
+	// ~> **Note:** VM templates cannot update existing content library items in-place
+	// like OVF templates. When [overwrite](#overwrite) is enabled, the existing item
+	// will be deleted before creating the new one.
 	Name string `mapstructure:"name"`
 	// A description for the content library item that will be created.
 	// Defaults to "Packer imported [vm_name](#vm_name) VM template".
@@ -80,6 +83,11 @@ type ContentLibraryDestinationConfig struct {
 	// obtained using ExportFlag.list. If unset, no flags will be used.
 	// Known values: `EXTRA_CONFIG`, `PRESERVE_MAC`.
 	OvfFlags []string `mapstructure:"ovf_flags"`
+	// Overwrite the content library item if it already exists. This only applies
+	// to VM templates. For OVF templates, existing items are always updated.
+	// When enabled for VM templates, the existing item will be deleted before
+	// creating the new one. Defaults to `false`.
+	Overwrite bool `mapstructure:"overwrite"`
 }
 
 func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
@@ -89,14 +97,22 @@ func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("a library name must be provided"))
 	}
 
+	if c.Overwrite {
+		if c.Ovf {
+			errs = packersdk.MultiErrorAppend(errs,
+				fmt.Errorf("overwrite is only supported for VM template imports (set ovf to false)"))
+		}
+		if c.Name == "" {
+			errs = packersdk.MultiErrorAppend(errs,
+				fmt.Errorf("overwrite requires content_library_destination.name to be set"))
+		}
+	}
+
 	if c.Ovf {
 		if c.Name == "" {
 			c.Name = lc.VMName
 		}
 	} else {
-		if c.Name == lc.VMName {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("the content library destination name must be different from the VM name"))
-		}
 
 		if c.Name == "" {
 			// Add timestamp to the name to differentiate from the original VM
@@ -116,6 +132,11 @@ func (c *ContentLibraryDestinationConfig) Prepare(lc *LocationConfig) []error {
 		}
 		if c.ResourcePool == "" {
 			c.ResourcePool = lc.ResourcePool
+		}
+
+		if c.Name == lc.VMName {
+			errs = packersdk.MultiErrorAppend(errs,
+				fmt.Errorf("content_library_destination.name must differ from vm_name for VM template imports"))
 		}
 	}
 	if c.Description == "" {
@@ -212,6 +233,19 @@ func (s *StepImportToContentLibrary) importOvfTemplate(vm *driver.VirtualMachine
 }
 
 func (s *StepImportToContentLibrary) importVmTemplate(vm *driver.VirtualMachineDriver) error {
+	existingItem, err := vm.FindContentLibraryItem(s.ContentLibConfig.Library, s.ContentLibConfig.Name)
+	if err == nil {
+		// Item exists
+		if !s.ContentLibConfig.Overwrite {
+			return fmt.Errorf("content library item '%s' already exists; set overwrite to true to replace it", s.ContentLibConfig.Name)
+		}
+		log.Printf("Deleting existing content library item '%s' before re-import", s.ContentLibConfig.Name)
+		if err := vm.DeleteContentLibraryItem(existingItem.ID); err != nil {
+			return fmt.Errorf("failed to delete existing content library item: %s", err)
+		}
+	}
+	// If err != nil the item was not found, which is the normal case — continue.
+
 	template := vcenter.Template{
 		Name:        s.ContentLibConfig.Name,
 		Description: s.ContentLibConfig.Description,

--- a/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
+++ b/builder/vsphere/common/step_import_to_content_library.hcl2spec.go
@@ -22,6 +22,7 @@ type FlatContentLibraryDestinationConfig struct {
 	Ovf          *bool    `mapstructure:"ovf" cty:"ovf" hcl:"ovf"`
 	SkipImport   *bool    `mapstructure:"skip_import" cty:"skip_import" hcl:"skip_import"`
 	OvfFlags     []string `mapstructure:"ovf_flags" cty:"ovf_flags" hcl:"ovf_flags"`
+	Overwrite    *bool    `mapstructure:"overwrite" cty:"overwrite" hcl:"overwrite"`
 }
 
 // FlatMapstructure returns a new FlatContentLibraryDestinationConfig.
@@ -48,6 +49,7 @@ func (*FlatContentLibraryDestinationConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ovf":           &hcldec.AttrSpec{Name: "ovf", Type: cty.Bool, Required: false},
 		"skip_import":   &hcldec.AttrSpec{Name: "skip_import", Type: cty.Bool, Required: false},
 		"ovf_flags":     &hcldec.AttrSpec{Name: "ovf_flags", Type: cty.List(cty.String), Required: false},
+		"overwrite":     &hcldec.AttrSpec{Name: "overwrite", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -49,6 +49,7 @@ type Driver interface {
 	FindContentLibraryFileDatastorePath(isoPath string) (string, error)
 	UpdateContentLibraryItem(item *library.Item, name string, description string) error
 	GetRestClient() *rest.Client
+	DeleteContentLibraryItem(itemID string) error
 	Cleanup() (error, error)
 }
 

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -127,6 +127,10 @@ func (d *DriverMock) UpdateContentLibraryItem(item *library.Item, name string, d
 	return nil
 }
 
+func (d *DriverMock) DeleteContentLibraryItem(itemID string) error {
+	return nil
+}
+
 func (d *DriverMock) GetRestClient() *rest.Client {
 	return nil
 }

--- a/builder/vsphere/driver/library.go
+++ b/builder/vsphere/driver/library.go
@@ -124,6 +124,13 @@ func (d *VCenterDriver) UpdateContentLibraryItem(item *library.Item, name string
 	return lm.UpdateLibraryItem(d.Ctx, item)
 }
 
+// DeleteContentLibraryItem deletes a content library item by its ID.
+// Returns an error if the deletion fails.
+func (d *VCenterDriver) DeleteContentLibraryItem(itemID string) error {
+	lm := library.NewManager(d.RestClient.client)
+	return lm.DeleteLibraryItem(d.Ctx, &library.Item{ID: itemID})
+}
+
 type LibraryFilePath struct {
 	path string
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"
 	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/vcenter"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -52,6 +53,8 @@ type VirtualMachine interface {
 	ConvertToVirtualMachine(vsphereCluster string, vsphereHost string, vsphereResourcePool string) error
 	ImportOvfToContentLibrary(ovf vcenter.OVF) error
 	ImportToContentLibrary(template vcenter.Template) error
+	FindContentLibraryItem(libraryName string, itemName string) (*library.Item, error)
+	DeleteContentLibraryItem(itemID string) error
 	GetDir() (string, error)
 	AddFloppy(imgPath string) error
 	SetBootOrder(order []string) error
@@ -1499,6 +1502,47 @@ func (vm *VirtualMachineDriver) NewNetwork(ref *types.ManagedObjectReference) *N
 // Datacenter returns the datacenter of the virtual machine.
 func (vm *VirtualMachineDriver) Datacenter() *object.Datacenter {
 	return vm.driver.Datacenter
+}
+
+// FindContentLibraryItem finds a content library item by library name and item name.
+// Returns the library item or an error if not found.
+func (vm *VirtualMachineDriver) FindContentLibraryItem(libraryName string, itemName string) (*library.Item, error) {
+	err := vm.driver.RestClient.Login(vm.driver.Ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := vm.driver.FindContentLibraryByName(libraryName)
+	if err != nil {
+		log.Printf("cannot find content library: %v", err)
+		vm.logout()
+		return nil, err
+	}
+
+	item, err := vm.driver.FindContentLibraryItem(l.library.ID, itemName)
+	if err != nil {
+		vm.logout()
+		return nil, err
+	}
+
+	_ = vm.driver.RestClient.Logout(vm.driver.Ctx)
+	return item, nil
+}
+
+// DeleteContentLibraryItem deletes a content library item by its ID.
+func (vm *VirtualMachineDriver) DeleteContentLibraryItem(itemID string) error {
+	err := vm.driver.RestClient.Login(vm.driver.Ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := vm.driver.DeleteContentLibraryItem(itemID); err != nil {
+		log.Printf("cannot delete content library item: %v", err)
+		vm.logout()
+		return err
+	}
+
+	return vm.driver.RestClient.Logout(vm.driver.Ctx)
 }
 
 // FindContentLibraryItemUUID finds a content library item by name.

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -6,12 +6,14 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
 	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/vcenter"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -194,6 +196,14 @@ func (vm *VirtualMachineMock) ImportOvfToContentLibrary(ovf vcenter.OVF) error {
 }
 
 func (vm *VirtualMachineMock) ImportToContentLibrary(template vcenter.Template) error {
+	return nil
+}
+
+func (vm *VirtualMachineMock) FindContentLibraryItem(libraryName string, itemName string) (*library.Item, error) {
+	return nil, fmt.Errorf("content library item %s not found", itemName)
+}
+
+func (vm *VirtualMachineMock) DeleteContentLibraryItem(itemID string) error {
 	return nil
 }
 

--- a/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/ContentLibraryDestinationConfig-not-required.mdx
@@ -5,17 +5,19 @@
   must be of type Local to allow deploying virtual machines.
 
 - `name` (string) - The name of the content library item that will be created or updated.
-  For VM templates, the name of the item should be different from
-  [vm_name](#vm_name) and the default is [vm_name](#vm_name) + timestamp
-  when not set. VM templates will always be imported to a new library item.
-  For OVF templates, the name defaults to [vm_name](#vm_name) when not set,
-  and if an item with the same name already exists it will be then updated
-  with the new OVF template, otherwise a new item will be created.
   
-  ~> **Note:** It's not possible to update existing content library items
-  with a new VM template. If updating an existing content library item is
-  necessary, use an OVF template instead by setting the [ovf](#ovf) option
-  as `true`.
+  For VM templates, the default is [vm_name](#vm_name) + timestamp when not set.
+  VM templates are always imported as new library items. If an item with the
+  specified name already exists, the import will fail unless [overwrite](#overwrite)
+  is set to `true`.
+  
+  For OVF templates, the name defaults to [vm_name](#vm_name) when not set.
+  If an item with the same name already exists, it will be updated with the
+  new OVF template, otherwise a new item will be created.
+  
+  ~> **Note:** VM templates cannot update existing content library items in-place
+  like OVF templates. When [overwrite](#overwrite) is enabled, the existing item
+  will be deleted before creating the new one.
 
 - `description` (string) - A description for the content library item that will be created.
   Defaults to "Packer imported [vm_name](#vm_name) VM template".
@@ -56,5 +58,10 @@
 - `ovf_flags` ([]string) - Flags to use for OVF package creation. The supported flags can be
   obtained using ExportFlag.list. If unset, no flags will be used.
   Known values: `EXTRA_CONFIG`, `PRESERVE_MAC`.
+
+- `overwrite` (bool) - Overwrite the content library item if it already exists. This only applies
+  to VM templates. For OVF templates, existing items are always updated.
+  When enabled for VM templates, the existing item will be deleted before
+  creating the new one. Defaults to `false`.
 
 <!-- End of code generated from the comments of the ContentLibraryDestinationConfig struct in builder/vsphere/common/step_import_to_content_library.go; -->


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Introduces support for an `overwrite` option when importing VM templates to a vSphere content library. This allows users to overwrite existing content library items when importing VM templates with the same name.

This provides the ability to build an virtual machine image and then add it to the content library with the same name each time.

Example:

```hcl
variable "var.machine_image_name" {
  type        = string
  default     = "alpine"
  description = "The name of the virtual machine image."
}

locals {
  timestamp                  = formatdate("YYYYMMDDhhmmss", timestamp())
  vm_name                    = "${var.machine_image_name}-${local.timestamp}"
  content_library_item_name  = var.machine_image_name
}

source "vsphere-iso" "example" {
  # ... other configuration ...
  vm_name = local.vm_name

  content_library_destination {
    library   = var.content_library_name            # The content library name.
    name      = local.content_library_item_name     # The content library item name will always be this value.
    destroy   = true                                # If true, the originating build will be removed after import.
    overwrite = true                                # If true, if a VM Template exists with the same name in the content
                                                    #   library, this flags to delete the existing item and
                                                    #   import the new image with the same name.
  }
}
```

The plugin now enforces the following:

- The `vm_name` and `content_library_destination.name` must not be identical.
- That `overwrite` applies only to VM template imports (`ovf = false`).
- That `overwrite` requires `content_library_destination.name` to be set.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Closes #11

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->