### PR TITLE
refactor: validate datastore and disk path parsing

### DIFF
--- a/post-processor/vsphere-template/step_mark_as_template.go
+++ b/post-processor/vsphere-template/step_mark_as_template.go
@@ -181,12 +181,29 @@ func datastorePath(vm *object.VirtualMachine) (*object.DatastorePath, error) {
 	}
 
 	if disk == "" {
-		return nil, fmt.Errorf("error finding disk in '%v'", vm.Name())
+		return nil, fmt.Errorf("error finding disk in %q", vm.Name())
 	}
 
+	return datastorePathFromDisk(disk, vm.Name())
+}
+
+func datastorePathFromDisk(disk, vmName string) (*object.DatastorePath, error) {
 	re := regexp.MustCompile(`\[(.*?)\]`)
-	datastore := re.FindStringSubmatch(disk)[1]
-	vmxPath := path.Join("/", path.Dir(strings.Split(disk, " ")[1]), vm.Name()+".vmx")
+	matches := re.FindStringSubmatch(disk)
+	if len(matches) < 2 || matches[1] == "" {
+		return nil, fmt.Errorf("error parsing datastore from disk path %q", disk)
+	}
+	datastore := matches[1]
+
+	parts := strings.SplitN(disk, " ", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("error parsing virtual machine disk path %q", disk)
+	}
+	diskPath := strings.TrimSpace(parts[1])
+	if diskPath == "" {
+		return nil, fmt.Errorf("error parsing virtual machine disk path %q", disk)
+	}
+	vmxPath := path.Join("/", path.Dir(diskPath), vmName+".vmx")
 
 	return &object.DatastorePath{
 		Datastore: datastore,

--- a/post-processor/vsphere-template/step_mark_as_template_test.go
+++ b/post-processor/vsphere-template/step_mark_as_template_test.go
@@ -10,6 +10,72 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
+func TestDatastorePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		disk        string
+		wantDS      string
+		wantPathSfx string // suffix that vmxPath should end with
+		wantErr     bool
+	}{
+		{
+			name:        "valid disk path",
+			disk:        "[datastore01] vm/test-vm/test-vm.vmdk",
+			wantDS:      "datastore01",
+			wantPathSfx: "vm/test-vm/test-vm.vmx",
+			wantErr:     false,
+		},
+		{
+			name:    "missing datastore brackets",
+			disk:    "vm/test-vm/test-vm.vmdk",
+			wantErr: true,
+		},
+		{
+			name:    "empty datastore name",
+			disk:    "[] vm/test-vm/test-vm.vmdk",
+			wantErr: true,
+		},
+		{
+			name:    "no space separator",
+			disk:    "[datastore01]vm/test-vm/test-vm.vmdk",
+			wantErr: true,
+		},
+		{
+			name:    "only datastore bracket no path",
+			disk:    "[datastore01] ",
+			wantErr: true,
+		},
+		{
+			name:        "disk path with leading whitespace after bracket",
+			disk:        "[datastore01]   vm/test-vm/test-vm.vmdk",
+			wantDS:      "datastore01",
+			wantPathSfx: "vm/test-vm/test-vm.vmx",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := datastorePathFromDisk(tt.disk, "test-vm")
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if result.Datastore != tt.wantDS {
+				t.Errorf("expected datastore %q, got %q", tt.wantDS, result.Datastore)
+			}
+			if tt.wantPathSfx != "" && result.Path[len(result.Path)-len(tt.wantPathSfx):] != tt.wantPathSfx {
+				t.Errorf("expected path suffix %q, got path %q", tt.wantPathSfx, result.Path)
+			}
+		})
+	}
+}
+
 func TestStepMarkAsTemplate_Override(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -85,13 +151,8 @@ func TestStepMarkAsTemplate_TemplateName(t *testing.T) {
 				ReregisterVM: config.TriFalse,
 			}
 
-			templateName := step.VMName
-			if step.TemplateName != "" {
-				templateName = step.TemplateName
-			}
-
-			if templateName != tt.expected {
-				t.Errorf("Expected template name to be %s, got %s", tt.expected, templateName)
+			if got := step.getEffectiveTemplateName(); got != tt.expected {
+				t.Errorf("expected template name %q, got %q", tt.expected, got)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Adds `datastorePathFromDisk` to centralize and harden parsing of VM disk paths (validates datastore brackets, disk path presence, and returns constructed .vmx path).

Updates `datastorePath` to call the new helper and improve error messages (use %q).

Add `TestDatastorePath` with multiple cases to cover valid and invalid disk strings.

Simplifies `TestStepMarkAsTemplate_TemplateName` to use `step.getEffectiveTemplateName()` instead of duplicating selection logic.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [x] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->